### PR TITLE
feat(spec): add 004-board-ui-animations specification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,3 +471,10 @@ Use `/speckit.specify` to create `specs/003-word-engine-scoring/`. Scope:
 - Supabase Cloud project setup
 - Sentry error tracking + APM
 - Mobile responsiveness validation
+
+## Active Technologies
+- TypeScript 5.x, React 19+, Next.js 16 (App Router) + Tailwind CSS 4.x, CSS Animations/Transforms (no Framer Motion needed for this scope) (004-board-ui-animations)
+- N/A (reads existing MatchState from Supabase Realtime broadcasts; no new persistence) (004-board-ui-animations)
+
+## Recent Changes
+- 004-board-ui-animations: Added TypeScript 5.x, React 19+, Next.js 16 (App Router) + Tailwind CSS 4.x, CSS Animations/Transforms (no Framer Motion needed for this scope)

--- a/specs/004-board-ui-animations/checklists/requirements.md
+++ b/specs/004-board-ui-animations/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Board UI and Animations
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.plan`.
+- 3 clarifications resolved during `/speckit.clarify` session (2026-02-23): player colors defined (Blue/Red), round resolution visual sequence established (highlights → overlays → summary), and loading state specified (skeleton grid).
+- Animation timing values (150-250ms, 300-400ms, 600-800ms) are PRD-defined product requirements, not implementation details.
+- References to "GPU-accelerated" in FR-041/FR-042 describe a performance characteristic (60 FPS sustained), not a specific technology choice.
+- WCAG 2.1 AA contrast ratios in FR-021 are accessibility standards, not implementation details.
+- FR-037 through FR-040 (Score Delta Popup) are explicitly marked as P3/deferrable.
+- The `prefers-reduced-motion` edge case (FR-044) ensures accessibility compliance for motion-sensitive users.
+- FR-036a establishes the round resolution visual sequence as a formal requirement.
+- FR-017a establishes the skeleton loading state as a formal requirement.

--- a/specs/004-board-ui-animations/contracts/README.md
+++ b/specs/004-board-ui-animations/contracts/README.md
@@ -1,0 +1,23 @@
+# API Contracts: Board UI and Animations
+
+**Feature**: 004-board-ui-animations
+
+## No New API Contracts
+
+This feature is entirely client-side. It introduces:
+- **0** new Server Actions
+- **0** new API routes
+- **0** new database queries
+- **0** new Realtime events
+
+All data consumed by the UI components already exists in the `MatchState` and `RoundSummary` types broadcast via the existing Supabase Realtime channel infrastructure (established in specs 002 and 003).
+
+## Existing Contracts Consumed (No Changes)
+
+| Contract | Type | Source |
+|----------|------|--------|
+| `match:${matchId}` Realtime channel | WebSocket broadcast | `lib/realtime/matchChannel.ts` |
+| `state` broadcast event | MatchState payload | `lib/match/statePublisher.ts` |
+| `round-summary` broadcast event | RoundSummary payload | `app/actions/match/publishRoundSummary.ts` |
+| `/api/match/${matchId}/move` | POST (swap submission) | `app/api/match/[matchId]/move/route.ts` |
+| `/api/match/${matchId}/state` | GET (polling fallback) | `app/api/match/[matchId]/state/route.ts` |

--- a/specs/004-board-ui-animations/data-model.md
+++ b/specs/004-board-ui-animations/data-model.md
@@ -1,0 +1,104 @@
+# Data Model: Board UI and Animations
+
+**Feature**: 004-board-ui-animations
+**Date**: 2026-02-23
+
+## Overview
+
+This feature is entirely client-side. No database schema changes, no new tables, no migrations. All data consumed by the UI components already exists in the `MatchState` type broadcast via Supabase Realtime.
+
+## Entities (Client-Side)
+
+### PlayerColors (new constant)
+
+Centralized color definitions extracted from BoardGrid's FROZEN_COLORS.
+
+```
+PlayerColors
+├── PLAYER_A_HEX: "#3B82F6" (Blue)
+├── PLAYER_A_OVERLAY: "rgba(59, 130, 246, 0.4)" (40% opacity)
+├── PLAYER_A_HIGHLIGHT: "rgba(59, 130, 246, 0.6)" (60% opacity for glow)
+├── PLAYER_B_HEX: "#EF4444" (Red)
+├── PLAYER_B_OVERLAY: "rgba(239, 68, 68, 0.4)" (40% opacity)
+├── PLAYER_B_HIGHLIGHT: "rgba(239, 68, 68, 0.6)" (60% opacity for glow)
+└── BOTH_GRADIENT: "linear-gradient(135deg, <A_OVERLAY> 50%, <B_OVERLAY> 50%)"
+```
+
+**Source**: Extracted from `components/game/BoardGrid.tsx` FROZEN_COLORS (existing values unchanged).
+**Consumers**: BoardGrid (frozen overlays), GameChrome (score accents), MatchClient (word highlights).
+
+### AnimationPhase (new enum)
+
+State machine for round resolution visual sequencing.
+
+```
+AnimationPhase
+├── "idle"            — No animation in progress
+├── "highlighting"    — Word discovery highlights playing (600-800ms)
+├── "freezing"        — Frozen tile overlays updating (~200ms settle)
+└── "showing-summary" — Round summary panel displayed
+```
+
+**Transitions**: idle → highlighting → freezing → showing-summary → idle (on dismiss)
+**Trigger**: Receiving a `round-summary` broadcast event in MatchClient.
+
+### GameChromeProps (new interface)
+
+Props for the opponent/player bar component.
+
+```
+GameChromeProps
+├── position: "opponent" | "player"
+├── playerName: string
+├── score: number
+├── timerSeconds: number
+├── timerPaused: boolean
+├── hasSubmitted: boolean (drives green/neutral timer color)
+├── moveCounter?: number (only for position="player")
+└── playerColor: string (hex color for accent)
+```
+
+**Source data**: All fields derivable from MatchState + session player ID.
+
+## Existing Entities (No Changes)
+
+### MatchState (consumed, not modified)
+
+```
+MatchState
+├── matchId: string
+├── board: string[][] (10x10)
+├── currentRound: number
+├── state: MatchPhase
+├── timers: { playerA: TimerState, playerB: TimerState }
+├── scores: ScoreTotals { playerA: number, playerB: number }
+├── lastSummary?: RoundSummary
+├── disconnectedPlayerId?: string
+└── frozenTiles?: FrozenTileMap (Record<"x,y", { owner: FrozenTileOwner }>)
+```
+
+### FrozenTileMap (consumed, not modified)
+
+```
+FrozenTileMap = Record<string, FrozenTile>
+├── key: "x,y" coordinate string (e.g., "3,5")
+└── value: FrozenTile { owner: "player_a" | "player_b" | "both" }
+```
+
+### RoundSummary (consumed, not modified)
+
+```
+RoundSummary
+├── matchId: string
+├── roundNumber: number
+├── words: WordScore[] (with playerId, coordinates for highlight positioning)
+├── deltas: ScoreTotals (round points earned)
+├── totals: ScoreTotals (cumulative scores)
+├── comboBonus?: ScoreTotals
+├── highlights: Coordinate[][] (tile groups for visual highlights)
+└── resolvedAt: string
+```
+
+## Database Impact
+
+**None**. Zero migrations. Zero schema changes. All data already flows from server to client via the existing Realtime broadcast infrastructure established in specs 002 and 003.

--- a/specs/004-board-ui-animations/plan.md
+++ b/specs/004-board-ui-animations/plan.md
@@ -1,0 +1,199 @@
+# Implementation Plan: Board UI and Animations
+
+**Branch**: `004-board-ui-animations` | **Date**: 2026-02-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/004-board-ui-animations/spec.md`
+
+## Summary
+
+Transform the match screen from a backend test harness into a playable game view by implementing the PRD Section 7.1 layout (opponent bar, 10x10 grid, player bar), responsive board sizing that fits all viewports, frozen tile ownership overlays, swap/shake/highlight animations, and game chrome (scores, move counter, timer state colors). This is a frontend-only feature requiring no server-side or database changes.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 19+, Next.js 16 (App Router)
+**Primary Dependencies**: Tailwind CSS 4.x, CSS Animations/Transforms (no Framer Motion needed for this scope)
+**Storage**: N/A (reads existing MatchState from Supabase Realtime broadcasts; no new persistence)
+**Testing**: Vitest for unit/component tests, Playwright for E2E visual flows
+**Target Platform**: Web (desktop, tablet, mobile browsers)
+**Project Type**: Web application (Next.js fullstack)
+**Performance Goals**: 60 FPS sustained for all animations, no dropped frames during swap/highlight sequences
+**Constraints**: GPU-accelerated properties only (transform, opacity); 44x44px minimum touch targets on mobile; WCAG 2.1 AA contrast (4.5:1) on frozen tile overlays
+**Scale/Scope**: ~8 modified files, ~3 new files, 0 API changes, 0 migration changes
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Server-Authoritative Game Logic | PASS | No server changes. All game state mutations remain server-side. This spec is view-layer only. |
+| II. Real-Time Performance Standards | PASS | 60 FPS animation target aligns with constitution. No impact on move RTT (<200ms) or word validation (<50ms). |
+| III. Type-Safe End-to-End | PASS | Consumes existing typed MatchState. No new Server Actions or API contracts. |
+| IV. Progressive Enhancement & Mobile-First | PASS | Core feature: responsive board sizing, 44x44px touch targets, mobile-first layout. |
+| V. Observability & Resilience | PASS | Existing `performance.mark("board-grid:hydrated")` preserved. Animation timing is client-only; no server-side observability needed. |
+| VI. Clean Code Principles | PASS | Functions <20 lines, single responsibility. New animation utilities will be pure functions. |
+| VII. Test Driven Development (TDD) | PASS | TDD workflow required: failing test first for each visual behavior. |
+| VIII. External Context Providers | N/A | No external libraries or APIs introduced. Pure CSS animations. |
+| IX. Commit Message Standards | PASS | Conventional Commits format with `feat(board-ui):` and `test(board-ui):` scopes. |
+
+**Gate result**: All principles pass. No violations requiring justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-board-ui-animations/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (client-side entities)
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (no new API contracts)
+│   └── README.md        # Explains why no contracts needed
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+components/
+├── game/
+│   ├── BoardGrid.tsx          # MODIFY: add swap animation, shake, highlight timing, skeleton
+│   ├── TimerHud.tsx           # MODIFY: add green/neutral color state per submission status
+│   ├── MoveFeedback.tsx       # NO CHANGE (not used in match flow)
+│   └── Board.tsx              # NO CHANGE (legacy standalone, not in match flow)
+├── match/
+│   ├── MatchClient.tsx        # MODIFY: new layout, animation sequencing, score delta popup
+│   ├── MatchShell.tsx         # MODIFY: remove debug metadata, conditional skeleton vs. content
+│   ├── RoundSummaryPanel.tsx  # NO CHANGE (already complete)
+│   ├── GameChrome.tsx         # NEW: opponent bar and player bar components
+│   └── WordHighlightOverlay.tsx # NO CHANGE (unused, may remove in cleanup)
+
+app/
+├── match/[matchId]/
+│   └── page.tsx               # MODIFY: remove nested <main>, simplify wrapper
+├── styles/
+│   └── board.css              # MODIFY: responsive viewport sizing, animation keyframes
+
+lib/
+├── constants/
+│   └── playerColors.ts        # NEW: centralized player color constants
+├── types/                     # NO CHANGE (existing types sufficient)
+
+tailwind.config.ts             # MODIFY: add animation tokens, player color tokens
+
+tests/
+├── unit/
+│   └── components/
+│       ├── BoardGrid.test.tsx     # NEW/MODIFY: animation timing, frozen overlay, skeleton
+│       ├── GameChrome.test.tsx     # NEW: score display, move counter, timer colors
+│       └── MatchClient.test.tsx   # MODIFY: layout structure, animation sequencing
+├── integration/
+│   └── ui/
+│       └── board-ui.spec.ts       # NEW: Playwright E2E for layout, responsive, animations
+```
+
+**Structure Decision**: Follows existing feature-based organization. New `GameChrome.tsx` component extracts opponent/player bar logic from MatchClient. Player colors centralized in `lib/constants/playerColors.ts` (currently hardcoded in BoardGrid only). No new directories needed.
+
+## Key Architectural Decisions
+
+### 1. CSS Animations over Framer Motion
+
+**Decision**: Use pure CSS animations (keyframes + transitions) instead of Framer Motion.
+
+**Rationale**: The animations in scope (swap translate, shake oscillation, highlight glow) are all achievable with CSS transforms and opacity. Adding Framer Motion (~32KB gzipped) for these simple cases violates the constitution's complexity justification principle. CSS animations are GPU-accelerated by default and require no additional runtime.
+
+**Implementation**: Define keyframes in `board.css`, trigger via CSS class toggling from React state. Use `onTransitionEnd` / `onAnimationEnd` callbacks for sequencing.
+
+### 2. Layout Refactor Strategy
+
+**Decision**: Refactor MatchShell into a thin wrapper that conditionally renders skeleton or game content. Extract game chrome (opponent/player bars) into a new `GameChrome.tsx` component.
+
+**Rationale**: MatchShell currently always renders loading skeletons alongside children (never hides them). The headline, status text, and debug metadata grid are always visible. The cleanest approach is to:
+1. Make MatchShell accept a `loading` prop to toggle skeleton vs. children
+2. Move debug metadata behind a dev-only toggle
+3. Extract the opponent/player bar chrome into a composable `GameChrome` component
+
+### 3. Board Responsive Sizing Approach
+
+**Decision**: Use CSS `min(calc(100vh - chrome-height), 100vw)` to constrain the board to the smaller of available height and width, maintaining square aspect ratio.
+
+**Rationale**: The current `width: 95%` approach doesn't account for vertical constraints (the board can overflow vertically on short viewports). The board needs to fit in the space between opponent bar (~60px) and player bar (~60px), so the available height is `100vh - ~120px - padding`. Using `min()` ensures the board is as large as possible without overflowing in either dimension.
+
+### 4. Animation Sequencing Model
+
+**Decision**: Use a state machine pattern in MatchClient for round resolution visual sequence: `idle → highlighting → freezing → summary`.
+
+**Rationale**: The spec requires sequential visual events (FR-036a): word highlights (600-800ms) → frozen overlays appear → round summary panel. A simple state machine with timeout-based transitions ensures deterministic sequencing and is easy to test. Each state triggers the appropriate visual change via props passed to children.
+
+### 5. Player Color Centralization
+
+**Decision**: Extract `FROZEN_COLORS` from BoardGrid into `lib/constants/playerColors.ts` and expand to include full-opacity and highlight variants.
+
+**Rationale**: Player colors are used in multiple components (BoardGrid frozen overlays, GameChrome score displays, word highlights). Centralizing prevents drift and makes the WCAG contrast requirement (FR-021) verifiable against a single source of truth.
+
+### 6. Skeleton Loading State
+
+**Decision**: Render a 10x10 grid of gray placeholder tiles (no letters) as the loading state, matching the final board dimensions exactly.
+
+**Rationale**: The skeleton grid prevents layout shift (CLS) when the real board data arrives. Gray tiles at the correct size provide spatial context while the match state loads. The skeleton reuses the same grid CSS as the real board.
+
+## Existing Code Analysis
+
+### Files to Modify
+
+| File | Lines | Key Changes |
+|------|-------|-------------|
+| `components/match/MatchClient.tsx` | 327 | New layout structure, animation state machine, pass chrome props |
+| `components/match/MatchShell.tsx` | 64 | Conditional skeleton/content, remove debug metadata from default view |
+| `components/game/BoardGrid.tsx` | 309 | Swap animation (CSS transform), shake animation, highlight timing update |
+| `components/game/TimerHud.tsx` | 47 | Green/neutral color based on submission status |
+| `app/match/[matchId]/page.tsx` | 52 | Remove nested `<main>`, simplify wrapper |
+| `app/styles/board.css` | 134 | Viewport-responsive sizing, new keyframes (shake, swap) |
+| `tailwind.config.ts` | 24 | Player color tokens, animation duration tokens |
+
+### Files to Create
+
+| File | Purpose |
+|------|---------|
+| `components/match/GameChrome.tsx` | Opponent bar + player bar (scores, timers, move counter) |
+| `lib/constants/playerColors.ts` | Centralized Blue/Red color values (hex, rgba, overlay variants) |
+| `tests/unit/components/GameChrome.test.tsx` | Unit tests for chrome component |
+
+### Key Data Dependencies (Already Available)
+
+| Data | Source | Type |
+|------|--------|------|
+| Board grid | `matchState.board` | `string[][]` (10x10) |
+| Frozen tiles | `matchState.frozenTiles` | `FrozenTileMap` (Record<"x,y", { owner }>) |
+| Scores | `matchState.scores` | `ScoreTotals` ({ playerA, playerB }) |
+| Timers | `matchState.timers` | `{ playerA: TimerState, playerB: TimerState }` |
+| Current round | `matchState.currentRound` | `number` |
+| Player slot | Derived from `currentPlayerId` + timer playerId | `"player_a" \| "player_b"` |
+| Scored words | `summary.words` | `WordScore[]` with coordinates |
+| Highlights | `summary.highlights` | `Coordinate[][]` |
+| Combo bonus | `summary.comboBonus` | `ScoreTotals` (optional) |
+| Score deltas | `summary.deltas` | `ScoreTotals` |
+
+### Existing Animation Infrastructure
+
+| What | Where | Status |
+|------|-------|--------|
+| Tile hover transition | `board.css` line 79 | `transform 150ms ease` - keep |
+| Tile selected state | `board.css` line 89 | `box-shadow` ring - keep |
+| Scored tile highlight | `board.css` line 106 | `@keyframes scored-tile-highlight` (3s) - replace with 600-800ms per spec |
+| Frozen tile colors | `BoardGrid.tsx` line 83 | `FROZEN_COLORS` object - extract to shared constant |
+| Frozen tile CSS class | `board.css` line 100 | `.board-grid__cell--frozen` - keep, enhance |
+| Highlight CSS class | `board.css` line 103 | `.board-grid__cell--scored` - update timing |
+
+### Known Issues to Address
+
+1. **Nested `<main>` tags**: Root layout has `<main>`, match page also wraps in `<main>`. Fix by removing inner `<main>` from page.tsx.
+2. **MatchShell always shows skeletons**: Loading placeholders render alongside real content. Fix with conditional rendering.
+3. **`aria-disabled` but not `disabled` on frozen tiles**: Frozen tiles have `aria-disabled={true}` but no `disabled` attribute, so they're still clickable. Should trigger shake animation instead of allowing click-through.
+4. **No swap animation**: Tiles update instantly. Need CSS transform-based position swap.
+5. **Highlight duration mismatch**: Current `scored-tile-highlight` keyframe is 3s; spec requires 600-800ms.
+6. **Width: 95% board sizing**: Not viewport-relative, can overflow vertically. Need min() based approach.
+
+## Complexity Tracking
+
+> No constitution violations; no complexity justifications needed.

--- a/specs/004-board-ui-animations/quickstart.md
+++ b/specs/004-board-ui-animations/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart: Board UI and Animations
+
+**Feature**: 004-board-ui-animations
+**Date**: 2026-02-23
+
+## Prerequisites
+
+- Node.js (version per `.nvmrc` or 18+)
+- pnpm (package manager)
+- Supabase CLI (for local DB; already configured from prior specs)
+
+## Setup
+
+No additional setup required beyond the standard project setup. This feature modifies only frontend components and CSS.
+
+```bash
+# 1. Switch to feature branch
+git checkout 004-board-ui-animations
+
+# 2. Install dependencies (no new packages added)
+pnpm install
+
+# 3. Start local Supabase (if not already running)
+pnpm supabase start
+
+# 4. Start dev server
+pnpm dev
+```
+
+## Development Workflow
+
+### Running Tests
+
+```bash
+# Unit tests (watch mode for TDD)
+pnpm test:unit -- --watch
+
+# Specific component tests
+pnpm test:unit -- components/game/BoardGrid.test.tsx
+pnpm test:unit -- components/match/GameChrome.test.tsx
+
+# All unit tests
+pnpm test:unit
+
+# E2E tests (requires dev server running)
+pnpm exec playwright test tests/integration/ui/board-ui.spec.ts
+
+# Lint + typecheck
+pnpm lint && pnpm typecheck
+```
+
+### Visual Testing Viewports
+
+Test the responsive board at these viewport sizes:
+
+| Name | Width | Height | Notes |
+|------|-------|--------|-------|
+| Desktop | 1280 | 800 | Primary development viewport |
+| Tablet | 768 | 1024 | Portrait tablet |
+| Phone | 375 | 667 | iPhone SE / small phone |
+
+Use Chrome DevTools device toolbar or Playwright viewport config.
+
+### Testing Animation Timing
+
+1. **Swap animation**: Select two tiles → verify 150-250ms smooth translate
+2. **Shake animation**: Click a frozen tile → verify 3-4 oscillations in 300-400ms
+3. **Word highlight**: Complete a round that scores a word → verify 600-800ms glow
+4. **Reduced motion**: Enable `prefers-reduced-motion` in DevTools → verify instant state changes
+
+### Testing Frozen Tile Overlays
+
+1. Complete rounds that score words for both players
+2. Verify Player 1 (blue) and Player 2 (red) overlays at 40% opacity
+3. If both players score words sharing a tile, verify split-diagonal pattern
+4. Use a contrast checker on frozen tile letter text (target: 4.5:1)
+
+### Debug Mode
+
+Access debug metadata (match ID, status, round info) via URL parameter:
+
+```
+http://localhost:3000/match/<matchId>?debug=1
+```
+
+This is stripped in production builds.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `components/match/GameChrome.tsx` | NEW: Opponent/player bars |
+| `components/match/MatchClient.tsx` | Animation sequencing, layout |
+| `components/match/MatchShell.tsx` | Skeleton/content toggle |
+| `components/game/BoardGrid.tsx` | Swap/shake/highlight animations |
+| `components/game/TimerHud.tsx` | Green/neutral timer colors |
+| `app/styles/board.css` | Responsive sizing, keyframes |
+| `lib/constants/playerColors.ts` | NEW: Centralized color constants |
+| `tailwind.config.ts` | Player color + animation tokens |
+
+## No New Dependencies
+
+This feature uses only existing dependencies:
+- **Tailwind CSS** for utility classes and responsive breakpoints
+- **CSS animations/transitions** for all motion (no Framer Motion)
+- **Vitest** for component/unit tests
+- **Playwright** for E2E visual tests

--- a/specs/004-board-ui-animations/research.md
+++ b/specs/004-board-ui-animations/research.md
@@ -1,0 +1,119 @@
+# Research: Board UI and Animations
+
+**Feature**: 004-board-ui-animations
+**Date**: 2026-02-23
+
+## Research Areas
+
+### 1. Animation Library vs. Pure CSS
+
+**Decision**: Pure CSS animations (keyframes + transitions)
+
+**Rationale**: All animations in scope are simple transform/opacity changes achievable with CSS:
+- Swap: `translateX`/`translateY` between two tile positions (150-250ms)
+- Shake: `translateX` oscillation keyframe (300-400ms)
+- Highlight glow: `box-shadow` + `opacity` keyframe (600-800ms)
+- Score delta popup: `opacity` transition (200ms in/out)
+
+Adding Framer Motion (~32KB gzipped) would introduce unnecessary bundle size for these simple cases. CSS animations are GPU-accelerated by default via the browser's compositor thread.
+
+**Alternatives considered**:
+- **Framer Motion**: Full animation library with layout animations and gesture support. Overkill for this scope. Would be appropriate if we needed physics-based spring animations or complex layout transitions (e.g., reordering tiles).
+- **Web Animations API (WAAPI)**: JavaScript-driven but browser-native. More control than CSS but adds complexity. Good candidate for swap animation since we need to calculate dynamic transform values at runtime. Could use as a targeted tool alongside CSS keyframes.
+- **React Spring**: Similar to Framer Motion but physics-based. Same overkill concern.
+
+**Note**: The swap animation requires dynamic transform calculation (tile A's position → tile B's position) which is harder with pure CSS classes. Implementation may use WAAPI or inline `style.transform` with transition for the swap specifically, while using CSS keyframes for shake and highlight.
+
+### 2. Responsive Board Sizing Strategy
+
+**Decision**: CSS `min()` function with `calc()` for viewport-based sizing
+
+**Rationale**: The board must be the largest possible square that fits in the space between opponent bar and player bar. Using:
+```css
+--chrome-height: 120px; /* opponent bar + player bar + gaps */
+--board-max: min(calc(100vh - var(--chrome-height)), calc(100vw - 2rem));
+width: var(--board-max);
+height: var(--board-max);
+```
+This ensures the board never overflows in either dimension and maintains square aspect ratio.
+
+**Alternatives considered**:
+- **Container queries**: `cqi`/`cqb` units relative to a container. Good for component isolation but browser support slightly less universal than `min()`/`calc()`. Adds complexity without benefit here.
+- **JavaScript resize observer**: Calculate board size in JS on resize events. Works but introduces layout jank (JS runs after paint). CSS-only solution is smoother.
+- **`vmin` units**: `width: 80vmin` scales relative to the smaller viewport dimension. Simple but doesn't account for the chrome height consuming vertical space. Board could still overflow vertically on short-but-wide viewports.
+
+### 3. Swap Animation Implementation
+
+**Decision**: Inline `style.transform` with CSS `transition` property
+
+**Rationale**: Swap animation requires dynamic pixel offsets (tile A must translate by exactly the pixel distance to tile B's position and vice versa). This is best achieved by:
+1. On swap trigger: measure tile positions via `getBoundingClientRect()`
+2. Apply `transform: translate(dx, dy)` inline styles to both tiles
+3. The existing `transition: transform 150ms ease` in board.css handles the animation
+4. On `transitionend` event: remove transform, update grid state, unblock interactions
+
+This avoids creating a CSS class for every possible swap direction/distance.
+
+**Alternatives considered**:
+- **CSS class with predefined transforms**: Would need classes for every possible offset combination (81+ for a 10x10 grid). Impractical.
+- **FLIP technique (First, Last, Invert, Play)**: Calculate position difference, apply inverse transform, then animate to identity. More complex but handles layout-driven changes well. Overkill since we control the exact positions.
+- **Absolute positioning during animation**: Temporarily take tiles out of flow, animate with absolute positioning, then re-insert. Risk of layout shift and complexity.
+
+### 4. Round Resolution Animation Sequencing
+
+**Decision**: React state machine with `useEffect` timeout chain
+
+**Rationale**: The three visual phases (highlight → freeze → summary) need sequential execution with specific timing. A state enum (`"idle" | "highlighting" | "freezing" | "showing-summary"`) with `useEffect` watching for transitions provides clean, testable sequencing:
+
+```
+onRoundSummary received:
+  → Set state to "highlighting", pass highlight data to BoardGrid
+  → After 800ms timeout: set state to "freezing", apply frozen tiles
+  → After 200ms (visual settle): set state to "showing-summary", show panel
+```
+
+**Alternatives considered**:
+- **Promise chain**: `await highlight(800ms).then(() => freeze()).then(() => showSummary())`. Harder to integrate with React's render cycle. Requires `useRef` to track cancellation.
+- **Custom event system**: Emit events between components. Over-engineered for a linear sequence.
+- **Single timeout with CSS delays**: Apply all CSS at once with staggered `animation-delay`. Doesn't work because the freeze data and summary panel need React state updates, not just CSS timing.
+
+### 5. Debug Metadata Toggle
+
+**Decision**: `?debug=1` URL parameter, checked via `useSearchParams()`, stripped in production via build-time constant
+
+**Rationale**: Simple, no keyboard shortcut conflicts, easily shareable debug URLs for testing. In production, the debug component tree is entirely excluded (not just hidden).
+
+**Alternatives considered**:
+- **Keyboard shortcut (e.g., Ctrl+Shift+D)**: Discoverability issue; no way to share debug state via URL.
+- **Environment variable only**: Can't toggle at runtime during testing sessions.
+- **localStorage flag**: Persists across sessions unexpectedly; harder to share.
+
+### 6. Player Color Centralization
+
+**Decision**: New `lib/constants/playerColors.ts` with hex, rgba, and Tailwind-compatible values
+
+**Rationale**: Player colors are already used in `BoardGrid.tsx` FROZEN_COLORS and will be needed in `GameChrome.tsx` (score display), word highlights, and potentially the score delta popup. A single source of truth prevents drift and makes WCAG contrast verification straightforward.
+
+The existing FROZEN_COLORS values already match the spec (Blue #3B82F6, Red #EF4444 at 40% opacity), confirming no visual change needed for frozen tiles — only extraction and reuse.
+
+### 7. Skeleton Board Loading State
+
+**Decision**: Reuse the same CSS grid with `aria-hidden` gray tiles, conditionally rendered when `matchState` is null/undefined
+
+**Rationale**: The skeleton must match the real board's dimensions exactly to prevent layout shift (CLS). By reusing the same `.board-grid` CSS and rendering 100 inert `<div>` elements instead of `<button>` elements, the skeleton is visually identical in size and position.
+
+**Alternatives considered**:
+- **Tailwind `animate-pulse` skeleton**: Standard skeleton pattern. Could add a subtle pulse to the gray tiles for visual polish. Low risk.
+- **Canvas-based placeholder**: Overkill for a simple gray grid.
+- **SSR-rendered board**: Would require knowing the board state at SSR time, which isn't available until after match state loads.
+
+### 8. WCAG Contrast Verification for Frozen Tiles
+
+**Research**: Verified contrast ratios for white text on colored overlays at 40% opacity over the dark tile background (#1e293b).
+
+| Color | Overlay at 40% | Blended with #1e293b | White text contrast |
+|-------|----------------|---------------------|-------------------|
+| Blue (#3B82F6) | rgba(59,130,246,0.4) | ~#2F5A8E | ~5.2:1 (passes AA) |
+| Red (#EF4444) | rgba(239,68,68,0.4) | ~#814040 | ~4.8:1 (passes AA) |
+
+Both colors meet the 4.5:1 WCAG AA threshold for normal text. The existing color choices are confirmed safe.

--- a/specs/004-board-ui-animations/spec.md
+++ b/specs/004-board-ui-animations/spec.md
@@ -1,0 +1,279 @@
+# Feature Specification: Board UI and Animations
+
+**Feature Branch**: `004-board-ui-animations`
+**Created**: 2026-02-23
+**Status**: Draft
+**Input**: Implement the PRD match layout (opponent bar, grid, player bar), responsive board sizing, frozen tile visual overlays, core interaction animations (swap, shake, word highlight), and game chrome (scores, move counter, timer state colors) to transform the match screen from a backend test harness into a playable game view.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - PRD Match Layout Structure (Priority: P1)
+
+When a player enters a match, the screen displays the PRD-defined layout: an opponent bar at the top (showing opponent name, timer, and score), the 10x10 game board in the center, and a player bar at the bottom (showing the player's name, timer, score, and move counter). This replaces the current developer-oriented layout with test metadata.
+
+**Why this priority**: The PRD layout is the foundational container for every other visual feature. Without the correct structure, responsive sizing, frozen tile overlays, and animations have no proper home. This is the frame that makes the game recognizable as a game.
+
+**Independent Test**: Navigate to an active match. Verify the screen shows three distinct regions stacked vertically: opponent bar, board grid, player bar, with no debug metadata (match ID, status text, round limit) visible in the default view.
+
+**Acceptance Scenarios**:
+
+1. **Given** a player navigates to an active match, **When** the match page loads, **Then** the screen displays an opponent bar at the top, a 10x10 grid in the center, and a player bar at the bottom, matching the PRD Section 7.1 desktop layout diagram.
+2. **Given** a match is in progress on a mobile viewport (width < 768px), **When** the player views the match, **Then** the layout stacks vertically with the opponent info bar, scrollable board, and player info bar per the PRD mobile layout diagram.
+3. **Given** the match page loads, **When** the player scans the screen, **Then** no debug metadata (match ID, "Round limit", "Status", "Board Loading" placeholders) is visible in the default play view.
+
+---
+
+### User Story 2 - Board Fits Viewport on All Devices (Priority: P1)
+
+The 10x10 game board scales to fit the available viewport space without overflowing or requiring horizontal scrolling. Tiles remain perfectly square and readable at all supported viewport sizes. The board uses the space between the opponent bar and player bar, never extending beyond the visible area on desktop.
+
+**Why this priority**: The board currently overflows the screen, making the game unplayable. Fixing viewport fit is a prerequisite for all other visual features and is the single highest-impact change for playability.
+
+**Independent Test**: Open a match on three viewport sizes (1280x800 desktop, 768x1024 tablet, 375x667 phone). Verify the board is fully visible, tiles are square, and no horizontal scrollbar appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a desktop viewport of 1280x800, **When** the match page loads, **Then** the full 10x10 grid is visible without scrolling and each tile is a square with readable text.
+2. **Given** a tablet viewport of 768x1024, **When** the match page loads, **Then** the board fits within the space between opponent and player bars, tiles are square, and no horizontal scroll is present.
+3. **Given** a phone viewport of 375x667, **When** the match page loads, **Then** the board scales down to fit the screen width, tiles remain square and readable, and vertical scrolling of the board is available if needed.
+4. **Given** any supported viewport, **When** the browser window is resized, **Then** the board re-scales dynamically to fit the new dimensions without a page reload.
+
+---
+
+### User Story 3 - Scores and Move Counter in Game Chrome (Priority: P1)
+
+Both players' current scores are displayed in their respective bars (opponent score in the opponent bar, player score in the player bar). A move counter formatted as "M{n}" is visible in the player bar, where n represents the current round number. Timers show the remaining time for each player.
+
+**Why this priority**: Players need to see scores, timers, and round progress at a glance to make strategic decisions. This is core game information that the PRD requires in the chrome.
+
+**Independent Test**: Start a match and complete two rounds. Verify that both players' scores update after each round, the move counter increments, and timers display remaining time.
+
+**Acceptance Scenarios**:
+
+1. **Given** a match where Player A has 45 points and Player B has 30 points, **When** the board displays for Player A, **Then** the opponent bar shows "30" and the player bar shows "45".
+2. **Given** a match in round 3, **When** the player views the match, **Then** the player bar displays "M3" as the move counter.
+3. **Given** both players' timers are running, **When** the match is in progress, **Then** each bar displays the respective player's remaining time.
+
+---
+
+### User Story 4 - Frozen Tiles Display Player Ownership (Priority: P1)
+
+After a round resolves and words are scored, frozen tiles display a colored overlay at 40% opacity indicating which player claimed them. The player's own frozen tiles use their assigned color, the opponent's frozen tiles use the opponent's color, and tiles claimed by both players display a split-diagonal pattern combining both colors. Players can visually distinguish frozen tiles from unfrozen tiles at a glance.
+
+**Why this priority**: Frozen tiles are the core strategic mechanic of Wottle. Without visual indication of territory ownership, players cannot plan moves around the constraint that frozen tiles cannot be swapped.
+
+**Independent Test**: Complete a round that scores a word. Verify the tiles of the scored word display a colored overlay at 40% opacity using the scoring player's color.
+
+**Acceptance Scenarios**:
+
+1. **Given** a round resolves and Player A scores a word using tiles at (0,0) through (4,0), **When** the board updates, **Then** those tiles display Player A's color as a 40% opacity overlay.
+2. **Given** tiles frozen by the opponent, **When** the player views the board, **Then** opponent-frozen tiles display the opponent's color at 40% opacity, visually distinct from the player's own frozen tiles.
+3. **Given** a tile at (2,0) is claimed by both players, **When** the board displays, **Then** that tile shows a split-diagonal pattern with each player's color occupying one triangle.
+4. **Given** frozen tiles with colored overlays, **When** measured for accessibility, **Then** the tile letter text maintains a minimum contrast ratio of 4.5:1 against the overlay background per WCAG 2.1 AA.
+
+---
+
+### User Story 5 - Tile Swap Animates Smoothly (Priority: P1)
+
+When a player selects two tiles and confirms a swap, the tiles animate smoothly to their new positions over 150-250ms with easing. During the animation, further tile interactions are blocked to prevent conflicting inputs. The animation is GPU-accelerated and runs at 60 FPS.
+
+**Why this priority**: Swap animation is the primary interaction in the game. Without it, moves feel instant and disorienting. The animation confirms to the player that their action was registered and shows exactly what changed.
+
+**Independent Test**: Select two tiles and trigger a swap. Verify the tiles visually slide to each other's positions over 150-250ms, and that clicking other tiles during the animation does nothing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a player selects tile A at (2,3) and tile B at (5,3), **When** the swap is confirmed, **Then** tile A animates to position (5,3) and tile B animates to position (2,3) simultaneously over 150-250ms with smooth easing.
+2. **Given** a swap animation is in progress, **When** the player attempts to select or interact with other tiles, **Then** the interaction is ignored until the current animation completes.
+3. **Given** the swap animation completes, **When** the tiles reach their final positions, **Then** the board state updates to reflect the new tile positions with no visual glitch or snap.
+
+---
+
+### User Story 6 - Invalid Swap Shows Rejection Feedback (Priority: P2)
+
+When a player attempts an invalid swap (e.g., selecting a frozen tile), the selected tiles shake with 3-4 oscillations over 300-400ms and briefly flash with a red border for 200ms. The player immediately understands their move was rejected without needing to read an error message.
+
+**Why this priority**: Clear rejection feedback prevents confusion and frustration. Without it, players may not realize their swap was rejected and may think the game is broken.
+
+**Independent Test**: Attempt to swap a frozen tile. Verify the tiles shake visibly and a red border flashes, then tiles return to their original positions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a player selects a frozen tile for swapping, **When** the swap is attempted, **Then** the selected tiles shake with 3-4 oscillations over 300-400ms.
+2. **Given** an invalid swap attempt, **When** the shake animation plays, **Then** a red border flash of 200ms duration appears around the selected tiles simultaneously.
+3. **Given** the shake animation completes, **When** the tiles settle, **Then** they return to their original positions and the board is ready for a new selection.
+
+---
+
+### User Story 7 - Word Discovery Highlights Scored Tiles (Priority: P2)
+
+After a round resolves and new words are scored, the tiles belonging to each scored word briefly highlight with a pulsing glow using the scoring player's color. The highlight lasts 600-800ms total (200ms fade in, 200-400ms hold, 200ms fade out). Multiple words discovered in the same round highlight simultaneously.
+
+**Why this priority**: Word highlights connect the abstract scoring event to the physical board, helping players understand which tiles formed words and building excitement. This is a key "game feel" feature.
+
+**Independent Test**: Complete a round that scores two words. Verify both sets of tiles highlight simultaneously with a pulsing glow for 600-800ms.
+
+**Acceptance Scenarios**:
+
+1. **Given** a round resolves and Player A scores the word "LAND" at tiles (0,0)-(3,0), **When** the round summary appears, **Then** tiles (0,0), (1,0), (2,0), (3,0) highlight with Player A's color in a pulsing glow lasting 600-800ms.
+2. **Given** a round resolves with two scored words, **When** the highlights trigger, **Then** both words' tiles highlight simultaneously (not sequentially).
+3. **Given** the highlight animation, **When** timed, **Then** it follows the pattern: 200ms fade in, 200-400ms hold at full intensity, 200ms fade out.
+
+---
+
+### User Story 8 - Score Delta Popup Shows Breakdown (Priority: P3)
+
+After a round resolves, a transient popup appears near the player's score showing a breakdown of points earned that round (e.g., "+18 letters, +3 length, +2 combo"). The popup fades in over 200ms, holds for 2-2.8s, and fades out over 200ms, then auto-dismisses.
+
+**Why this priority**: The score delta popup is a polish feature that enhances scoring transparency. The round summary panel already provides detailed breakdowns, so this is supplementary. Deferring this to a later pass is acceptable.
+
+**Independent Test**: Complete a round that scores a word. Verify a popup appears near the score showing the point breakdown and auto-dismisses after 2-3 seconds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a round resolves and the player earns 23 points (18 letters + 5 length + 0 combo), **When** the round summary appears, **Then** a popup near the player's score shows "+18 letters, +5 length".
+2. **Given** a score delta popup is displayed, **When** 2-3 seconds elapse, **Then** the popup fades out over 200ms and disappears without user interaction.
+3. **Given** a score delta popup, **When** the player starts a new swap, **Then** the popup dismisses immediately.
+
+---
+
+### Edge Cases
+
+- What happens when the viewport is extremely narrow (< 320px width)?
+  - The board scales down but may become unreadable. A minimum tile size of 28px is enforced; if the viewport cannot accommodate 10 tiles at 28px plus padding, the board overflows horizontally with scroll enabled. This is an edge case for very small devices that are below the practical minimum for gameplay.
+- What happens when a swap animation is interrupted by a round resolution broadcast?
+  - The swap animation completes before the round resolution state is applied. Animation completion is a prerequisite for applying incoming state updates.
+- What happens when many words are highlighted simultaneously (e.g., 4+ words from a combo)?
+  - All word highlights play simultaneously. If tiles overlap between words, the tile shows the brightest/most recent highlight. Performance remains at 60 FPS due to GPU-accelerated transforms.
+- What happens when the user has `prefers-reduced-motion` enabled?
+  - All animations (swap, shake, highlight, popup) are replaced with instant state changes (no motion). Frozen tile overlays, layout, and score updates are unaffected.
+- What happens when timer state changes (submitted vs. active) mid-round?
+  - The timer display color updates immediately: green while the player has not submitted, neutral once submitted. No animation is needed for this transition.
+- What happens to debug metadata (match ID, status) in development?
+  - Debug metadata is hidden by default in the play view but can be toggled visible via a dev-only mechanism (e.g., URL parameter or keyboard shortcut). This is not exposed in production builds.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+#### PRD Layout Structure
+
+- **FR-001**: System MUST display the match screen in three vertically stacked regions: opponent bar (top), 10x10 game board (center), player bar (bottom), matching the PRD Section 7.1 layout diagram.
+- **FR-002**: The opponent bar MUST display the opponent's name/label, remaining timer, and current score.
+- **FR-003**: The player bar MUST display the player's name/label, remaining timer, current score, and move counter formatted as "M{n}".
+- **FR-004**: On mobile viewports (width < 768px), the layout MUST stack vertically with opponent info, board, and player info per the PRD mobile layout diagram. Timer and move counter MAY wrap to separate lines.
+- **FR-005**: The layout MUST identify which bar belongs to which player by using the `playerSlot` assignment from the match state.
+
+#### Responsive Board Sizing
+
+- **FR-006**: The 10x10 game board MUST scale to fit the available space between the opponent bar and player bar without causing horizontal overflow on viewports >= 320px wide.
+- **FR-007**: Board tiles MUST remain square (1:1 aspect ratio) at all viewport sizes.
+- **FR-008**: The board MUST dynamically re-scale when the viewport is resized without requiring a page reload.
+- **FR-009**: The board MUST enforce a minimum tile size of 28px to maintain readability. If the viewport cannot accommodate the board at this minimum size, horizontal scrolling is permitted.
+- **FR-010**: On desktop viewports, the full 10x10 grid MUST be visible without any scrolling.
+
+#### Game Chrome
+
+- **FR-011**: The opponent bar MUST display the opponent's current cumulative score, sourced from `matchState.scores` using the opponent's player slot.
+- **FR-012**: The player bar MUST display the player's current cumulative score, sourced from `matchState.scores` using the player's own slot.
+- **FR-013**: The player bar MUST display a move counter formatted as "M{n}" where n is the current round number, derived from `matchState.currentRound`.
+- **FR-014**: The timer display MUST show green when the respective player has not yet submitted their swap for the current round, and switch to a neutral color once they have submitted (their clock is paused), per PRD Section 7.2.
+
+#### Declutter
+
+- **FR-015**: The default match play view MUST NOT display debug metadata including: match ID, "Round limit" text, "Status" text, "Board Loading" placeholder, or "Players" section.
+- **FR-016**: Debug metadata MUST remain accessible via a dev-only toggle mechanism (e.g., URL parameter or keyboard shortcut) that is not available in production builds.
+- **FR-017**: Reconnect/polling banners, swap error messages, and the round summary panel MUST remain visible in the play view (these are gameplay-relevant, not debug information).
+- **FR-017a**: While match state is loading (before initial data arrives), the board area MUST display a skeleton 10x10 grid with gray placeholder tiles (no letters). The skeleton MUST be replaced with the actual board once the match state is received, with no layout shift.
+
+#### Frozen Tile Overlays
+
+- **FR-018**: Frozen tiles MUST display a colored overlay at 40% opacity using the owning player's color: Blue (#3B82F6) for Player 1, Red (#EF4444) for Player 2.
+- **FR-019**: Tiles frozen by the opponent MUST display the opponent's color at 40% opacity, visually distinct from the current player's frozen tiles.
+- **FR-020**: Tiles claimed by both players MUST display a split-diagonal pattern where each player's color occupies one triangle of the tile.
+- **FR-021**: The tile letter text on frozen tiles MUST maintain a minimum contrast ratio of 4.5:1 against the overlay background per WCAG 2.1 AA.
+- **FR-022**: Frozen tile overlays MUST update immediately when a round resolves and new tiles are frozen, without requiring a page reload or manual refresh.
+
+#### Swap Animation
+
+- **FR-023**: When a valid swap is confirmed, the two tiles MUST animate to each other's positions simultaneously over 150-250ms with smooth easing.
+- **FR-024**: During a swap animation, all tile interactions (selection, swapping) MUST be blocked until the animation completes.
+- **FR-025**: Swap animations MUST use GPU-accelerated properties (transforms, opacity) to maintain 60 FPS.
+- **FR-026**: After the swap animation completes, the board state MUST update to reflect the new tile positions with no visual discontinuity (snap or flicker).
+- **FR-027**: The swap animation MUST complete before the move submission is sent to the server (animation is visual feedback for the local state change, not dependent on server response).
+
+#### Invalid Swap Feedback
+
+- **FR-028**: When a swap is rejected (frozen tile, invalid selection, etc.), the selected tiles MUST shake with 3-4 horizontal oscillations over 300-400ms.
+- **FR-029**: Simultaneously with the shake, a red border MUST flash around the selected tiles for 200ms duration.
+- **FR-030**: After the shake animation completes, tiles MUST return to their exact original positions.
+- **FR-031**: Shake and red border animations MUST use GPU-accelerated properties to maintain 60 FPS.
+
+#### Word Discovery Highlights
+
+- **FR-032**: After a round resolves, tiles belonging to each newly scored word MUST highlight with a pulsing glow effect using the scoring player's assigned color.
+- **FR-033**: The highlight timing MUST follow: 200ms fade in, 200-400ms hold at full intensity, 200ms fade out (600-800ms total).
+- **FR-034**: Multiple words discovered in the same round MUST highlight simultaneously (not sequentially).
+- **FR-035**: Word highlights MUST be visually distinct from frozen tile overlays (highlight is a temporary glow; overlay is a persistent tint).
+- **FR-036**: The highlight coordinates MUST be sourced from the scored word data in the round summary broadcast.
+- **FR-036a**: Round resolution visual events MUST play in this sequence: (1) word discovery highlights play on scored tiles (600-800ms), (2) frozen tile overlays appear on newly frozen tiles, (3) round summary panel displays. Each step begins only after the previous step completes.
+
+#### Score Delta Popup (P3 - Deferrable)
+
+- **FR-037**: After a round resolves, a transient popup MUST appear adjacent to the player's score display showing the point breakdown for that round.
+- **FR-038**: The popup content MUST show individual components (e.g., "+18 letters, +5 length, +2 combo") with zero-value components omitted.
+- **FR-039**: The popup MUST fade in over 200ms, hold for 2-2.8s, and fade out over 200ms, then auto-dismiss.
+- **FR-040**: If the player begins a new interaction (tile selection) before the popup auto-dismisses, the popup MUST dismiss immediately.
+
+#### Animation Performance
+
+- **FR-041**: All animations (swap, shake, highlight, popup) MUST run at a sustained 60 FPS, verified by absence of dropped frames in browser performance profiling.
+- **FR-042**: All animations MUST use GPU-accelerated CSS properties (transform, opacity) rather than layout-triggering properties (top, left, width, height).
+
+#### Accessibility
+
+- **FR-043**: All interactive elements (tiles, buttons) MUST meet the minimum 44x44px touch target size on mobile viewports per WCAG 2.5.5.
+- **FR-044**: When `prefers-reduced-motion` media query is active, all animations (swap, shake, highlight, popup) MUST be replaced with instant state changes (no motion). Layout, overlays, and data updates remain functional.
+- **FR-045**: Score updates, round transitions, and error states MUST be announced to screen readers via appropriate ARIA live regions.
+
+## Clarifications
+
+### Session 2026-02-23
+
+- Q: What are the two player colors used for frozen tile overlays and word highlights? → A: Blue (#3B82F6) and Red (#EF4444) — standard competitive duel colors.
+- Q: What is the visual sequence for round resolution events (highlights, overlays, summary panel)? → A: Sequential — word highlights play first (600-800ms), then frozen tile overlays appear, then the round summary panel shows.
+- Q: What should the board display while match state is loading? → A: Skeleton 10x10 grid with gray placeholder tiles (no letters) that fills in when data arrives.
+
+### Key Entities
+
+- **GameChrome**: The non-board UI elements surrounding the game grid (opponent bar, player bar) that display scores, timers, move counter, and player identity.
+- **FrozenTileOverlay**: The visual representation of a frozen tile's ownership state, rendered as a 40% opacity colored layer over the tile with letter text on top. Supports single-owner and dual-owner (split-diagonal) variants.
+- **SwapAnimation**: The visual transition when two tiles exchange positions, parameterized by duration (150-250ms), easing function, and the two tile coordinates involved.
+- **WordHighlight**: A temporary visual effect applied to tiles of a scored word after round resolution, parameterized by player color, timing (600-800ms), and tile coordinates.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: The match layout conforms to the PRD Section 7.1 diagram on desktop (1280x800): opponent bar with timer + score at top, 10x10 grid centered, player bar with timer + score + M{n} at bottom.
+- **SC-002**: The board fits entirely within the viewport on desktop (1280x800), tablet (768x1024), and phone (375x667) without horizontal scrolling, verified by visual inspection at each resolution.
+- **SC-003**: No debug metadata (match ID, status, round limit) is visible in the default play view on production builds.
+- **SC-004**: Frozen tiles display distinct ownership overlays: own-color, opponent-color, and split-diagonal for shared tiles, verified visually with all three ownership states present on a single board.
+- **SC-005**: Tile swap animation duration is between 150ms and 250ms, measured via browser performance timeline or programmatic timing assertions.
+- **SC-006**: Invalid swap shake animation shows 3-4 visible oscillations over 300-400ms with a concurrent red border flash, verified visually on a frozen tile swap attempt.
+- **SC-007**: Word discovery highlight lasts 600-800ms with visible fade in and fade out phases, verified after a round that scores at least one word.
+- **SC-008**: All animations run at 60 FPS with no visible jank, verified by Chrome DevTools Performance tab showing no dropped frames during swap and highlight sequences.
+- **SC-009**: Touch targets for tiles measure at least 44x44px on mobile viewports, verified by element inspection on a 375px-wide viewport.
+- **SC-010**: When `prefers-reduced-motion` is enabled in browser/OS settings, all animations are replaced with instant state changes (no visible motion), verified by toggling the preference and repeating the swap and highlight flows.
+- **SC-011**: Frozen tile letter text maintains 4.5:1 contrast ratio against the overlay background, verified with a contrast checking tool for each player color at 40% opacity.
+
+### Assumptions
+
+- No server-side changes or database schema modifications are required for this feature. All data needed (scores, timers, frozen tiles, player slot, current round, word scores) is already available in the match state broadcast from spec 003.
+- Player colors are Blue (#3B82F6) and Red (#EF4444). Player 1 (first slot) is Blue; Player 2 (second slot) is Red. These colors are used for frozen tile overlays, word highlights, and split-diagonal shared tiles.
+- The existing `matchState.scores`, `matchState.currentRound`, `matchState.timers`, and `matchState.frozenTiles` fields provide all data needed for game chrome and frozen tile overlays.
+- The `playerSlot` assignment (which player is "you" vs "opponent") is already determined at match join time and available in the client state.
+- The round summary broadcast already includes scored word data with tile coordinates, which is sufficient for word highlight positioning.
+- FR-037 through FR-040 (Score Delta Popup) are P3 and deferrable to a later spec if implementation time is constrained. The round summary panel already provides detailed scoring breakdowns.
+- The move counter M{n} can be derived from `matchState.currentRound` without additional server-side state.
+- The existing `MoveFeedback` component and round summary panel continue to function as-is; this spec adds new visual features alongside them, not as replacements.

--- a/specs/004-board-ui-animations/tasks.md
+++ b/specs/004-board-ui-animations/tasks.md
@@ -1,0 +1,320 @@
+# Tasks: Board UI and Animations
+
+**Input**: Design documents from `/specs/004-board-ui-animations/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md
+
+**Tests**: TDD is NON-NEGOTIABLE per constitution. Test tasks are included and MUST be written and fail before implementation.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create shared constants and configuration that multiple user stories depend on
+
+- [ ] T001 [P] Create centralized player color constants in `lib/constants/playerColors.ts` — export PLAYER_A_HEX (#3B82F6), PLAYER_A_OVERLAY (rgba 40%), PLAYER_A_HIGHLIGHT (rgba 60%), PLAYER_B_HEX (#EF4444), PLAYER_B_OVERLAY (rgba 40%), PLAYER_B_HIGHLIGHT (rgba 60%), BOTH_GRADIENT (linear-gradient 135deg split), and a `getPlayerColors(slot: PlayerSlot)` helper that returns the correct color set for a given player slot
+- [ ] T002 [P] Update `tailwind.config.ts` — add player color tokens under `colors.player` (player.a: #3B82F6, player.b: #EF4444) and animation duration tokens under `transitionDuration` (swap: 200ms, shake: 350ms, highlight: 700ms) so Tailwind classes like `bg-player-a` and `duration-swap` are available
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Refactor existing components to accept the new layout pattern. MUST complete before any user story work begins.
+
+- [ ] T003 Refactor `components/match/MatchShell.tsx` — accept a `loading` boolean prop. When `loading=true`, render a skeleton layout (gray header bars + 10x10 gray tile grid via `aria-hidden` divs reusing `.board-grid` CSS). When `loading=false`, render only `{children}`. Remove the always-visible "Board Loading" / "Players" placeholder sections. Keep `data-testid="match-shell"`
+- [ ] T004 Fix nested `<main>` tag in `app/match/[matchId]/page.tsx` — replace the inner `<main>` element with a `<div>` or `<section>` to avoid invalid HTML nesting with root layout's `<main>`. Preserve existing className and responsive constraints
+- [ ] T005 Add skeleton board rendering to `components/game/BoardGrid.tsx` — when `grid` prop is empty or undefined, render 100 inert gray `<div>` placeholder tiles (not `<button>`) using the same `.board-grid` CSS grid. Include `aria-hidden="true"` on the skeleton container. No layout shift when real data replaces skeleton (FR-017a)
+
+**Checkpoint**: MatchShell conditionally renders skeleton or content. Page has valid HTML structure. BoardGrid handles empty state.
+
+---
+
+## Phase 3: User Story 1 — PRD Match Layout Structure (Priority: P1) — MVP
+
+**Goal**: Match screen displays opponent bar (top) → 10x10 grid (center) → player bar (bottom) per PRD §7.1. Debug metadata hidden by default.
+
+**Independent Test**: Navigate to an active match. Verify three vertically stacked regions with no debug metadata visible.
+
+### Tests for User Story 1
+
+- [ ] T006 [P] [US1] Write failing test in `tests/unit/components/GameChrome.test.tsx` — test that GameChrome renders opponent bar with name, timer, and score; renders player bar with name, timer, score, and move counter M{n}; correctly maps playerSlot to opponent/player position; does not render move counter in opponent bar
+- [ ] T007 [P] [US1] Write failing test in `tests/unit/components/MatchClient.test.tsx` — test that MatchClient renders layout in order: GameChrome(opponent) → BoardGrid → GameChrome(player); no debug metadata (match ID, "Round limit", "Status") is rendered when `?debug` param is absent; debug metadata IS rendered when `?debug=1` is in URL
+
+### Implementation for User Story 1
+
+- [ ] T008 [US1] Create `components/match/GameChrome.tsx` — a client component that renders a horizontal bar with: player name/label, timer (using TimerHud or inline), cumulative score, and optional move counter M{n}. Accept props: `position` ("opponent" | "player"), `playerName`, `score`, `timerSeconds`, `isPaused`, `hasSubmitted`, `moveCounter?`, `playerColor`. Use `playerColor` for a subtle accent (border or score text color). Apply Tailwind responsive classes for mobile stacking (FR-004)
+- [ ] T009 [US1] Refactor `components/match/MatchClient.tsx` layout — replace current render structure with: `<GameChrome position="opponent" .../>` → `<BoardGrid .../>` → `<GameChrome position="player" .../>`. Derive opponent/player props from `matchState.scores`, `matchState.timers`, `matchState.currentRound`, `playerSlot`, and `currentPlayerId`. Remove the inline `<TimerHud>` usage above the board (timer is now inside GameChrome). Keep reconnect/polling/error banners and RoundSummaryPanel
+- [ ] T010 [US1] Implement debug metadata toggle in `components/match/MatchClient.tsx` — read `?debug=1` URL parameter via `useSearchParams()`. Only when present, render a collapsible section showing match ID, round number, status, player IDs. In production builds (check `process.env.NODE_ENV`), skip rendering the debug section entirely (FR-015, FR-016)
+
+**Checkpoint**: Match screen shows opponent bar → board → player bar. Debug metadata hidden by default, accessible via `?debug=1`. US1 acceptance scenarios satisfied.
+
+---
+
+## Phase 4: User Story 2 — Board Fits Viewport on All Devices (Priority: P1)
+
+**Goal**: Board scales to fit available viewport space. No overflow. Square tiles. Works on desktop, tablet, phone.
+
+**Independent Test**: Open match at 1280x800, 768x1024, 375x667. Board fully visible, tiles square, no horizontal scrollbar.
+
+### Tests for User Story 2
+
+- [ ] T011 [US2] Write failing test in `tests/unit/components/BoardGrid.test.tsx` — test that BoardGrid container has CSS properties ensuring square aspect ratio; test that `--board-max` custom property is computed (or verify the responsive CSS classes are applied); test minimum tile size of 28px is enforced via CSS min-width
+
+### Implementation for User Story 2
+
+- [ ] T012 [US2] Update `app/styles/board.css` — replace `width: 95%` on `.board-grid` with viewport-responsive sizing: use CSS custom properties `--chrome-height` (sum of opponent bar + player bar + gaps, ~120px) and `--board-max: min(calc(100vh - var(--chrome-height) - 2rem), calc(100vw - 2rem))`. Set `width: var(--board-max); max-width: var(--board-max)` on the board container. Ensure `aspect-ratio: 1` on the grid wrapper. Add `min-width: 28px` on `.board-grid__cell` (FR-009). Keep existing gap/font clamp values but adjust breakpoints if needed
+- [ ] T013 [US2] Update mobile breakpoints in `app/styles/board.css` — at `@media (max-width: 768px)`, set `--chrome-height` to account for taller stacked bars. At `@media (max-width: 480px)`, enable `overflow-x: auto` only if board exceeds viewport (FR-009 fallback). Verify no horizontal scroll on 375px viewport when tiles are >= 28px
+
+**Checkpoint**: Board fits viewport on all three reference viewports. Tiles remain square. No horizontal scroll on desktop/tablet. Mobile allows vertical scroll if needed.
+
+---
+
+## Phase 5: User Story 3 — Scores and Move Counter in Game Chrome (Priority: P1)
+
+**Goal**: Both players' scores, timers with state colors, and move counter M{n} are visible in game chrome.
+
+**Independent Test**: Complete two rounds. Scores update, move counter increments, timer shows green/neutral.
+
+### Tests for User Story 3
+
+- [ ] T014 [P] [US3] Write failing test in `tests/unit/components/GameChrome.test.tsx` — test that score displays the numeric value from props; test that move counter renders "M3" when moveCounter=3; test that move counter is absent for position="opponent"; test that timer text is green (class or style) when `hasSubmitted=false` and neutral when `hasSubmitted=true`
+- [ ] T015 [P] [US3] Write failing test in `tests/unit/components/TimerHud.test.tsx` — test that TimerHud accepts `hasSubmitted` prop and applies green text color class when false, neutral color class when true (FR-014)
+
+### Implementation for User Story 3
+
+- [ ] T016 [US3] Add score and move counter data binding in `components/match/GameChrome.tsx` — render `score` as a prominent number (e.g., `text-2xl font-bold`). Render `moveCounter` as "M{n}" (e.g., `text-sm font-mono`). Use `playerColor` for score accent. Format timer via existing MM:SS logic or delegate to TimerHud sub-component
+- [ ] T017 [US3] Add timer state colors to `components/game/TimerHud.tsx` — accept new `hasSubmitted` boolean prop. When `hasSubmitted=false`, apply green text color (`text-emerald-400`). When `hasSubmitted=true`, apply neutral color (`text-slate-400`). Keep existing countdown and paused logic unchanged (FR-014)
+- [ ] T018 [US3] Wire submission status into GameChrome in `components/match/MatchClient.tsx` — derive `hasSubmitted` for each player from round submission state. If not directly available in MatchState, use timer `status === "paused"` as proxy (timer pauses on submission per existing logic). Pass to GameChrome → TimerHud
+
+**Checkpoint**: Opponent bar shows opponent score + timer. Player bar shows own score + timer + M{n}. Timer color changes on submission.
+
+---
+
+## Phase 6: User Story 4 — Frozen Tiles Display Player Ownership (Priority: P1)
+
+**Goal**: Frozen tiles show colored overlays (blue/red/split) at 40% opacity with WCAG-compliant contrast.
+
+**Independent Test**: Score words for both players. Verify distinct blue, red, and split-diagonal overlays.
+
+### Tests for User Story 4
+
+- [ ] T019 [US4] Write failing test in `tests/unit/components/BoardGrid.test.tsx` — test that a tile with `frozenTiles["3,5"] = { owner: "player_a" }` renders with blue overlay style; test `player_b` renders red overlay; test `both` renders the split-diagonal gradient; test that frozen tile letters remain visible (not hidden by overlay); test `aria-disabled="true"` on frozen tiles
+
+### Implementation for User Story 4
+
+- [ ] T020 [US4] Refactor frozen tile rendering in `components/game/BoardGrid.tsx` — replace inline `FROZEN_COLORS` constant with import from `lib/constants/playerColors.ts`. Use the centralized `PLAYER_A_OVERLAY`, `PLAYER_B_OVERLAY`, and `BOTH_GRADIENT` values. Ensure the overlay is a pseudo-element or positioned div layered behind the letter text (not replacing background) so text contrast is maintained. Add `data-frozen-owner` attribute for test targeting. Verify existing `board-grid__cell--frozen` CSS class is still applied (FR-018, FR-019, FR-020)
+- [ ] T021 [US4] Enhance frozen tile CSS in `app/styles/board.css` — ensure `.board-grid__cell--frozen` positions the color overlay behind the letter text (e.g., via `::after` pseudo-element with `position: absolute; inset: 0; z-index: 0` and the color as background, with letter text at `z-index: 1`). Verify letter text contrast meets 4.5:1 WCAG AA against each overlay color (FR-021). Update `board-grid__cell--frozen` hover to prevent the lift effect on frozen tiles
+
+**Checkpoint**: Frozen tiles display blue (player_a), red (player_b), or split (both) overlays at 40% opacity. Letters readable. WCAG contrast passes.
+
+---
+
+## Phase 7: User Story 5 — Tile Swap Animates Smoothly (Priority: P1)
+
+**Goal**: Swapped tiles animate to each other's positions over 150-250ms. Input blocked during animation.
+
+**Independent Test**: Select two tiles and trigger swap. Tiles slide smoothly. Cannot interact during animation.
+
+### Tests for User Story 5
+
+- [ ] T022 [US5] Write failing test in `tests/unit/components/BoardGrid.test.tsx` — test that triggering a swap sets an `isAnimating` state that blocks further tile clicks; test that after swap animation completes (transitionend fires), `isAnimating` is cleared and tiles are clickable again; test that swap animation uses `transform` property (not top/left)
+
+### Implementation for User Story 5
+
+- [ ] T023 [US5] Update swap transition in `app/styles/board.css` — ensure `.board-grid__cell` has `transition: transform 200ms ease-out, border-color 150ms ease, box-shadow 150ms ease`. Add `.board-grid__cell--animating` class that applies `will-change: transform` for GPU layer promotion during animation. Add `@media (prefers-reduced-motion: reduce)` override that sets `transition-duration: 0ms` (FR-042, FR-044)
+- [ ] T024 [US5] Implement swap animation in `components/game/BoardGrid.tsx` — on swap trigger: (1) measure positions of both tiles via `getBoundingClientRect()` using refs, (2) calculate dx/dy pixel offsets between the two tiles, (3) set inline `style.transform = translate(dx, dy)` on each tile (opposite directions), (4) set `isAnimating=true` to block all tile interactions (FR-024), (5) listen for `transitionend` event on either tile, (6) on transition end: clear transforms, update `currentGrid` state with swapped values, set `isAnimating=false`, call existing `submitSwapRequest()` (FR-023, FR-026, FR-027)
+- [ ] T025 [US5] Add tile refs for animation measurement in `components/game/BoardGrid.tsx` — create a `tileRefs` map (Map<string, HTMLButtonElement>) keyed by "col,row" coordinate strings. Assign refs to each tile button via callback ref. Used by T024 for `getBoundingClientRect()` measurement during swap animation
+
+**Checkpoint**: Swap triggers smooth 200ms slide animation. Tiles end at correct positions. Cannot click during animation.
+
+---
+
+## Phase 8: User Story 6 — Invalid Swap Shows Rejection Feedback (Priority: P2)
+
+**Goal**: Frozen tile swap attempts trigger shake (3-4 oscillations, 300-400ms) + red border flash (200ms).
+
+**Independent Test**: Click a frozen tile for swap. Tiles shake and flash red.
+
+### Tests for User Story 6
+
+- [ ] T026 [US6] Write failing test in `tests/unit/components/BoardGrid.test.tsx` — test that attempting to swap a frozen tile adds `board-grid__cell--shake` CSS class to the selected tiles; test that the shake class is removed after animation completes (animationend event); test that tile positions do not change after shake
+
+### Implementation for User Story 6
+
+- [ ] T027 [US6] Add shake keyframe animation to `app/styles/board.css` — define `@keyframes tile-shake` with 3-4 horizontal oscillations (`translateX` alternating +-4px) over 350ms. Define `.board-grid__cell--shake` class that applies the keyframe with `animation: tile-shake 350ms ease-out`. Add concurrent red border via `.board-grid__cell--shake { border-color: #ef4444; box-shadow: 0 0 0 2px rgba(239,68,68,0.5) }` that fades after 200ms. Add `prefers-reduced-motion` override to disable (FR-028, FR-029, FR-031, FR-044)
+- [ ] T028 [US6] Implement shake trigger in `components/game/BoardGrid.tsx` — when a player selects a frozen tile as the second tile in a swap (or selects a frozen tile as first tile), detect that the swap is invalid BEFORE sending to server. Add `board-grid__cell--shake` class to the involved tiles. Listen for `animationend` event, then remove the class and clear selection. Ensure `isAnimating` is set during shake to block further interactions (FR-030). Also trigger shake on server-rejected swaps (existing error path)
+
+**Checkpoint**: Frozen tile interactions trigger visible shake + red flash. Tiles return to original positions. Input re-enabled after animation.
+
+---
+
+## Phase 9: User Story 7 — Word Discovery Highlights Scored Tiles (Priority: P2)
+
+**Goal**: After round resolves, scored tiles highlight with player-colored glow for 600-800ms. Sequential: highlights → freeze overlays → summary panel.
+
+**Independent Test**: Complete a round scoring two words. Both highlight simultaneously for 600-800ms with fade in/out.
+
+### Tests for User Story 7
+
+- [ ] T029 [P] [US7] Write failing test in `tests/unit/components/BoardGrid.test.tsx` — test that tiles matching highlight coordinates receive `board-grid__cell--scored` class with the correct player color CSS variable; test that multiple word groups highlight simultaneously; test that highlight class is removed after 700ms
+- [ ] T030 [P] [US7] Write failing test in `tests/unit/components/MatchClient.test.tsx` — test that when a round-summary event is received, MatchClient transitions through animation phases: "highlighting" → "freezing" → "showing-summary"; test that `RoundSummaryPanel` is only rendered when phase is "showing-summary"; test that frozen tiles are only updated when phase transitions from "highlighting" to "freezing"
+
+### Implementation for User Story 7
+
+- [ ] T031 [US7] Update scored-tile-highlight keyframe in `app/styles/board.css` — replace existing `@keyframes scored-tile-highlight` (currently 3s) with new timing: 200ms fade-in (opacity 0→1, box-shadow grows), 300ms hold at full intensity, 200ms fade-out (opacity 1→0, box-shadow shrinks). Total 700ms. Use CSS custom property `--highlight-color` so the glow color is set per-tile by the component. Add `prefers-reduced-motion` override (FR-033, FR-044). Ensure highlight glow is visually distinct from frozen overlay (FR-035) — use `box-shadow` outer glow rather than background tint
+- [ ] T032 [US7] Implement animation phase state machine in `components/match/MatchClient.tsx` — add `animationPhase` state: `"idle" | "highlighting" | "freezing" | "showing-summary"`. On `onSummary` callback: (1) store summary data, (2) set phase to "highlighting" and pass highlight coordinates + player colors to BoardGrid, (3) after 800ms timeout → set phase to "freezing" and apply new frozen tiles from summary to matchState, (4) after 200ms → set phase to "showing-summary" and render RoundSummaryPanel. On summary dismiss → set phase to "idle". Ensure incoming state broadcasts are queued (not applied) while `animationPhase !== "idle"` (edge case from spec) (FR-036a)
+- [ ] T033 [US7] Wire player-colored highlights in `components/game/BoardGrid.tsx` — accept new optional `highlightPlayerColors` prop (map of coordinate key to player color hex). When applying `board-grid__cell--scored` class, also set `--highlight-color` CSS variable on the tile element to the scoring player's color from `playerColors.ts`. Update highlight timeout from `highlightDurationMs` (currently 3000) to 800ms default
+
+**Checkpoint**: Round resolution plays highlight → freeze → summary sequence. Highlights last ~700ms with player colors. Summary panel appears only after highlights + freeze complete.
+
+---
+
+## Phase 10: User Story 8 — Score Delta Popup Shows Breakdown (Priority: P3 — Deferrable)
+
+**Goal**: Transient popup near player's score showing "+N letters, +N length, +N combo" after round resolves. Auto-dismisses in 2-3s.
+
+**Independent Test**: Complete a round scoring a word. Popup appears near score with breakdown, auto-dismisses.
+
+### Tests for User Story 8
+
+- [ ] T034 [US8] Write failing test for score delta popup component — create `tests/unit/components/ScoreDeltaPopup.test.tsx`. Test that component renders breakdown text with non-zero components; test that zero-value components are omitted; test that popup auto-dismisses after ~2.5s (via timer mock); test that popup dismisses immediately when `onDismiss` is called
+
+### Implementation for User Story 8
+
+- [ ] T035 [US8] Create `components/match/ScoreDeltaPopup.tsx` — a client component positioned absolutely near the player score area. Accept props: `lettersPoints`, `lengthBonus`, `comboBonus`, `onDismiss`. Render "+N letters" for non-zero lettersPoints, "+N length" for non-zero lengthBonus, "+N combo" for non-zero comboBonus (FR-038). Use CSS `opacity` transition for 200ms fade-in, hold 2.5s, 200ms fade-out (FR-039). Auto-dismiss via `setTimeout`. Add `prefers-reduced-motion` support. `aria-live="polite"` for screen readers
+- [ ] T036 [US8] Integrate ScoreDeltaPopup in `components/match/MatchClient.tsx` — during the "showing-summary" animation phase, also render `<ScoreDeltaPopup>` with the current player's round deltas extracted from `summary.deltas` and word breakdown. Dismiss popup when player selects a tile (FR-040) or after auto-dismiss timeout. Position popup adjacent to the player's GameChrome bar using relative positioning
+
+**Checkpoint**: Score delta popup appears after round resolution with breakdown text. Auto-dismisses in 2-3s. Dismissed by tile interaction.
+
+---
+
+## Phase 11: Polish & Cross-Cutting Concerns
+
+**Purpose**: Accessibility, performance, and integration validation across all stories
+
+- [ ] T037 Add `prefers-reduced-motion` support to all animation CSS in `app/styles/board.css` — verify that a single `@media (prefers-reduced-motion: reduce)` block disables all animation durations (swap transition, shake keyframe, highlight keyframe, popup fade). Functional state changes (grid update, overlay application, popup visibility) still occur instantly (FR-044)
+- [ ] T038 Add ARIA live regions for score and round announcements in `components/match/MatchClient.tsx` — add a visually hidden `aria-live="polite"` region that announces: score updates ("Your score: 45. Opponent score: 30."), round transitions ("Round 3 of 10"), and error states ("Swap rejected: tile is frozen"). Ensure announcements do not duplicate the RoundSummaryPanel's own ARIA (FR-045)
+- [ ] T039 [P] Verify 44x44px touch targets on mobile in `app/styles/board.css` — ensure `.board-grid__cell` minimum size is 44px on viewports where tiles can be that large. On very small viewports where 28px minimum applies, accept the trade-off (already documented in edge cases). Add `min-height: 44px; min-width: 44px` via `@media (min-width: 480px)` (FR-043)
+- [ ] T040 [P] Run lint, typecheck, and existing test suite — execute `pnpm lint && pnpm typecheck && pnpm test:unit` and fix any regressions introduced by the refactoring. Ensure zero warnings policy is maintained
+- [ ] T041 Write Playwright E2E test in `tests/integration/ui/board-ui.spec.ts` — test three viewport sizes (1280x800, 768x1024, 375x667): verify layout structure (opponent bar, board, player bar), board fits viewport, no horizontal scroll on desktop. Test swap interaction: two tiles animate. Test frozen tile: shake on attempt. Test round summary: highlights appear then summary panel shows
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Foundational — BLOCKS US2, US3, US7, US8
+- **US2 (Phase 4)**: Depends on US1 (needs layout structure to size within)
+- **US3 (Phase 5)**: Depends on US1 (needs GameChrome component to add data to)
+- **US4 (Phase 6)**: Depends on Foundational only (modifies BoardGrid, independent of layout)
+- **US5 (Phase 7)**: Depends on Foundational only (modifies BoardGrid, independent of layout)
+- **US6 (Phase 8)**: Depends on US5 (extends swap interaction with rejection feedback)
+- **US7 (Phase 9)**: Depends on US1 (adds sequencing to MatchClient)
+- **US8 (Phase 10)**: Depends on US3 (positions popup near score in GameChrome)
+- **Polish (Phase 11)**: Depends on all desired user stories being complete
+
+### User Story Dependencies (DAG)
+
+```text
+Setup (T001-T002)
+  └─→ Foundational (T003-T005)
+        ├─→ US1 Layout (T006-T010) ──→ US2 Sizing (T011-T013)
+        │                            ├─→ US3 Chrome (T014-T018) ──→ US8 Popup (T034-T036)
+        │                            └─→ US7 Highlights (T029-T033)
+        ├─→ US4 Frozen Overlays (T019-T021) [independent]
+        └─→ US5 Swap Animation (T022-T025) ──→ US6 Shake (T026-T028)
+```
+
+### Parallel Opportunities
+
+**After Foundational completes**, these can run in parallel:
+- US1 (layout) — modifies MatchClient, creates GameChrome
+- US4 (frozen overlays) — modifies BoardGrid overlay rendering
+- US5 (swap animation) — modifies BoardGrid swap interaction
+
+**After US1 completes**, these can run in parallel:
+- US2 (sizing) — modifies board.css
+- US3 (chrome data) — modifies GameChrome, TimerHud
+- US7 (highlights) — modifies MatchClient sequencing
+
+---
+
+## Parallel Example: After Foundational
+
+```bash
+# These three stories touch different files and can run simultaneously:
+# US1: MatchClient.tsx, GameChrome.tsx (new), page.tsx
+# US4: BoardGrid.tsx frozen overlay code, board.css frozen styles
+# US5: BoardGrid.tsx swap logic, board.css swap transition
+```
+
+## Parallel Example: After US1
+
+```bash
+# These three stories touch different files:
+# US2: board.css sizing only
+# US3: GameChrome.tsx data, TimerHud.tsx colors
+# US7: MatchClient.tsx sequencing, board.css highlight keyframe
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: Foundational (T003-T005)
+3. Complete Phase 3: User Story 1 — Layout (T006-T010)
+4. **STOP and VALIDATE**: Match screen shows PRD layout. Debug metadata hidden.
+5. Deploy/demo if ready — game is visually recognizable as a game
+
+### Incremental Delivery
+
+1. Setup + Foundational → Infrastructure ready
+2. US1 (Layout) → PRD match screen structure (MVP!)
+3. US2 (Sizing) + US4 (Frozen) + US5 (Swap) → Board fits, territory visible, swaps feel good
+4. US3 (Chrome) → Scores and timers with state colors
+5. US6 (Shake) + US7 (Highlights) → Full animation suite
+6. US8 (Popup) → Polish feature (deferrable)
+7. Polish → Accessibility, E2E tests, regression check
+
+### Task Count Summary
+
+| Phase | Story | Tasks | Parallel |
+|-------|-------|-------|----------|
+| 1 | Setup | 2 | 2 |
+| 2 | Foundational | 3 | 0 |
+| 3 | US1 Layout (P1) | 5 | 2 |
+| 4 | US2 Sizing (P1) | 3 | 0 |
+| 5 | US3 Chrome (P1) | 5 | 2 |
+| 6 | US4 Frozen (P1) | 3 | 0 |
+| 7 | US5 Swap (P1) | 4 | 0 |
+| 8 | US6 Shake (P2) | 3 | 0 |
+| 9 | US7 Highlights (P2) | 5 | 2 |
+| 10 | US8 Popup (P3) | 3 | 0 |
+| 11 | Polish | 5 | 2 |
+| **Total** | | **41** | **10** |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks in same phase
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently testable after its phase completes
+- TDD: Write failing tests FIRST (T006/T007 before T008/T009/T010, etc.)
+- Commit after each task or logical group per constitution Principle VII
+- US8 (Score Delta Popup) is P3 and explicitly deferrable — skip if time-constrained
+- All animation CSS must include `prefers-reduced-motion` overrides (consolidated in T037)
+- No server-side changes, no migrations, no new API contracts in this entire feature


### PR DESCRIPTION
Complete speckit workflow (specify → clarify → plan → tasks) for the board UI and animations feature, combining the responsive layout proposal and PRD match screen redesign into a single spec.

Includes:
- spec.md: 8 user stories (layout, responsive sizing, game chrome, frozen tiles, swap/shake animations, word highlights, score popup), 45 functional requirements, 11 success criteria
- plan.md: implementation plan with 6 architectural decisions (CSS-only animations, min() viewport sizing, React state machine sequencing, centralized player colors, debug toggle, skeleton loading)
- research.md: 8 research decisions with rationale and alternatives
- data-model.md: client-side entities (PlayerColors, AnimationPhase, GameChromeProps) — zero database changes
- tasks.md: 41 tasks across 11 phases organized by user story
- quickstart.md: dev setup, test commands, visual testing viewports
- contracts/README.md: confirms no new API contracts
- checklists/requirements.md: all validation items pass
- CLAUDE.md: updated active technologies for 004