### PR TITLE
feat(014): resign functionality & lobby polish

### DIFF
--- a/app/actions/match/resignMatch.ts
+++ b/app/actions/match/resignMatch.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import "server-only";
+
+import { readLobbySession } from "@/lib/matchmaking/profile";
+import { assertWithinRateLimit } from "@/lib/rate-limiting/middleware";
+import { writeMatchLog } from "@/lib/match/logWriter";
+import { publishMatchState } from "@/lib/match/statePublisher";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+import { trackMatchResult } from "@/lib/observability/log";
+
+export interface ResignResult {
+  matchId: string;
+  winnerId: string;
+  resigned: true;
+}
+
+export async function resignMatch(
+  matchId: string,
+): Promise<ResignResult> {
+  const session = await readLobbySession();
+  if (!session) {
+    throw new Error("Authentication required.");
+  }
+
+  const playerId = session.player.id;
+
+  assertWithinRateLimit({
+    identifier: playerId,
+    scope: "match:resign",
+    limit: 5,
+    windowMs: 60_000,
+    errorMessage: "Too many resign attempts. Please wait.",
+  });
+
+  const supabase = getServiceRoleClient();
+
+  const { data: match, error } = await supabase
+    .from("matches")
+    .select("id,state,player_a_id,player_b_id,winner_id")
+    .eq("id", matchId)
+    .single();
+
+  if (error || !match) {
+    throw new Error("Match not found.");
+  }
+
+  const isParticipant =
+    playerId === match.player_a_id || playerId === match.player_b_id;
+
+  if (!isParticipant) {
+    throw new Error("You are not a participant in this match.");
+  }
+
+  if (match.state === "completed") {
+    throw new Error("Match has already ended.");
+  }
+
+  const winnerId =
+    playerId === match.player_a_id
+      ? match.player_b_id
+      : match.player_a_id;
+
+  // Mark match as completed with forfeit — winner is the opponent
+  await supabase
+    .from("matches")
+    .update({
+      state: "completed",
+      winner_id: winnerId,
+      ended_reason: "forfeit",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", matchId);
+
+  // Reset both players to available
+  await supabase
+    .from("players")
+    .update({
+      status: "available",
+      last_seen_at: new Date().toISOString(),
+    })
+    .in("id", [match.player_a_id, match.player_b_id]);
+
+  await writeMatchLog(supabase, {
+    matchId,
+    eventType: "match.forfeit",
+    actorId: playerId,
+    metadata: { winnerId, resignedBy: playerId },
+  });
+
+  await publishMatchState(matchId);
+
+  trackMatchResult({
+    matchId,
+    winnerId,
+    loserId: playerId,
+    endedReason: "forfeit",
+    isDraw: false,
+    scores: { playerA: 0, playerB: 0 },
+    totalRounds: 0,
+  });
+
+  return {
+    matchId,
+    winnerId,
+    resigned: true,
+  };
+}

--- a/components/match/FinalSummary.tsx
+++ b/components/match/FinalSummary.tsx
@@ -251,7 +251,19 @@ export function FinalSummary({
           <p className="text-sm uppercase tracking-wide text-emerald-200/80">
             Winner
           </p>
-          <p className="text-2xl font-semibold text-white">{winner.displayName}</p>
+          <p className="text-2xl font-semibold text-white">
+            {winner.displayName}
+          </p>
+          {endedReason === "forfeit" && (
+            <p
+              className="mt-1 text-sm text-white/60"
+              data-testid="final-summary-forfeit-label"
+            >
+              {winner.id === currentPlayerId
+                ? "Your opponent resigned"
+                : "You resigned"}
+            </p>
+          )}
         </div>
       ) : (
         <div className="mt-6 rounded-2xl border border-sky-500/30 bg-sky-500/5 p-4">

--- a/components/match/GameChrome.tsx
+++ b/components/match/GameChrome.tsx
@@ -22,6 +22,10 @@ interface GameChromeProps {
   roundHistoryCount?: number;
   /** Callback to toggle the round history overlay. */
   onHistoryToggle?: () => void;
+  /** Callback to trigger resignation. Only shown for the "player" position. */
+  onResign?: () => void;
+  /** Whether the resign button should be disabled (e.g. during resolution). */
+  resignDisabled?: boolean;
 }
 
 export function GameChrome({
@@ -37,6 +41,8 @@ export function GameChrome({
   scoreDeltaRound,
   roundHistoryCount = 0,
   onHistoryToggle,
+  onResign,
+  resignDisabled = false,
 }: GameChromeProps) {
   const [displaySeconds, setDisplaySeconds] = useState(timerSeconds);
 
@@ -114,6 +120,19 @@ export function GameChrome({
             <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-emerald-500 text-[10px] font-bold text-white">
               {roundHistoryCount}
             </span>
+          </button>
+        )}
+
+        {onResign && (
+          <button
+            type="button"
+            aria-label="Resign"
+            onClick={onResign}
+            disabled={resignDisabled}
+            className="rounded-md bg-red-500/20 px-2 py-1 text-xs text-red-300 transition hover:bg-red-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+            data-testid="resign-button"
+          >
+            Resign
           </button>
         )}
       </div>

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -18,6 +18,7 @@ import { getPlayerColors } from "@/lib/constants/playerColors";
 import { getBrowserSupabaseClient } from "@/lib/supabase/browser";
 import { subscribeToMatchChannel } from "@/lib/realtime/matchChannel";
 import { handlePlayerDisconnect } from "@/app/actions/match/handleDisconnect";
+import { resignMatch } from "@/app/actions/match/resignMatch";
 import { MatchShell } from "./MatchShell";
 
 
@@ -83,6 +84,10 @@ export function MatchClient({
   const [accumulatedWords, setAccumulatedWords] = useState<WordHistoryRow[]>([]);
   const [accumulatedScores, setAccumulatedScores] = useState<ScoreboardRow[]>([]);
   const [historyOpen, setHistoryOpen] = useState(false);
+
+  // Resign state
+  const [showResignDialog, setShowResignDialog] = useState(false);
+  const [isResigning, setIsResigning] = useState(false);
 
   // Animation phase machine for post-round highlight sequence (US7)
   type AnimationPhase = "idle" | "highlighting" | "showing-summary";
@@ -353,6 +358,21 @@ export function MatchClient({
     setSwapError(message);
   }, []);
 
+  const handleResignConfirm = useCallback(async () => {
+    setIsResigning(true);
+    try {
+      await resignMatch(matchId);
+      setShowResignDialog(false);
+    } catch (e) {
+      setSwapError(
+        e instanceof Error ? e.message : "Failed to resign.",
+      );
+      setShowResignDialog(false);
+    } finally {
+      setIsResigning(false);
+    }
+  }, [matchId]);
+
   // Derive opponent timer
   const opponentTimer: TimerState = useMemo(() => {
     if (matchState.timers.playerA.playerId === currentPlayerId) {
@@ -511,6 +531,12 @@ export function MatchClient({
             scoreDeltaRound={summary?.roundNumber}
             roundHistoryCount={roundHistory.length}
             onHistoryToggle={() => setHistoryOpen((v) => !v)}
+            onResign={() => setShowResignDialog(true)}
+            resignDisabled={
+              matchState.state === "resolving" ||
+              matchState.state === "completed" ||
+              isResigning
+            }
           />
         </div>
 
@@ -587,6 +613,45 @@ export function MatchClient({
               biggestSwing={biggestSwing}
               highestWord={highestWord}
             />
+          </div>
+        </div>
+      )}
+      {showResignDialog && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+          data-testid="resign-dialog-backdrop"
+        >
+          <div
+            className="w-full max-w-sm rounded-2xl border border-white/10 bg-slate-900 p-6 shadow-2xl"
+            role="alertdialog"
+            aria-label="Confirm resignation"
+            data-testid="resign-dialog"
+          >
+            <h2 className="text-lg font-semibold text-white">
+              Resign?
+            </h2>
+            <p className="mt-2 text-sm text-white/70">
+              Are you sure you want to resign? Your opponent will win.
+            </p>
+            <div className="mt-6 flex gap-3">
+              <button
+                type="button"
+                onClick={handleResignConfirm}
+                disabled={isResigning}
+                className="rounded-xl bg-red-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-400 disabled:opacity-50"
+                data-testid="resign-confirm"
+              >
+                {isResigning ? "Resigning..." : "Yes, Resign"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowResignDialog(false)}
+                className="rounded-xl border border-white/20 px-4 py-2 text-sm text-white transition hover:bg-white/10"
+                data-testid="resign-cancel"
+              >
+                Cancel
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/tests/unit/app/actions/resignMatch.test.ts
+++ b/tests/unit/app/actions/resignMatch.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/server", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+vi.mock("@/lib/matchmaking/profile", () => ({
+  readLobbySession: vi.fn(),
+}));
+vi.mock("@/lib/rate-limiting/middleware", () => ({
+  assertWithinRateLimit: vi.fn(),
+}));
+vi.mock("@/lib/match/logWriter", () => ({
+  writeMatchLog: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/match/statePublisher", () => ({
+  publishMatchState: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/observability/log", () => ({
+  trackMatchResult: vi.fn(),
+}));
+
+import { resignMatch } from "@/app/actions/match/resignMatch";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+import { readLobbySession } from "@/lib/matchmaking/profile";
+import { writeMatchLog } from "@/lib/match/logWriter";
+import { publishMatchState } from "@/lib/match/statePublisher";
+
+const PLAYER_A = "player-a";
+const PLAYER_B = "player-b";
+const MATCH_ID = "match-1";
+
+function mockSession(playerId: string) {
+  vi.mocked(readLobbySession).mockResolvedValue({
+    player: { id: playerId, username: "test", displayName: "Test" },
+  } as any);
+}
+
+function makeSupabaseMock(
+  matchData: Record<string, unknown> | null,
+  matchError: { message: string } | null = null,
+) {
+  const selectChain = {
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({
+      data: matchData,
+      error: matchError,
+    }),
+  };
+
+  const updateChain = {
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+  };
+
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => selectChain),
+      update: vi.fn(() => updateChain),
+    })),
+  };
+}
+
+describe("resignMatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when not authenticated", async () => {
+    vi.mocked(readLobbySession).mockResolvedValue(null);
+    await expect(resignMatch(MATCH_ID)).rejects.toThrow(
+      "Authentication required.",
+    );
+  });
+
+  it("throws when player is not a participant", async () => {
+    mockSession("outsider");
+    const mock = makeSupabaseMock({
+      id: MATCH_ID,
+      state: "in_progress",
+      player_a_id: PLAYER_A,
+      player_b_id: PLAYER_B,
+      winner_id: null,
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(mock as any);
+
+    await expect(resignMatch(MATCH_ID)).rejects.toThrow(
+      "You are not a participant in this match.",
+    );
+  });
+
+  it("throws when match has already ended", async () => {
+    mockSession(PLAYER_A);
+    const mock = makeSupabaseMock({
+      id: MATCH_ID,
+      state: "completed",
+      player_a_id: PLAYER_A,
+      player_b_id: PLAYER_B,
+      winner_id: PLAYER_B,
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(mock as any);
+
+    await expect(resignMatch(MATCH_ID)).rejects.toThrow(
+      "Match has already ended.",
+    );
+  });
+
+  it("resigns successfully and declares opponent as winner", async () => {
+    mockSession(PLAYER_A);
+    const mock = makeSupabaseMock({
+      id: MATCH_ID,
+      state: "in_progress",
+      player_a_id: PLAYER_A,
+      player_b_id: PLAYER_B,
+      winner_id: null,
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(mock as any);
+
+    const result = await resignMatch(MATCH_ID);
+
+    expect(result).toEqual({
+      matchId: MATCH_ID,
+      winnerId: PLAYER_B,
+      resigned: true,
+    });
+    expect(writeMatchLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        matchId: MATCH_ID,
+        eventType: "match.forfeit",
+        actorId: PLAYER_A,
+      }),
+    );
+    expect(publishMatchState).toHaveBeenCalledWith(MATCH_ID);
+  });
+
+  it("declares player A as winner when player B resigns", async () => {
+    mockSession(PLAYER_B);
+    const mock = makeSupabaseMock({
+      id: MATCH_ID,
+      state: "in_progress",
+      player_a_id: PLAYER_A,
+      player_b_id: PLAYER_B,
+      winner_id: null,
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(mock as any);
+
+    const result = await resignMatch(MATCH_ID);
+
+    expect(result).toEqual({
+      matchId: MATCH_ID,
+      winnerId: PLAYER_A,
+      resigned: true,
+    });
+  });
+
+  it("throws when match is not found", async () => {
+    mockSession(PLAYER_A);
+    const mock = makeSupabaseMock(null, { message: "Not found" });
+    vi.mocked(getServiceRoleClient).mockReturnValue(mock as any);
+
+    await expect(resignMatch(MATCH_ID)).rejects.toThrow(
+      "Match not found.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Resign Server Action** (`app/actions/match/resignMatch.ts`): Session validation, participant check, match-in-progress guard, rate limiting (`match:resign` 5/min), sets match to completed with `ended_reason: "forfeit"`, resets player statuses, writes match log, broadcasts state via Realtime
- **Resign UI**: Button in player GameChrome bar, confirmation dialog in MatchClient ("Are you sure? Your opponent will win."), disabled during round resolution
- **FinalSummary forfeit display**: Shows "Your opponent resigned" or "You resigned" when match ended by forfeit
- **Lobby status**: Already implemented — `LobbyCard` renders colored status pills for available/in-match/matchmaking states

## Test plan

- [x] `pnpm test` — 55 files, 402 tests, all passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — zero warnings
- [ ] Manual: Start match → click Resign → confirm → opponent sees completed state → FinalSummary shows forfeit
- [ ] Manual: Verify resign button disabled during round resolution and after match ends
- [ ] Manual: Lobby shows correct status badges for available vs in-match players

🤖 Generated with [Claude Code](https://claude.com/claude-code)