### PR TITLE
test(integration): fix autoPass T010 timer setup after dual-flag change

### DIFF
--- a/tests/integration/match/autoPass.spec.ts
+++ b/tests/integration/match/autoPass.spec.ts
@@ -45,7 +45,7 @@ describe("autoPass synthesis (T010)", () => {
           player_a_id: PLAYER_A,
           player_b_id: PLAYER_B,
           board_seed: "seed-1",
-          player_a_timer_ms: 300_000,
+          player_a_timer_ms: 3_600_000, // 60 min — not expired after 10-min elapsed round
           player_b_timer_ms: 0, // Player B has no time left
           frozen_tiles: {},
         },


### PR DESCRIPTION
After c04f059, both-players-flagged check fires before auto-pass synthesis when both clocks are expired. The test used player_a_timer_ms: 300_000 (5 min) with a round started 10 min ago, so Player A's clock was also expired, triggering match completion. Set player_a_timer_ms to 3_600_000 (60 min) so only Player B's clock is expired, allowing auto-pass synthesis to run.