### PR TITLE
feat(us4): add accessible move feedback

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { BoardGrid } from "../components/game/BoardGrid";
+import { BoardExperience } from "../components/game/BoardExperience";
 import { getBoard } from "./actions/getBoard";
 
 export default async function Home() {
@@ -43,8 +43,8 @@ export default async function Home() {
       <div className="rounded-lg border border-white/10 bg-slate-900/70 p-6 text-sm text-white/80 shadow-xl">
         <h3 className="text-base font-semibold text-white">Live Board</h3>
         <p className="mt-2 text-xs text-white/60">
-          Letters are sized for desktop and mobile viewports. Later phases will enable tile
-          selection and swaps against the same dataset.
+          Letters are sized for desktop and mobile viewports. Select any two tiles to request a
+          swap and the result is announced through accessible feedback powered by Supabase data.
         </p>
 
         {errorMessage ? (
@@ -58,7 +58,7 @@ export default async function Home() {
           </div>
         ) : board ? (
           <div className="mt-6 space-y-4">
-            <BoardGrid grid={board.grid} />
+            <BoardExperience initialGrid={board.grid} />
           </div>
         ) : (
           <div className="mt-6 text-xs text-white/60">

--- a/components/game/BoardExperience.tsx
+++ b/components/game/BoardExperience.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type {
+  BoardGrid as BoardGridType,
+  MoveRequest,
+  MoveResult,
+} from "../../lib/types/board";
+import { BoardGrid } from "./BoardGrid";
+import {
+  MoveFeedback,
+  type MoveFeedbackDetails,
+} from "./MoveFeedback";
+
+interface BoardExperienceProps {
+  initialGrid: BoardGridType;
+}
+
+type SwapCompletePayload = {
+  move: MoveRequest;
+  result: MoveResult;
+};
+
+type SwapErrorPayload = {
+  move: MoveRequest;
+  message: string;
+  grid: BoardGridType;
+};
+
+function createFeedbackId(prefix: string): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function formatCoordinate({ x, y }: { x: number; y: number }): string {
+  return `row ${y + 1}, column ${x + 1}`;
+}
+
+export function BoardExperience({ initialGrid }: BoardExperienceProps) {
+  const [grid, setGrid] = useState<BoardGridType>(initialGrid);
+  const [feedback, setFeedback] = useState<MoveFeedbackDetails | null>(null);
+
+  useEffect(() => {
+    setGrid(initialGrid);
+  }, [initialGrid]);
+
+  const dismissFeedback = useCallback(() => {
+    setFeedback(null);
+  }, []);
+
+  const handleSwapComplete = useCallback(
+    ({ move, result }: SwapCompletePayload) => {
+      setGrid(result.grid);
+
+      if (result.status === "accepted") {
+        setFeedback({
+          id: createFeedbackId("success"),
+          variant: "success",
+          message: `Move accepted. Swapped ${formatCoordinate(move.from)} with ${formatCoordinate(move.to)}.`,
+        });
+        return;
+      }
+
+      setFeedback({
+        id: createFeedbackId("error"),
+        variant: "error",
+        message: result.error ?? "Invalid swap request.",
+      });
+    },
+    []
+  );
+
+  const handleSwapError = useCallback(
+    ({ grid: previousGrid, message }: SwapErrorPayload) => {
+      setGrid(previousGrid);
+      setFeedback({
+        id: createFeedbackId("error"),
+        variant: "error",
+        message,
+      });
+    },
+    []
+  );
+
+  return (
+    <div className="space-y-4">
+      <BoardGrid
+        grid={grid}
+        onSwapComplete={handleSwapComplete}
+        onSwapError={handleSwapError}
+      />
+      <MoveFeedback feedback={feedback} onDismiss={dismissFeedback} />
+    </div>
+  );
+}

--- a/components/game/BoardGrid.tsx
+++ b/components/game/BoardGrid.tsx
@@ -11,6 +11,12 @@ import type {
 interface BoardGridProps {
   grid: BoardGridType;
   className?: string;
+  onSwapComplete?: (details: { move: MoveRequest; result: MoveResult }) => void;
+  onSwapError?: (details: {
+    move: MoveRequest;
+    message: string;
+    grid: BoardGridType;
+  }) => void;
 }
 
 type SelectedTile = {
@@ -46,14 +52,21 @@ async function submitSwapRequest(move: MoveRequest): Promise<MoveResult> {
   );
 }
 
-export function BoardGrid({ grid, className }: BoardGridProps) {
+export function BoardGrid({
+  grid,
+  className,
+  onSwapComplete,
+  onSwapError,
+}: BoardGridProps) {
   const [currentGrid, setCurrentGrid] = useState<BoardGridType>(grid);
   const [selected, setSelected] = useState<SelectedTile | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    if (typeof performance !== "undefined" && typeof performance.mark === "function") {
+    if (
+      typeof performance !== "undefined" &&
+      typeof performance.mark === "function"
+    ) {
       performance.mark("board-grid:hydrated");
     }
   }, [grid]);
@@ -73,38 +86,38 @@ export function BoardGrid({ grid, className }: BoardGridProps) {
   const handleSwap = useCallback(
     async (from: SelectedTile, to: SelectedTile) => {
       setIsSubmitting(true);
-      setErrorMessage(null);
-      const previousGrid = currentGrid;
+      const previousGrid = currentGrid.map((row) => [...row]) as BoardGridType;
+      const moveRequest: MoveRequest = {
+        from,
+        to,
+      };
 
       try {
-        const result = await submitSwapRequest({
-          from,
-          to,
-        });
+        const result = await submitSwapRequest(moveRequest);
 
-        if (result.status === "accepted") {
-          setCurrentGrid(result.grid);
-          setErrorMessage(null);
-        } else {
-          setCurrentGrid(previousGrid);
-          setErrorMessage(result.error ?? "Invalid swap request.");
-        }
+        setCurrentGrid(result.grid);
+        onSwapComplete?.({ move: moveRequest, result });
       } catch (error) {
         setCurrentGrid(previousGrid);
         const message =
           error instanceof Error
             ? error.message
             : "Network error while submitting swap. Please try again.";
-        if (/network/i.test(message)) {
-          setErrorMessage("Network error while submitting swap. Please try again.");
-        } else {
-          setErrorMessage(message);
-        }
+
+        const normalizedMessage = /network/i.test(message)
+          ? "Network error while submitting swap. Please try again."
+          : message;
+
+        onSwapError?.({
+          move: moveRequest,
+          message: normalizedMessage,
+          grid: previousGrid,
+        });
       } finally {
         setIsSubmitting(false);
       }
     },
-    [currentGrid]
+    [currentGrid, onSwapComplete, onSwapError]
   );
 
   const handleTileClick = useCallback(
@@ -157,7 +170,9 @@ export function BoardGrid({ grid, className }: BoardGridProps) {
                   role="gridcell"
                   aria-colindex={colIndex + 1}
                   aria-selected={isSelected}
-                  className={`board-grid__cell${isSelected ? " board-grid__cell--selected" : ""}`}
+                  className={`board-grid__cell${
+                    isSelected ? " board-grid__cell--selected" : ""
+                  }`}
                   data-testid="board-tile"
                   data-col={colIndex}
                   data-row={rowIndex}
@@ -177,18 +192,6 @@ export function BoardGrid({ grid, className }: BoardGridProps) {
           </div>
         ))}
       </div>
-
-      {errorMessage && (
-        <div
-          data-testid="swap-error"
-          role="alert"
-          aria-live="assertive"
-          className="board-grid__error"
-        >
-          {errorMessage}
-        </div>
-      )}
     </div>
   );
 }
-

--- a/components/game/MoveFeedback.tsx
+++ b/components/game/MoveFeedback.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export type MoveFeedbackVariant = "success" | "error";
+
+export interface MoveFeedbackDetails {
+  id: string;
+  variant: MoveFeedbackVariant;
+  message: string;
+  title?: string;
+}
+
+interface MoveFeedbackProps {
+  feedback: MoveFeedbackDetails | null;
+  onDismiss?: () => void;
+  autoHideMs?: number;
+}
+
+const BASE_CLASSES =
+  "move-feedback relative mt-4 w-full max-w-md rounded-lg border px-5 py-4 text-sm shadow-lg outline-none transition focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900";
+const SUCCESS_CLASSES = "border-emerald-400/60 bg-emerald-500/10 text-emerald-50";
+const ERROR_CLASSES = "border-rose-500/70 bg-rose-500/15 text-rose-50";
+const DEFAULT_AUTO_HIDE_MS = 6000;
+
+export function MoveFeedback({
+  feedback,
+  onDismiss,
+  autoHideMs = DEFAULT_AUTO_HIDE_MS,
+}: MoveFeedbackProps) {
+  const toastRef = useRef<HTMLDivElement | null>(null);
+  const lastFocusKeyRef = useRef<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const focusKey = feedback ? `${feedback.id}:${feedback.variant}:${feedback.message}` : null;
+
+  useEffect(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    if (!feedback || feedback.variant !== "success" || !onDismiss || autoHideMs <= 0) {
+      return;
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      onDismiss();
+    }, autoHideMs);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [feedback, onDismiss, autoHideMs]);
+
+  useEffect(() => {
+    if (!focusKey) {
+      lastFocusKeyRef.current = null;
+      return;
+    }
+
+    if (focusKey === lastFocusKeyRef.current) {
+      return;
+    }
+
+    lastFocusKeyRef.current = focusKey;
+
+    const timer = setTimeout(() => {
+      toastRef.current?.focus({ preventScroll: true });
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [focusKey]);
+
+  const liveRegionTone = feedback?.variant === "error" ? "assertive" : "polite";
+
+  const toastClasses =
+    feedback?.variant === "success"
+      ? `${BASE_CLASSES} ${SUCCESS_CLASSES}`
+      : `${BASE_CLASSES} ${ERROR_CLASSES}`;
+
+  return (
+    <>
+      <div
+        aria-atomic="true"
+        aria-live={liveRegionTone}
+        className="sr-only"
+        data-testid="move-feedback-live-region"
+      >
+        {feedback?.message ?? ""}
+      </div>
+      {feedback ? (
+        <div
+          ref={toastRef}
+          aria-atomic="true"
+          aria-live={feedback.variant === "success" ? "polite" : "assertive"}
+          className={toastClasses}
+          data-variant={feedback.variant}
+          data-testid="move-feedback-toast"
+          role={feedback.variant === "success" ? "status" : "alert"}
+          tabIndex={-1}
+        >
+          <div className="flex items-start gap-3">
+            <div
+              aria-hidden="true"
+              className="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full"
+              data-variant-indicator={feedback.variant}
+              style={{
+                backgroundColor:
+                  feedback.variant === "success"
+                    ? "rgba(34, 197, 94, 0.9)"
+                    : "rgba(244, 63, 94, 0.9)",
+              }}
+            />
+            <div className="flex-1 space-y-1">
+              <p className="text-sm font-semibold">
+                {feedback.title ??
+                  (feedback.variant === "success" ? "Move accepted" : "Move rejected")}
+              </p>
+              <p className="text-sm text-white/80">{feedback.message}</p>
+            </div>
+            {onDismiss ? (
+              <button
+                type="button"
+                aria-label="Dismiss move feedback"
+                className="ml-2 inline-flex flex-shrink-0 items-center justify-center rounded-md border border-white/20 bg-white/5 px-2 py-1 text-xs font-medium text-white/80 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+                data-testid="move-feedback-dismiss"
+                onClick={() => {
+                  if (timeoutRef.current) {
+                    clearTimeout(timeoutRef.current);
+                    timeoutRef.current = null;
+                  }
+
+                  onDismiss?.();
+                }}
+              >
+                Dismiss
+              </button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/specs/001-e2e-board-scaffold/tasks.md
+++ b/specs/001-e2e-board-scaffold/tasks.md
@@ -125,11 +125,11 @@
 **Goal**: Provide clear confirmation/error feedback after swaps
 **Independent Test**: After a swap, a confirmation (or error) toast appears and is announced to screen readers
 
-- [ ] T044 [P] [US4] [TDD-RED] Write unit test for `MoveFeedback` feedback states in `tests/unit/components/game/MoveFeedback.test.tsx`
-- [ ] T045 [P] [US4] [TDD-RED] Write Playwright spec verifying accessible feedback behavior in `tests/integration/ui/swap-feedback.spec.ts`
-- [ ] T046 [US4] [TDD-GREEN] Implement `MoveFeedback` component with toast + live region in `components/game/MoveFeedback.tsx`
-- [ ] T047 [US4] [TDD-GREEN] Integrate feedback into the swap workflow in `app/page.tsx`
-- [ ] T048 [US4] [TDD-REFACTOR] Harden accessibility with aria-live and focus management in `components/game/MoveFeedback.tsx`
+- [x] T044 [P] [US4] [TDD-RED] Write unit test for `MoveFeedback` feedback states in `tests/unit/components/game/MoveFeedback.test.tsx`
+- [x] T045 [P] [US4] [TDD-RED] Write Playwright spec verifying accessible feedback behavior in `tests/integration/ui/swap-feedback.spec.ts`
+- [x] T046 [US4] [TDD-GREEN] Implement `MoveFeedback` component with toast + live region in `components/game/MoveFeedback.tsx`
+- [x] T047 [US4] [TDD-GREEN] Integrate feedback into the swap workflow in `app/page.tsx`
+- [x] T048 [US4] [TDD-REFACTOR] Harden accessibility with aria-live and focus management in `components/game/MoveFeedback.tsx`
 
 ---
 

--- a/tests/integration/ui/swap-feedback.spec.ts
+++ b/tests/integration/ui/swap-feedback.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+const BOARD_TILE_SELECTOR = '[data-testid="board-tile"]';
+const FEEDBACK_SELECTOR = '[data-testid="move-feedback-toast"]';
+
+test.describe("Swap feedback accessibility", () => {
+  test("displays success feedback with a polite live region", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(BOARD_TILE_SELECTOR);
+
+    await page.click(`${BOARD_TILE_SELECTOR}:nth-of-type(1)`);
+    await page.click(`${BOARD_TILE_SELECTOR}:nth-of-type(2)`);
+
+    const toast = page.locator(FEEDBACK_SELECTOR);
+    await expect(toast).toBeVisible({ timeout: 5000 });
+    await expect(toast).toHaveAttribute("role", "status");
+    await expect(toast).toHaveAttribute("aria-live", "polite");
+    await expect(toast).toContainText(/move accepted/i);
+    await expect(toast).toBeFocused();
+  });
+
+  test("surfaces assertive feedback for rejected swaps", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(BOARD_TILE_SELECTOR);
+
+    const firstTile = page.locator(BOARD_TILE_SELECTOR).first();
+    await firstTile.click();
+    await firstTile.click();
+
+    const toast = page.locator(FEEDBACK_SELECTOR);
+    await expect(toast).toBeVisible({ timeout: 5000 });
+    await expect(toast).toHaveAttribute("role", "alert");
+    await expect(toast).toHaveAttribute("aria-live", "assertive");
+    await expect(toast).toContainText(/invalid swap/i);
+  });
+});

--- a/tests/integration/ui/swap-flow.spec.ts
+++ b/tests/integration/ui/swap-flow.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 const BOARD_TILE_SELECTOR = "[data-testid=\"board-tile\"]";
-const ERROR_SELECTOR = "[data-testid=\"swap-error\"]";
+const FEEDBACK_SELECTOR = "[data-testid=\"move-feedback-toast\"]";
 
 async function getTileLetters(page: import("@playwright/test").Page, indices: number[]) {
   const tiles = page.locator(BOARD_TILE_SELECTOR);
@@ -28,7 +28,10 @@ test.describe("Swap flow", () => {
     await page.click(`${BOARD_TILE_SELECTOR}:nth-of-type(1)`);
     await page.click(`${BOARD_TILE_SELECTOR}:nth-of-type(2)`);
 
-    await expect(page.locator(ERROR_SELECTOR)).toBeHidden({ timeout: 5000 });
+    const feedbackToast = page.locator(FEEDBACK_SELECTOR);
+    await expect(feedbackToast).toBeVisible({ timeout: 5000 });
+    await expect(feedbackToast).toHaveAttribute("data-variant", "success");
+    await expect(feedbackToast).toContainText(/move accepted/i);
 
     await expect
       .poll(async () => getTileLetters(page, [0, 1]))
@@ -49,9 +52,10 @@ test.describe("Swap flow", () => {
     await firstTile.click();
     await firstTile.click();
 
-    const errorBanner = page.locator(ERROR_SELECTOR);
-    await expect(errorBanner).toBeVisible();
-    await expect(errorBanner).toContainText(/invalid swap/i);
+    const feedbackToast = page.locator(FEEDBACK_SELECTOR);
+    await expect(feedbackToast).toBeVisible();
+    await expect(feedbackToast).toHaveAttribute("data-variant", "error");
+    await expect(feedbackToast).toContainText(/invalid swap/i);
 
     const letterAfter = (await firstTile.textContent())?.trim();
     expect(letterAfter).toBe(letterBefore);

--- a/tests/integration/ui/swap-network-failure.spec.ts
+++ b/tests/integration/ui/swap-network-failure.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 const BOARD_TILE_SELECTOR = "[data-testid=\"board-tile\"]";
-const ERROR_SELECTOR = "[data-testid=\"swap-error\"]";
+const FEEDBACK_SELECTOR = "[data-testid=\"move-feedback-toast\"]";
 
 test("restores the previous board state when the swap request fails", async ({ page }) => {
   await page.route("**/api/swap", async (route) => {
@@ -27,9 +27,10 @@ test("restores the previous board state when the swap request fails", async ({ p
   await tiles.nth(0).click();
   await tiles.nth(1).click();
 
-  const errorBanner = page.locator(ERROR_SELECTOR);
-  await expect(errorBanner).toBeVisible();
-  await expect(errorBanner).toContainText(/network/i);
+  const feedbackToast = page.locator(FEEDBACK_SELECTOR);
+  await expect(feedbackToast).toBeVisible();
+  await expect(feedbackToast).toHaveAttribute("data-variant", "error");
+  await expect(feedbackToast).toContainText(/network/i);
 
   const [firstAfter, secondAfter] = await Promise.all([
     tiles.nth(0).textContent(),

--- a/tests/unit/components/game/MoveFeedback.test.tsx
+++ b/tests/unit/components/game/MoveFeedback.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { MoveFeedback, type MoveFeedbackDetails } from "../../../../components/game/MoveFeedback";
+
+describe("MoveFeedback component", () => {
+  test("renders nothing when feedback is null", () => {
+    render(<MoveFeedback feedback={null} />);
+
+    expect(screen.queryByTestId("move-feedback-toast")).toBeNull();
+
+    const liveRegion = screen.getByTestId("move-feedback-live-region");
+    expect(liveRegion).toHaveAttribute("aria-live", "polite");
+  });
+
+  test("renders success feedback with polite live region", () => {
+    const feedback: MoveFeedbackDetails = {
+      id: "success-1",
+      variant: "success",
+      message: "Swap accepted",
+    };
+
+    render(<MoveFeedback feedback={feedback} />);
+
+    const toast = screen.getByTestId("move-feedback-toast");
+
+    expect(toast).toHaveAttribute("role", "status");
+    expect(toast).toHaveAttribute("aria-live", "polite");
+    expect(toast).toHaveTextContent("Swap accepted");
+    expect(toast).toHaveAttribute("data-variant", "success");
+  });
+
+  test("focuses the toast when feedback changes", async () => {
+    const { rerender } = render(<MoveFeedback feedback={null} />);
+
+    const success: MoveFeedbackDetails = {
+      id: "success-1",
+      variant: "success",
+      message: "Swap accepted",
+    };
+
+    rerender(<MoveFeedback feedback={success} />);
+
+    const successToast = await screen.findByTestId("move-feedback-toast");
+
+    await waitFor(() => expect(successToast).toHaveFocus());
+
+    const error: MoveFeedbackDetails = {
+      id: "error-1",
+      variant: "error",
+      message: "Network error while submitting swap. Please try again.",
+    };
+
+    rerender(<MoveFeedback feedback={error} />);
+
+    const errorToast = await screen.findByTestId("move-feedback-toast");
+
+    expect(errorToast).toHaveAttribute("role", "alert");
+    expect(errorToast).toHaveAttribute("aria-live", "assertive");
+    await waitFor(() => expect(errorToast).toHaveFocus());
+  });
+
+  test("calls onDismiss when the dismiss button is activated", () => {
+    const handleDismiss = vi.fn();
+
+    const feedback: MoveFeedbackDetails = {
+      id: "success-2",
+      variant: "success",
+      message: "Swap accepted",
+    };
+
+    render(<MoveFeedback feedback={feedback} onDismiss={handleDismiss} />);
+
+    const dismissButton = screen.getByRole("button", { name: /dismiss move feedback/i });
+    fireEvent.click(dismissButton);
+
+    expect(handleDismiss).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable MoveFeedback toast with focus + live region handling
- wrap board interactions in BoardExperience to emit swap results and toasts
- extend test suites and docs to cover success, rejection, and network feedback

## Testing
- pnpm vitest run tests/unit/components/game/MoveFeedback.test.tsx
- pnpm vitest run tests/unit/components/game/BoardGrid.test.tsx