### PR TITLE
feat(scoring): allow scoring words with opponent-frozen tiles

### DIFF
--- a/lib/game-engine/deltaDetector.ts
+++ b/lib/game-engine/deltaDetector.ts
@@ -10,6 +10,8 @@ import { DEFAULT_GAME_CONFIG } from "@/lib/constants/game-config";
 /** A word attributed to a specific player. */
 export interface AttributedWord extends BoardWord {
   playerId: string;
+  /** "x,y" keys of tiles in this word frozen by the opponent (for partial letter scoring). */
+  opponentFrozenKeys: ReadonlySet<string>;
 }
 
 /** A move accepted after conflict resolution. */
@@ -210,27 +212,26 @@ function removeSubwords<T extends BoardWord>(words: T[]): T[] {
 }
 
 /**
- * Check whether a word contains any tile frozen by the opponent.
+ * Return the set of "x,y" keys for tiles in `word` that are frozen by the opponent.
+ * Tiles owned by "both" are NOT included — both players may score through them freely.
  */
-function containsOpponentFrozenTile(
+function getOpponentFrozenKeys(
   word: BoardWord,
   frozenTiles: FrozenTileMap,
   playerSlot: "player_a" | "player_b",
-): boolean {
+): Set<string> {
   const opponentSlot =
     playerSlot === "player_a" ? "player_b" : "player_a";
+  const keys = new Set<string>();
 
   for (const tile of word.tiles) {
     const key = `${tile.x},${tile.y}`;
     const frozen = frozenTiles[key];
-    if (frozen) {
-      if (frozen.owner === opponentSlot) {
-        return true;
-      }
-      // "both" means both players own it → valid for both
+    if (frozen?.owner === opponentSlot) {
+      keys.add(key);
     }
   }
-  return false;
+  return keys;
 }
 
 /**
@@ -325,10 +326,10 @@ export function detectNewWords(params: {
       if (word.direction !== "right" && word.direction !== "down") continue;
       if (excludeKeys.has(wordKey(word))) continue;
       if (reportedKeys.has(wordKey(word))) continue;
-      if (containsOpponentFrozenTile(word, frozenTiles, playerSlot)) continue;
       if (hasCrossWordViolation(board, word, frozenTileSet, dictionary, extraTileSet)) continue;
       if (hasInlineExtensionViolation(board, word, frozenTileSet, dictionary, extraTileSet)) continue;
-      candidates.push({ ...word, playerId: pId });
+      const opponentFrozenKeys = getOpponentFrozenKeys(word, frozenTiles, playerSlot);
+      candidates.push({ ...word, playerId: pId, opponentFrozenKeys });
     }
 
     // Phase 2: suppress sub-words — only the longest word in each tile run scores.

--- a/lib/game-engine/wordEngine.ts
+++ b/lib/game-engine/wordEngine.ts
@@ -34,7 +34,14 @@ function scoreAttributedWords(
   priorScoredWordsByPlayer?: Record<string, Set<string>>,
 ): WordScoreBreakdown[] {
   return words.map((word) => {
-    const lettersPoints = calculateLetterPoints(word.text);
+    // Score only the letters contributed by this player (not opponent-frozen tiles).
+    // Length bonus uses the full word length regardless of tile ownership.
+    const ownLetters = word.tiles
+      .map((t, i) =>
+        word.opponentFrozenKeys.has(`${t.x},${t.y}`) ? "" : word.text[i],
+      )
+      .join("");
+    const lettersPoints = calculateLetterPoints(ownLetters);
     const lengthBonus = calculateLengthBonus(word.length);
     const normalizedWord = word.text.toLowerCase();
     const playerSet = priorScoredWordsByPlayer?.[word.playerId];

--- a/tests/unit/lib/game-engine/deltaDetector.test.ts
+++ b/tests/unit/lib/game-engine/deltaDetector.test.ts
@@ -334,8 +334,11 @@ describe("deltaDetector", () => {
       expect(result.find((w) => w.text === "def")).toBeUndefined();
     });
 
-    test("T032: accepts new word when inline extension through frozen tiles forms a valid sequence", () => {
-      // Same forward-extension setup as T030 but "abcdef" IS in the dictionary
+    test("T032: accepts word when inline extension through frozen tiles forms a valid sequence", () => {
+      // Same forward-extension setup as T030 but "abcdef" IS in the dictionary.
+      // The scanner finds both "abc" (cols 0-2) and "abcdef" (cols 0-5).
+      // "abc" is suppressed as a subword of "abcdef", so only "abcdef" scores.
+      // "abcdef" contains opponent-frozen tiles (cols 3-5) so opponentFrozenKeys is populated.
       const customDict = new Set(["abc", "def", "abcdef"]);
 
       const boardBefore = emptyBoard();
@@ -363,8 +366,53 @@ describe("deltaDetector", () => {
         playerBId: PLAYER_B,
       });
 
-      // "abc" + frozen "def" = "abcdef" IS in dict → no inline violation → "abc" scores
-      expect(result.find((w) => w.text === "abc")).toBeDefined();
+      // "abcdef" scores (not rejected for containing opponent tiles)
+      const scored = result.find((w) => w.text === "abcdef");
+      expect(scored).toBeDefined();
+      // Opponent-frozen keys cover the "def" portion (cols 3-5)
+      expect(scored!.opponentFrozenKeys).toEqual(new Set(["3,0", "4,0", "5,0"]));
+      // "abc" is suppressed as a strict subword of "abcdef"
+      expect(result.find((w) => w.text === "abc")).toBeUndefined();
+    });
+
+    test("T034: scores word that contains opponent-frozen tiles (no longer rejected)", () => {
+      // Player B places tiles to create "abcdef" where "abc" (cols 0-2) are
+      // frozen by player_a. The word is valid → Player B should score with
+      // opponentFrozenKeys covering the "abc" portion.
+      const customDict = new Set(["abcdef", "def"]);
+
+      const boardBefore = emptyBoard();
+      // Before: "abc" already on board (frozen), "fed" at cols 3-5 (wrong order)
+      boardBefore[0][0] = "a"; boardBefore[0][1] = "b"; boardBefore[0][2] = "c";
+      boardBefore[0][3] = "f"; boardBefore[0][4] = "e"; boardBefore[0][5] = "d";
+
+      const boardAfter = boardBefore.map((row) => [...row]) as BoardGrid;
+      boardAfter[0][3] = "d"; boardAfter[0][5] = "f"; // Player B swaps (3,0) ↔ (5,0)
+
+      const frozenTiles: FrozenTileMap = {
+        "0,0": { owner: "player_a" },
+        "1,0": { owner: "player_a" },
+        "2,0": { owner: "player_a" },
+      };
+
+      const result = detectNewWords({
+        boardBefore,
+        boardAfter,
+        dictionary: customDict,
+        acceptedMoves: [
+          { playerId: PLAYER_B, fromX: 3, fromY: 0, toX: 5, toY: 0 },
+        ],
+        frozenTiles,
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+      });
+
+      // "abcdef" must now score (no longer rejected for containing opponent tiles)
+      const scored = result.find((w) => w.text === "abcdef");
+      expect(scored).toBeDefined();
+      expect(scored!.playerId).toBe(PLAYER_B);
+      // opponentFrozenKeys covers the "abc" portion (cols 0-2, frozen by player_a)
+      expect(scored!.opponentFrozenKeys).toEqual(new Set(["0,0", "1,0", "2,0"]));
     });
 
     test("T033: rejects new vertical word that extends downward into frozen tiles forming an invalid sequence", () => {

--- a/tests/unit/lib/game-engine/wordEngine.test.ts
+++ b/tests/unit/lib/game-engine/wordEngine.test.ts
@@ -485,4 +485,100 @@ describe("wordEngine", () => {
       expect(result.durationMs).toBeGreaterThanOrEqual(0);
     });
   });
+
+  describe("partial letter scoring (opponent-frozen tiles)", () => {
+    test("scores only own tiles' letter points when word spans opponent-frozen tiles", async () => {
+      // Player B forms "abcdef" where cols 3-5 ("def") are frozen by player_a.
+      // Expected: lettersPoints = value of "abc" only, lengthBonus = (6-2)*5 = 20.
+      const boardBefore = emptyBoard();
+      const boardAfter = emptyBoard();
+      boardAfter[0][0] = "a"; boardAfter[0][1] = "b"; boardAfter[0][2] = "c";
+      boardAfter[0][3] = "d"; boardAfter[0][4] = "e"; boardAfter[0][5] = "f";
+
+      const frozenMap: FrozenTileMap = {
+        "3,0": { owner: "player_a" },
+        "4,0": { owner: "player_a" },
+        "5,0": { owner: "player_a" },
+      };
+
+      // Mock detectNewWords to return an attributed word with opponentFrozenKeys set
+      const spy = vi.spyOn(deltaDetector, "detectNewWords").mockReturnValueOnce([
+        {
+          text: "abcdef",
+          displayText: "abcdef",
+          direction: "right" as const,
+          start: { x: 0, y: 0 },
+          length: 6,
+          tiles: [
+            { x: 0, y: 0 }, { x: 1, y: 0 }, { x: 2, y: 0 },
+            { x: 3, y: 0 }, { x: 4, y: 0 }, { x: 5, y: 0 },
+          ],
+          playerId: PLAYER_B,
+          opponentFrozenKeys: new Set(["3,0", "4,0", "5,0"]),
+        },
+      ]);
+
+      const result = await processRoundScoring({
+        matchId: MATCH_ID,
+        roundId: ROUND_ID,
+        boardBefore,
+        boardAfter,
+        acceptedMoves: [{ playerId: PLAYER_B, fromX: 0, fromY: 0, toX: 2, toY: 0 }],
+        frozenTiles: frozenMap,
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+      });
+
+      spy.mockRestore();
+
+      const word = result.playerBWords.find((w) => w.word === "abcdef");
+      expect(word).toBeDefined();
+      // Letter points only for own tiles "abc" (positions 0-2)
+      const { calculateLetterPoints } = await import("@/lib/game-engine/scorer");
+      const expectedLetters = calculateLetterPoints("abc");
+      expect(word!.lettersPoints).toBe(expectedLetters);
+      // Length bonus for full 6-letter word
+      expect(word!.lengthBonus).toBe(20);
+      expect(word!.totalPoints).toBe(expectedLetters + 20);
+    });
+
+    test("scores all tiles when no opponent-frozen tiles are present", async () => {
+      // Sanity check: empty opponentFrozenKeys → full letter points as before.
+      const boardBefore = emptyBoard();
+      const boardAfter = emptyBoard();
+      boardAfter[0][0] = "a"; boardAfter[0][1] = "b"; boardAfter[0][2] = "c";
+
+      const spy = vi.spyOn(deltaDetector, "detectNewWords").mockReturnValueOnce([
+        {
+          text: "abc",
+          displayText: "abc",
+          direction: "right" as const,
+          start: { x: 0, y: 0 },
+          length: 3,
+          tiles: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 2, y: 0 }],
+          playerId: PLAYER_A,
+          opponentFrozenKeys: new Set<string>(),
+        },
+      ]);
+
+      const result = await processRoundScoring({
+        matchId: MATCH_ID,
+        roundId: ROUND_ID,
+        boardBefore,
+        boardAfter,
+        acceptedMoves: [{ playerId: PLAYER_A, fromX: 0, fromY: 0, toX: 2, toY: 0 }],
+        frozenTiles: EMPTY_FROZEN,
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+      });
+
+      spy.mockRestore();
+
+      const word = result.playerAWords.find((w) => w.word === "abc");
+      expect(word).toBeDefined();
+      const { calculateLetterPoints } = await import("@/lib/game-engine/scorer");
+      expect(word!.lettersPoints).toBe(calculateLetterPoints("abc"));
+      expect(word!.lengthBonus).toBe(5); // (3-2)*5
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Frozen tiles now **only** prevent swapping; they no longer block scoring
- When a player extends an opponent's frozen word into a longer valid word (e.g. Red owns TAÐI, Blue adds RA to form RATAÐI), the extending player earns:
  - Letter points for the **tiles they contributed** (RA) only
  - Length bonus based on the **full word length** (6 letters → 20 pts)
- Tiles owned by `"both"` are treated as freely scoreable by either player (no partial deduction)

## Implementation

- `detectNewWords` no longer rejects words containing opponent-frozen tiles; instead it annotates each `AttributedWord` with `opponentFrozenKeys: ReadonlySet<string>` — the positions of tiles frozen by the opponent within that word
- `scoreAttributedWords` skips opponent-frozen tiles when summing letter points, but passes the full word length to `calculateLengthBonus`
- The existing inline-extension validation (`hasInlineExtensionViolation`) is unchanged — it still enforces that words adjacent to frozen tiles form valid combined sequences

## Test plan

- [x] T032 updated: extended word `"abcdef"` scores (not the shorter subword `"abc"`), with `opponentFrozenKeys` populated for the inherited tiles
- [x] T034 added: proves a word containing opponent-frozen tiles is no longer rejected
- [x] Two new `wordEngine` tests verify partial letter scoring via mocked `detectNewWords`
- [x] All 337 existing tests pass
- [x] `pnpm typecheck` and `pnpm lint` both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)