### PR TITLE
Phase 1a: Warm Editorial theme flip + TopBar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,8 +2,50 @@
 @config "../tailwind.config.ts";
 
 :root {
-  color-scheme: dark;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color-scheme: light;
+
+  /* Surfaces — warm paper + deep ink */
+  --paper: oklch(0.975 0.012 85);
+  --paper-2: oklch(0.955 0.014 82);
+  --paper-3: oklch(0.925 0.016 80);
+  --ink: oklch(0.22 0.025 258);
+  --ink-2: oklch(0.29 0.027 258);
+  --ink-3: oklch(0.38 0.024 258);
+  --ink-soft: oklch(0.52 0.020 258);
+
+  /* Accent — warm ochre (brand) */
+  --ochre: oklch(0.72 0.13 70);
+  --ochre-deep: oklch(0.58 0.14 60);
+  --ochre-tint: oklch(0.93 0.045 80);
+
+  /* Player colors */
+  --p1: oklch(0.68 0.14 60);
+  --p1-tint: oklch(0.92 0.06 70);
+  --p1-deep: oklch(0.48 0.14 55);
+  --p2: oklch(0.56 0.08 220);
+  --p2-tint: oklch(0.92 0.035 220);
+  --p2-deep: oklch(0.38 0.08 220);
+
+  /* Semantic */
+  --good: oklch(0.62 0.12 150);
+  --warn: oklch(0.70 0.15 40);
+  --bad: oklch(0.58 0.17 25);
+
+  /* Lines */
+  --hair: color-mix(in oklab, var(--ink) 14%, transparent);
+  --hair-strong: color-mix(in oklab, var(--ink) 22%, transparent);
+
+  /* Shadows */
+  --shadow-sm: 0 1px 0 color-mix(in oklab, var(--ink) 8%, transparent);
+  --shadow-md:
+    0 1px 2px color-mix(in oklab, var(--ink) 6%, transparent),
+    0 8px 24px color-mix(in oklab, var(--ink) 10%, transparent);
+  --shadow-lg:
+    0 2px 4px color-mix(in oklab, var(--ink) 8%, transparent),
+    0 20px 60px color-mix(in oklab, var(--ink) 16%, transparent);
+
+  font-family: var(--font-inter, "Inter"), system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
 }
 
 html,
@@ -14,5 +56,7 @@ body {
 
 body {
   margin: 0;
-  background: #020617;
+  background: var(--paper);
+  color: var(--ink);
+  -webkit-font-smoothing: antialiased;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./styles/board.css";
 import "./styles/lobby.css";
 import { GearMenu } from "@/components/ui/GearMenu";
 import { ToastProvider } from "@/components/ui/ToastProvider";
+import { TopBar } from "@/components/ui/TopBar";
 
 const fraunces = Fraunces({
   subsets: ["latin", "latin-ext"],
@@ -38,7 +39,8 @@ export default function RootLayout({
       <body className="min-h-screen overflow-x-clip bg-surface-0 text-text-primary antialiased">
         <ToastProvider>
           <div className="relative flex min-h-screen flex-col">
-            <div className="pointer-events-none absolute right-4 top-4 z-20">
+            <TopBar />
+            <div className="pointer-events-none absolute right-4 top-4 z-30">
               <div className="pointer-events-auto">
                 <GearMenu />
               </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Fraunces } from "next/font/google";
+import { Fraunces, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import "./styles/board.css";
 import "./styles/lobby.css";
@@ -14,6 +14,14 @@ const fraunces = Fraunces({
   axes: ["opsz"],
 });
 
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin", "latin-ext"],
+  display: "swap",
+  preload: true,
+  variable: "--font-jetbrains-mono",
+  weight: ["400", "500"],
+});
+
 export const metadata: Metadata = {
   title: "Wottle — Icelandic word duel",
   description:
@@ -26,7 +34,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={fraunces.variable}>
+    <html lang="en" className={`${fraunces.variable} ${jetbrainsMono.variable}`}>
       <body className="min-h-screen overflow-x-clip bg-surface-0 text-text-primary antialiased">
         <ToastProvider>
           <div className="relative flex min-h-screen flex-col">

--- a/app/match/[matchId]/loading.tsx
+++ b/app/match/[matchId]/loading.tsx
@@ -2,7 +2,7 @@ import { MatchShell } from "@/components/match/MatchShell";
 
 export default function MatchLoading() {
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-8 p-6 text-white">
+    <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-8 p-6 text-ink">
       <MatchShell matchId="pending" />
     </main>
   );

--- a/app/match/[matchId]/page.tsx
+++ b/app/match/[matchId]/page.tsx
@@ -45,7 +45,7 @@ export default async function MatchPage({
   );
 
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-8 p-6 text-white">
+    <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-8 p-6 text-ink">
       <MatchClient
         currentPlayerId={session.player.id}
         initialState={matchState}

--- a/app/match/[matchId]/summary/page.tsx
+++ b/app/match/[matchId]/summary/page.tsx
@@ -241,7 +241,7 @@ export default async function MatchSummaryPage({
   }
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-8 py-4 text-white sm:p-6">
+    <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-8 py-4 text-ink sm:p-6">
       <FinalSummary
         currentPlayerId={session!.player.id}
         matchId={matchId}

--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -39,10 +39,10 @@
   aspect-ratio: 1; /* Grid itself must be square — independent of wrapper height */
   padding: clamp(0.75rem, 1vw, 1rem);
   border-radius: 1rem;
-  background: linear-gradient(145deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.75));
+  background: linear-gradient(145deg, color-mix(in oklab, var(--paper) 92%, transparent), color-mix(in oklab, var(--paper) 77%, transparent));
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 18px 28px -24px rgba(15, 118, 255, 0.5);
+    inset 0 1px 0 color-mix(in oklab, var(--p1) 8%, transparent),
+    0 18px 28px -24px color-mix(in oklab, var(--p1) 50%, transparent);
 
   transform: scale(var(--board-scale, 1));
   transform-origin: center center;
@@ -62,13 +62,13 @@
   aspect-ratio: 1 / 1;
   min-width: 0;
   border-radius: 0.65rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid color-mix(in oklab, var(--ink) 20%, transparent);
   background: radial-gradient(
     circle at 30% 30%,
-    rgba(248, 250, 252, 0.14),
-    rgba(30, 41, 59, 0.85)
+    color-mix(in oklab, var(--paper) 14%, transparent),
+    color-mix(in oklab, var(--paper) 85%, transparent)
   );
-  color: rgba(248, 250, 252, 0.92);
+  color: color-mix(in oklab, var(--paper) 92%, transparent);
   font-weight: 600;
   font-size: var(--board-grid-font-size);
   letter-spacing: 0; /* letter-spacing shifts single chars off-center; no spacing needed on tiles */
@@ -76,8 +76,8 @@
   cursor: pointer;
   overflow: visible; /* Safari: border-radius on <button> implicitly clips — force off */
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    inset 0 -4px 12px rgba(15, 23, 42, 0.35);
+    inset 0 1px 0 color-mix(in oklab, var(--p1) 12%, transparent),
+    inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent);
   transition:
     transform 200ms ease-out,
     border-color 150ms ease,
@@ -112,10 +112,10 @@
 
 .board-grid__cell:hover,
 .board-grid__cell:focus-within {
-  border-color: rgba(14, 165, 233, 0.65);
+  border-color: color-mix(in oklab, var(--p1) 65%, transparent);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.18),
-    0 12px 22px -18px rgba(14, 165, 233, 0.75);
+    inset 0 1px 0 color-mix(in oklab, var(--p1) 18%, transparent),
+    0 12px 22px -18px color-mix(in oklab, var(--p1) 75%, transparent);
   transform: translateY(-1px);
   outline: none;
 }
@@ -127,12 +127,12 @@
 }
 
 .board-grid__cell--selected {
-  background: rgba(251, 146, 60, 0.7) !important;
-  border-color: rgba(251, 146, 60, 0.9);
+  background: color-mix(in oklab, var(--accent) 70%, transparent) !important;
+  border-color: color-mix(in oklab, var(--accent) 90%, transparent);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.25),
-    0 0 0 3px rgba(251, 146, 60, 0.35),
-    inset 0 -4px 12px rgba(15, 23, 42, 0.35);
+    inset 0 1px 0 color-mix(in oklab, var(--p1) 25%, transparent),
+    0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent),
+    inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent);
 }
 
 /* Opponent move reveal: sky-blue flash then fade (distinct from orange locked tiles) */
@@ -142,29 +142,29 @@
 
 @keyframes opponent-reveal-fade {
   0% {
-    background: rgba(56, 189, 248, 0.75);
+    background: color-mix(in oklab, var(--p1) 75%, transparent);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.3),
-      0 0 0 3px rgba(56, 189, 248, 0.5);
+      inset 0 1px 0 color-mix(in oklab, var(--p1) 30%, transparent),
+      0 0 0 3px color-mix(in oklab, var(--p1) 50%, transparent);
   }
   40% {
-    background: rgba(56, 189, 248, 0.55);
+    background: color-mix(in oklab, var(--p1) 55%, transparent);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.2),
-      0 0 0 2px rgba(56, 189, 248, 0.3);
+      inset 0 1px 0 color-mix(in oklab, var(--p1) 20%, transparent),
+      0 0 0 2px color-mix(in oklab, var(--p1) 30%, transparent);
   }
   100% {
     background: transparent;
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.12),
-      inset 0 -4px 12px rgba(15, 23, 42, 0.35);
+      inset 0 1px 0 color-mix(in oklab, var(--p1) 12%, transparent),
+      inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .board-grid__cell--opponent-reveal {
     animation: none;
-    background: rgba(56, 189, 248, 0.55);
+    background: color-mix(in oklab, var(--p1) 55%, transparent);
   }
 }
 
@@ -182,15 +182,15 @@
 .board-grid--locked .board-grid__cell:hover,
 .board-grid--locked .board-grid__cell:focus-within {
   transform: none;
-  border-color: rgba(148, 163, 184, 0.2);
+  border-color: color-mix(in oklab, var(--ink) 20%, transparent);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    inset 0 -4px 12px rgba(15, 23, 42, 0.35);
+    inset 0 1px 0 color-mix(in oklab, var(--p1) 12%, transparent),
+    inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent);
 }
 
 /* Move lock: orange highlight on swapped tiles until next round (US1) */
 .board-grid__cell--locked {
-  background: rgba(251, 146, 60, 0.7) !important;
+  background: color-mix(in oklab, var(--accent) 70%, transparent) !important;
   cursor: not-allowed;
   opacity: 1 !important;
   filter: none !important;
@@ -210,15 +210,15 @@
   z-index: 20;
   padding: 0.5rem 1.25rem;
   border-radius: 0.75rem;
-  background: rgba(251, 146, 60, 0.85);
-  color: #fff;
+  background: color-mix(in oklab, var(--accent) 85%, transparent);
+  color: var(--paper);
   font-size: clamp(0.75rem, 1vw + 0.3rem, 1rem);
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   pointer-events: none;
   white-space: nowrap;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px color-mix(in oklab, var(--ink) 40%, transparent);
   animation: lock-banner-in 300ms ease-out forwards;
 }
 
@@ -254,8 +254,8 @@
 .board-grid__cell--frozen:focus-within {
   transform: none;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    inset 0 -4px 12px rgba(15, 23, 42, 0.35);
+    inset 0 1px 0 color-mix(in oklab, var(--p1) 12%, transparent),
+    inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent);
 }
 
 /* Scored tile highlight: 700ms player-colored glow (PRD §7.2) */
@@ -266,29 +266,29 @@
 @keyframes scored-tile-highlight {
   0% {
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.12),
-      inset 0 -4px 12px rgba(15, 23, 42, 0.35),
+      inset 0 1px 0 color-mix(in oklab, var(--p1) 12%, transparent),
+      inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent),
       0 0 0 0 var(--highlight-color, transparent);
     opacity: 1;
   }
   28% {
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.3),
-      inset 0 -4px 12px rgba(15, 23, 42, 0.35),
+      inset 0 1px 0 color-mix(in oklab, var(--p1) 30%, transparent),
+      inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent),
       0 0 0 6px var(--highlight-color, transparent);
     opacity: 1;
   }
   71% {
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.3),
-      inset 0 -4px 12px rgba(15, 23, 42, 0.35),
+      inset 0 1px 0 color-mix(in oklab, var(--p1) 30%, transparent),
+      inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent),
       0 0 0 6px var(--highlight-color, transparent);
     opacity: 1;
   }
   100% {
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.12),
-      inset 0 -4px 12px rgba(15, 23, 42, 0.35),
+      inset 0 1px 0 color-mix(in oklab, var(--p1) 12%, transparent),
+      inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent),
       0 0 0 0 var(--highlight-color, transparent);
     opacity: 0.8;
   }
@@ -298,8 +298,8 @@
 .board-grid__cell--scored.board-grid__cell--scored-static {
   animation: none;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.2),
-    inset 0 -4px 12px rgba(15, 23, 42, 0.35),
+    inset 0 1px 0 color-mix(in oklab, var(--p1) 20%, transparent),
+    inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent),
     0 0 0 2px var(--highlight-color, transparent);
 }
 
@@ -307,8 +307,8 @@
   .board-grid__cell--scored {
     animation: none;
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.2),
-      inset 0 -4px 12px rgba(15, 23, 42, 0.35),
+      inset 0 1px 0 color-mix(in oklab, var(--p1) 20%, transparent),
+      inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent),
       0 0 0 2px var(--highlight-color, transparent);
   }
 }
@@ -337,7 +337,7 @@
   white-space: nowrap;
   font-size: 0.7rem;
   font-weight: 600;
-  color: rgba(52, 211, 153, 0.95);
+  color: color-mix(in oklab, var(--accent-alt) 95%, transparent);
   pointer-events: none;
   animation: score-delta-popup 3s ease-out forwards;
 }
@@ -370,11 +370,11 @@
 /* Invalid swap: shake + red border flash on rejected move */
 .board-grid__cell--invalid {
   animation: invalid-shake 400ms ease-in-out forwards;
-  border-color: rgba(239, 68, 68, 0.9) !important;
+  border-color: color-mix(in oklab, var(--p2) 90%, transparent) !important;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.2),
-    0 0 0 2px rgba(239, 68, 68, 0.4),
-    inset 0 -4px 12px rgba(15, 23, 42, 0.35) !important;
+    inset 0 1px 0 color-mix(in oklab, var(--p1) 20%, transparent),
+    0 0 0 2px color-mix(in oklab, var(--p2) 40%, transparent),
+    inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent) !important;
 }
 
 @keyframes invalid-shake {
@@ -407,12 +407,12 @@
 
 .board-grid__error {
   border-radius: 0.75rem;
-  border: 1px solid rgba(248, 113, 113, 0.35);
-  background: rgba(248, 113, 113, 0.12);
-  color: rgba(254, 226, 226, 0.95);
+  border: 1px solid color-mix(in oklab, var(--p2) 35%, transparent);
+  background: color-mix(in oklab, var(--p2) 12%, transparent);
+  color: color-mix(in oklab, var(--p2) 95%, transparent);
   font-size: 0.9rem;
   padding: 0.75rem 1rem;
-  box-shadow: 0 10px 24px -20px rgba(248, 113, 113, 0.65);
+  box-shadow: 0 10px 24px -20px color-mix(in oklab, var(--p2) 65%, transparent);
 }
 
 /* ─── Three-column match layout (018-match-hud-layout) ──────────────── */
@@ -518,19 +518,19 @@
   z-index: 25;
   padding: 0.75rem 2.5rem;
   border-radius: 1rem;
-  background: rgba(15, 23, 42, 0.92);
-  border: 2px solid rgba(56, 189, 248, 0.4);
-  color: #fff;
+  background: color-mix(in oklab, var(--paper) 92%, transparent);
+  border: 2px solid color-mix(in oklab, var(--p1) 40%, transparent);
+  color: var(--paper);
   font-size: clamp(1.5rem, 4vw + 0.5rem, 2.5rem);
   font-weight: 900;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   pointer-events: none;
   white-space: nowrap;
-  text-shadow: 0 0 20px rgba(56, 189, 248, 0.5);
+  text-shadow: 0 0 20px color-mix(in oklab, var(--p1) 50%, transparent);
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.6),
-    0 0 0 1px rgba(56, 189, 248, 0.15);
+    0 8px 32px color-mix(in oklab, var(--ink) 60%, transparent),
+    0 0 0 1px color-mix(in oklab, var(--p1) 15%, transparent);
   animation: round-announce 1200ms ease-out forwards;
 }
 
@@ -554,11 +554,11 @@
 }
 
 .round-announce--final {
-  border-color: rgba(52, 211, 153, 0.5);
-  text-shadow: 0 0 24px rgba(52, 211, 153, 0.6);
+  border-color: color-mix(in oklab, var(--accent-alt) 50%, transparent);
+  text-shadow: 0 0 24px color-mix(in oklab, var(--accent-alt) 60%, transparent);
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.6),
-    0 0 0 1px rgba(52, 211, 153, 0.2);
+    0 8px 32px color-mix(in oklab, var(--ink) 60%, transparent),
+    0 0 0 1px color-mix(in oklab, var(--accent-alt) 20%, transparent);
   animation: round-announce-final 2400ms ease-out forwards;
 }
 
@@ -591,21 +591,21 @@
 /* ─── Timer state colors ─────────────────────────────────────────── */
 
 .timer-display--running {
-  background: rgba(22, 163, 74, 0.85); /* green-600 */
+  background: color-mix(in oklab, var(--accent-success) 85%, transparent);
 }
 
 .timer-display--paused {
-  background: rgba(234, 138, 0, 0.85); /* orange */
+  background: color-mix(in oklab, var(--accent-warning) 85%, transparent);
 }
 
 .timer-display--expired {
-  background: rgba(220, 38, 38, 0.9); /* red-600 */
+  background: color-mix(in oklab, var(--p2) 90%, transparent);
 }
 
 /* ≤15 s — yellow with brightness flash */
 @keyframes timer-low-flash {
-  0%, 100% { background: rgba(234, 179, 8, 0.85); filter: brightness(1); }
-  50%      { background: rgba(250, 204, 21, 1);    filter: brightness(1.35); }
+  0%, 100% { background: color-mix(in oklab, var(--accent-warning) 85%, transparent); filter: brightness(1); }
+  50%      { background: color-mix(in oklab, var(--accent-warning) 100%, transparent);  filter: brightness(1.35); }
 }
 
 .timer-display--low {
@@ -615,8 +615,8 @@
 @media (prefers-reduced-motion: reduce) {
   .timer-display--low {
     animation: none;
-    background: rgba(234, 179, 8, 0.85);
-    border: 2px solid #ca8a04;
+    background: color-mix(in oklab, var(--accent-warning) 85%, transparent);
+    border: 2px solid color-mix(in oklab, var(--accent-warning) 100%, transparent);
   }
 }
 

--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -68,7 +68,7 @@
     color-mix(in oklab, var(--paper) 14%, transparent),
     color-mix(in oklab, var(--paper) 85%, transparent)
   );
-  color: color-mix(in oklab, var(--paper) 92%, transparent);
+  color: var(--ink);
   font-weight: 600;
   font-size: var(--board-grid-font-size);
   letter-spacing: 0; /* letter-spacing shifts single chars off-center; no spacing needed on tiles */
@@ -127,11 +127,11 @@
 }
 
 .board-grid__cell--selected {
-  background: color-mix(in oklab, var(--accent) 70%, transparent) !important;
-  border-color: color-mix(in oklab, var(--accent) 90%, transparent);
+  background: color-mix(in oklab, var(--ochre) 70%, transparent) !important;
+  border-color: color-mix(in oklab, var(--ochre) 90%, transparent);
   box-shadow:
     inset 0 1px 0 color-mix(in oklab, var(--p1) 25%, transparent),
-    0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent),
+    0 0 0 3px color-mix(in oklab, var(--ochre) 35%, transparent),
     inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent);
 }
 
@@ -190,7 +190,7 @@
 
 /* Move lock: orange highlight on swapped tiles until next round (US1) */
 .board-grid__cell--locked {
-  background: color-mix(in oklab, var(--accent) 70%, transparent) !important;
+  background: color-mix(in oklab, var(--ochre) 70%, transparent) !important;
   cursor: not-allowed;
   opacity: 1 !important;
   filter: none !important;
@@ -210,7 +210,7 @@
   z-index: 20;
   padding: 0.5rem 1.25rem;
   border-radius: 0.75rem;
-  background: color-mix(in oklab, var(--accent) 85%, transparent);
+  background: color-mix(in oklab, var(--ochre) 85%, transparent);
   color: var(--paper);
   font-size: clamp(0.75rem, 1vw + 0.3rem, 1rem);
   font-weight: 700;
@@ -337,7 +337,7 @@
   white-space: nowrap;
   font-size: 0.7rem;
   font-weight: 600;
-  color: color-mix(in oklab, var(--accent-alt) 95%, transparent);
+  color: color-mix(in oklab, var(--good) 95%, transparent);
   pointer-events: none;
   animation: score-delta-popup 3s ease-out forwards;
 }
@@ -554,11 +554,11 @@
 }
 
 .round-announce--final {
-  border-color: color-mix(in oklab, var(--accent-alt) 50%, transparent);
-  text-shadow: 0 0 24px color-mix(in oklab, var(--accent-alt) 60%, transparent);
+  border-color: color-mix(in oklab, var(--good) 50%, transparent);
+  text-shadow: 0 0 24px color-mix(in oklab, var(--good) 60%, transparent);
   box-shadow:
     0 8px 32px color-mix(in oklab, var(--ink) 60%, transparent),
-    0 0 0 1px color-mix(in oklab, var(--accent-alt) 20%, transparent);
+    0 0 0 1px color-mix(in oklab, var(--good) 20%, transparent);
   animation: round-announce-final 2400ms ease-out forwards;
 }
 
@@ -591,11 +591,11 @@
 /* ─── Timer state colors ─────────────────────────────────────────── */
 
 .timer-display--running {
-  background: color-mix(in oklab, var(--accent-success) 85%, transparent);
+  background: color-mix(in oklab, var(--good) 85%, transparent);
 }
 
 .timer-display--paused {
-  background: color-mix(in oklab, var(--accent-warning) 85%, transparent);
+  background: color-mix(in oklab, var(--warn) 85%, transparent);
 }
 
 .timer-display--expired {
@@ -604,8 +604,8 @@
 
 /* ≤15 s — yellow with brightness flash */
 @keyframes timer-low-flash {
-  0%, 100% { background: color-mix(in oklab, var(--accent-warning) 85%, transparent); filter: brightness(1); }
-  50%      { background: color-mix(in oklab, var(--accent-warning) 100%, transparent);  filter: brightness(1.35); }
+  0%, 100% { background: color-mix(in oklab, var(--warn) 85%, transparent); filter: brightness(1); }
+  50%      { background: color-mix(in oklab, var(--warn) 100%, transparent);  filter: brightness(1.35); }
 }
 
 .timer-display--low {
@@ -615,8 +615,8 @@
 @media (prefers-reduced-motion: reduce) {
   .timer-display--low {
     animation: none;
-    background: color-mix(in oklab, var(--accent-warning) 85%, transparent);
-    border: 2px solid color-mix(in oklab, var(--accent-warning) 100%, transparent);
+    background: color-mix(in oklab, var(--warn) 85%, transparent);
+    border: 2px solid color-mix(in oklab, var(--warn) 100%, transparent);
   }
 }
 

--- a/app/styles/lobby.css
+++ b/app/styles/lobby.css
@@ -15,10 +15,8 @@
  */
 .lobby-ambient-bg {
   position: relative;
-  background-color: #0B1220;
+  background-color: var(--paper);
   isolation: isolate;
-  /* Contain decorative pseudo-element overflow (ambient halos, hero glow)
-     without creating a new scrolling context that would break position:sticky. */
   overflow-x: clip;
 }
 
@@ -28,9 +26,9 @@
   inset: 0;
   z-index: -1;
   background-image:
-    radial-gradient(ellipse 80% 50% at 10% 0%, rgba(232, 182, 76, 0.18) 0%, transparent 60%),
-    radial-gradient(ellipse 70% 55% at 90% 100%, rgba(56, 189, 248, 0.12) 0%, transparent 65%),
-    linear-gradient(180deg, #0B1220 0%, #0A1220 40%, #07101B 100%);
+    radial-gradient(ellipse 80% 50% at 88% 10%, var(--ochre-tint) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 40% at 10% 90%, color-mix(in oklab, var(--p2-tint) 50%, transparent) 0%, transparent 60%),
+    linear-gradient(180deg, var(--paper) 0%, var(--paper-2) 100%);
   pointer-events: none;
 }
 
@@ -40,8 +38,8 @@
   inset: 0;
   z-index: -1;
   background-image:
-    linear-gradient(rgba(242, 234, 211, 0.035) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(242, 234, 211, 0.035) 1px, transparent 1px);
+    linear-gradient(color-mix(in oklab, var(--ink) 4%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in oklab, var(--ink) 4%, transparent) 1px, transparent 1px);
   background-size: 56px 56px;
   mask-image: radial-gradient(ellipse 70% 55% at 50% 35%, rgba(0, 0, 0, 1) 30%, transparent 75%);
   -webkit-mask-image: radial-gradient(ellipse 70% 55% at 50% 35%, rgba(0, 0, 0, 1) 30%, transparent 75%);
@@ -81,7 +79,7 @@
 /* ---- Primary CTA — gradient fill + accent glow ---- */
 .lobby-primary-cta {
   background: linear-gradient(135deg, #E8B64C 0%, #D9A130 60%, #B8821F 100%);
-  color: #0B1220;
+  color: var(--ink);
   box-shadow:
     0 10px 32px -8px rgba(232, 182, 76, 0.55),
     inset 0 1px 0 rgba(255, 255, 255, 0.35),

--- a/components/game/MoveFeedback.tsx
+++ b/components/game/MoveFeedback.tsx
@@ -18,7 +18,7 @@ interface MoveFeedbackProps {
 }
 
 const BASE_CLASSES =
-  "move-feedback relative mt-4 w-full max-w-md rounded-lg border px-5 py-4 text-sm shadow-lg outline-none transition focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900";
+  "move-feedback relative mt-4 w-full max-w-md rounded-lg border px-5 py-4 text-sm shadow-lg outline-none transition focus-visible:ring-2 focus-visible:ring-ink-soft focus-visible:ring-offset-2 focus-visible:ring-offset-paper";
 const SUCCESS_CLASSES = "border-emerald-400/60 bg-emerald-500/10 text-emerald-50";
 const ERROR_CLASSES = "border-rose-500/70 bg-rose-500/15 text-rose-50";
 const DEFAULT_AUTO_HIDE_MS = 6000;
@@ -120,13 +120,13 @@ export function MoveFeedback({
                 {feedback.title ??
                   (feedback.variant === "success" ? "Move accepted" : "Move rejected")}
               </p>
-              <p className="text-sm text-white/80">{feedback.message}</p>
+              <p className="text-sm text-ink-3">{feedback.message}</p>
             </div>
             {onDismiss ? (
               <button
                 type="button"
                 aria-label="Dismiss move feedback"
-                className="ml-2 inline-flex flex-shrink-0 items-center justify-center rounded-md border border-white/20 bg-white/5 px-2 py-1 text-xs font-medium text-white/80 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+                className="ml-2 inline-flex flex-shrink-0 items-center justify-center rounded-md border border-hair-strong bg-paper-2 px-2 py-1 text-xs font-medium text-ink-3 transition hover:bg-paper-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink-soft focus-visible:ring-offset-2 focus-visible:ring-offset-paper"
                 data-testid="move-feedback-dismiss"
                 onClick={() => {
                   if (timeoutRef.current) {

--- a/components/game/TimerHud.tsx
+++ b/components/game/TimerHud.tsx
@@ -30,11 +30,11 @@ export function TimerHud({ timeLeft, isPaused, roundNumber, hasSubmitted = false
     const seconds = displayTime % 60;
 
     return (
-        <div className="flex items-center justify-between bg-slate-800 p-4 rounded-lg text-white w-full max-w-md mx-auto mb-4" data-testid="timer-hud">
+        <div className="flex items-center justify-between bg-paper-2 p-4 rounded-lg text-ink w-full max-w-md mx-auto mb-4" data-testid="timer-hud">
             <div className="text-xl font-bold" data-testid="round-indicator">
                 Round {roundNumber}
             </div>
-            <div className={`text-2xl font-mono ${!hasSubmitted ? "text-emerald-400" : "text-slate-400"}`} data-testid="timer-display">
+            <div className={`text-2xl font-mono ${!hasSubmitted ? "text-emerald-400" : "text-ink-soft"}`} data-testid="timer-display">
                 {minutes}:{seconds.toString().padStart(2, "0")}
             </div>
             {isPaused && (

--- a/components/match/FinalSummary.tsx
+++ b/components/match/FinalSummary.tsx
@@ -94,7 +94,7 @@ function reasonLabel(reason: MatchEndedReason) {
 
 function TopWordsList({ words }: { words: TopWord[] }) {
   if (words.length === 0) {
-    return <p className="text-xs text-white/40">No words scored</p>;
+    return <p className="text-xs text-ink-soft">No words scored</p>;
   }
 
   return (
@@ -102,7 +102,7 @@ function TopWordsList({ words }: { words: TopWord[] }) {
       {words.map((entry, idx) => (
         <li
           key={`${entry.word}-${idx}`}
-          className="flex items-center justify-between text-xs text-white/70"
+          className="flex items-center justify-between text-xs text-ink-3"
         >
           <span className="font-mono uppercase tracking-wide">{entry.word}</span>
           <span>{entry.totalPoints} pts</span>
@@ -122,7 +122,7 @@ function RatingDeltaDisplay({
   if (ratingDelta === undefined) {
     return (
       <p
-        className="mt-1 text-sm text-white/40 italic"
+        className="mt-1 text-sm text-ink-soft italic"
         data-testid="rating-pending"
       >
         Rating update pending
@@ -136,7 +136,7 @@ function RatingDeltaDisplay({
       ? "text-emerald-400"
       : ratingDelta < 0
         ? "text-rose-400"
-        : "text-white/60";
+        : "text-ink-soft";
 
   return (
     <p className="mt-1 text-sm" data-testid="rating-delta">
@@ -145,7 +145,7 @@ function RatingDeltaDisplay({
         {ratingDelta}
       </span>
       {ratingAfter !== undefined && (
-        <span className="ml-2 text-white/50">
+        <span className="ml-2 text-ink-soft">
           → {ratingAfter}
         </span>
       )}
@@ -283,22 +283,22 @@ export function FinalSummary({
       />
     )}
     <section
-      className="w-full overflow-hidden rounded-3xl border border-white/10 bg-slate-950/70 p-3 shadow-2xl shadow-slate-950/60 sm:p-8"
-      data-testid="final-summary-view"
+      className="w-full overflow-hidden rounded-3xl border border-hair bg-paper p-3 shadow-2xl shadow-paper/60 sm:p-8"
+      data-testid="final-summary-root"
     >
       {/* Board with player HUD panels, matching in-game 3-column layout */}
       {board && (
         <div className="summary-board-layout mb-6" data-testid="final-summary-board">
           {/* Left panel: current player (same as in-game) */}
           <div className="summary-board-layout__panel">
-            <div className="flex flex-col items-center gap-2 rounded-xl border border-white/10 bg-gray-900/80 p-4">
+            <div className="flex flex-col items-center gap-2 rounded-xl border border-hair bg-paper-2 p-4">
               <PlayerAvatar
                 displayName={currentPlayer?.displayName ?? "You"}
                 avatarUrl={null}
                 playerColor={currentPlayerColor}
                 size="md"
               />
-              <span className="max-w-[10rem] truncate text-sm font-semibold text-white">
+              <span className="max-w-[10rem] truncate text-sm font-semibold text-ink">
                 {currentPlayer?.displayName ?? "You"}
               </span>
               <span
@@ -307,7 +307,7 @@ export function FinalSummary({
               >
                 {currentPlayer?.score ?? 0}
               </span>
-              <span className="text-xs text-white/50">
+              <span className="text-xs text-ink-soft">
                 Time used: {formatDuration(currentPlayer?.timeUsedMs ?? 0)}
               </span>
             </div>
@@ -327,14 +327,14 @@ export function FinalSummary({
 
           {/* Right panel: opponent (same as in-game) */}
           <div className="summary-board-layout__panel">
-            <div className="flex flex-col items-center gap-2 rounded-xl border border-white/10 bg-gray-900/80 p-4">
+            <div className="flex flex-col items-center gap-2 rounded-xl border border-hair bg-paper-2 p-4">
               <PlayerAvatar
                 displayName={opponent?.displayName ?? "Opponent"}
                 avatarUrl={null}
                 playerColor={opponentColor}
                 size="md"
               />
-              <span className="max-w-[10rem] truncate text-sm font-semibold text-white">
+              <span className="max-w-[10rem] truncate text-sm font-semibold text-ink">
                 {opponent?.displayName ?? "Opponent"}
               </span>
               <span
@@ -343,7 +343,7 @@ export function FinalSummary({
               >
                 {opponent?.score ?? 0}
               </span>
-              <span className="text-xs text-white/50">
+              <span className="text-xs text-ink-soft">
                 Time used: {formatDuration(opponent?.timeUsedMs ?? 0)}
               </span>
             </div>
@@ -351,7 +351,7 @@ export function FinalSummary({
         </div>
       )}
       {/* Tab bar */}
-      <div className="mb-6 flex gap-2 border-b border-white/10 pb-1" role="tablist" aria-label="Match summary">
+      <div className="mb-6 flex gap-2 border-b border-hair pb-1" role="tablist" aria-label="Match summary">
         <button
           type="button"
           role="tab"
@@ -362,7 +362,7 @@ export function FinalSummary({
           className={`rounded-t-xl px-4 py-2 text-sm font-medium transition ${
             activeTab === "overview"
               ? "border-b-2 border-emerald-400 text-emerald-300"
-              : "text-white/60 hover:text-white/90"
+              : "text-ink-soft hover:text-ink"
           }`}
           data-testid="tab-overview"
         >
@@ -378,7 +378,7 @@ export function FinalSummary({
           className={`rounded-t-xl px-4 py-2 text-sm font-medium transition ${
             activeTab === "round-history"
               ? "border-b-2 border-emerald-400 text-emerald-300"
-              : "text-white/60 hover:text-white/90"
+              : "text-ink-soft hover:text-ink"
           }`}
           data-testid="tab-round-history"
         >
@@ -397,9 +397,9 @@ export function FinalSummary({
         <p className="text-sm uppercase tracking-[0.3em] text-emerald-200/80">
           Match Complete
         </p>
-        <h1 className="text-3xl font-bold text-white">Final Summary</h1>
+        <h1 className="text-3xl font-bold text-ink">Final Summary</h1>
         <p
-          className="text-white/70"
+          className="text-ink-3"
           data-testid="final-summary-ended-reason"
         >
           {isDualTimeout ? "Both players timed out" : reasonLabel(endedReason)}
@@ -411,12 +411,12 @@ export function FinalSummary({
           <p className="text-sm uppercase tracking-wide text-emerald-200/80">
             Winner
           </p>
-          <p className="text-2xl font-semibold text-white">
+          <p className="text-2xl font-semibold text-ink">
             {winner.displayName}
           </p>
           {endedReason === "forfeit" && (
             <p
-              className="mt-1 text-sm text-white/60"
+              className="mt-1 text-sm text-ink-soft"
               data-testid="final-summary-forfeit-label"
             >
               {winner.id === currentPlayerId
@@ -430,7 +430,7 @@ export function FinalSummary({
           <p className="text-sm uppercase tracking-wide text-sky-200/80">
             Draw
           </p>
-          <p className="text-2xl font-semibold text-white">
+          <p className="text-2xl font-semibold text-ink">
             Both players tied after the final round.
           </p>
         </div>
@@ -475,7 +475,7 @@ export function FinalSummary({
         </button>
         <button
           type="button"
-          className="rounded-2xl border border-white/20 px-5 py-3 text-white transition hover:bg-white/10"
+          className="rounded-2xl border border-hair-strong px-5 py-3 text-ink transition hover:bg-paper-2"
           onClick={() => router.push("/")}
           data-testid="final-summary-back-lobby"
         >
@@ -493,21 +493,21 @@ export function FinalSummary({
             className={`rounded-2xl border p-4 ${
               player.id === winnerId
                 ? "border-emerald-400/40 bg-emerald-500/5"
-                : "border-white/10 bg-white/5"
+                : "border-hair bg-paper-2"
             }`}
           >
             <button
               type="button"
-              className="text-xs uppercase tracking-wide text-white/60 hover:text-emerald-300 transition"
+              className="text-xs uppercase tracking-wide text-ink-soft hover:text-emerald-300 transition"
               onClick={() => setProfilePlayerId(player.id)}
             >
               {player.id === currentPlayerId ? "You" : player.displayName}
             </button>
-            <p className="mt-2 text-4xl font-bold text-white">{player.score}</p>
-            <p className="mt-1 text-sm text-white/70">
+            <p className="mt-2 text-4xl font-bold text-ink">{player.score}</p>
+            <p className="mt-1 text-sm text-ink-3">
               Time used: {formatDuration(player.timeUsedMs)}
             </p>
-            <p className="mt-1 text-sm text-white/70">
+            <p className="mt-1 text-sm text-ink-3">
               {player.frozenTileCount} tiles frozen
             </p>
             <RatingDeltaDisplay
@@ -516,7 +516,7 @@ export function FinalSummary({
             />
             {player.topWords.length > 0 && (
               <div className="mt-3">
-                <p className="text-xs uppercase tracking-wide text-white/40">
+                <p className="text-xs uppercase tracking-wide text-ink-soft">
                   Top words
                 </p>
                 <TopWordsList words={player.topWords} />
@@ -527,20 +527,20 @@ export function FinalSummary({
       </div>
 
       <div
-        className="mt-8 rounded-2xl border border-white/10 bg-white/5 p-4"
+        className="mt-8 rounded-2xl border border-hair bg-paper-2 p-4"
         data-testid="final-summary-timers"
       >
-        <h2 className="text-lg font-semibold text-white">Per-round Scoreboard</h2>
+        <h2 className="text-lg font-semibold text-ink">Per-round Scoreboard</h2>
         <div className="mt-4 space-y-2">
           {scoreboard.length === 0 && (
-            <p className="text-sm text-white/60">
+            <p className="text-sm text-ink-soft">
               No scoreboard snapshots recorded for this match.
             </p>
           )}
           {scoreboard.map((row) => (
             <div
               key={row.roundNumber}
-              className="flex items-center justify-between rounded-xl bg-slate-900/60 px-4 py-2 text-sm text-white/80"
+              className="flex items-center justify-between rounded-xl bg-paper-3 px-4 py-2 text-sm text-ink-3"
             >
               <span>Round {row.roundNumber}</span>
               <span>
@@ -552,12 +552,12 @@ export function FinalSummary({
       </div>
 
       <div
-        className="mt-8 rounded-2xl border border-white/10 bg-white/5 p-4"
+        className="mt-8 rounded-2xl border border-hair bg-paper-2 p-4"
         data-testid="final-summary-word-history"
       >
-        <h2 className="text-lg font-semibold text-white">Word History</h2>
+        <h2 className="text-lg font-semibold text-ink">Word History</h2>
         {wordHistory.length === 0 ? (
-          <p className="mt-2 text-sm text-white/60">
+          <p className="mt-2 text-sm text-ink-soft">
             No words were scored in this match.
           </p>
         ) : (
@@ -567,18 +567,18 @@ export function FinalSummary({
               return (
                 <div
                   key={`${entry.roundNumber}-${entry.word}-${index}`}
-                  className="rounded-xl border border-white/10 bg-slate-900/60 px-4 py-3 text-sm text-white"
+                  className="rounded-xl border border-hair bg-paper-3 px-4 py-3 text-sm text-ink"
                 >
                   <div className="flex items-center justify-between">
                     <span className="font-semibold">Round {entry.roundNumber}</span>
-                    <span className="text-white/60">
+                    <span className="text-ink-soft">
                       {entry.totalPoints} pts
                     </span>
                   </div>
                   <p className="text-lg font-mono uppercase tracking-wide">
                     {entry.word}
                   </p>
-                  <p className="text-white/70">
+                  <p className="text-ink-3">
                     {player?.displayName ?? "Unknown"} ·{" "}
                     {entry.lettersPoints} base + {entry.bonusPoints} bonus
                   </p>
@@ -590,7 +590,7 @@ export function FinalSummary({
       </div>
 
       {currentPlayer && (
-        <p className="mt-4 text-sm text-white/60">
+        <p className="mt-4 text-sm text-ink-soft">
           Playing as <span className="font-semibold">{currentPlayer.displayName}</span>
         </p>
       )}

--- a/components/match/FinalSummary.tsx
+++ b/components/match/FinalSummary.tsx
@@ -283,7 +283,7 @@ export function FinalSummary({
       />
     )}
     <section
-      className="w-full overflow-hidden rounded-3xl border border-hair bg-paper p-3 shadow-2xl shadow-paper/60 sm:p-8"
+      className="w-full overflow-hidden rounded-3xl border border-hair bg-paper p-3 shadow-wottle-lg sm:p-8"
       data-testid="final-summary-root"
     >
       {/* Board with player HUD panels, matching in-game 3-column layout */}

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -827,10 +827,10 @@ export function MatchClient({
 
       {showDebug && (
         <details
-          className="mt-4 rounded-lg border border-white/10 bg-slate-900/50 p-3 text-xs text-white/60"
+          className="mt-4 rounded-lg border border-hair bg-paper-2 p-3 text-xs text-ink-soft"
           data-testid="debug-metadata"
         >
-          <summary className="cursor-pointer text-white/40">
+          <summary className="cursor-pointer text-ink-soft">
             Debug Info
           </summary>
           <dl className="mt-2 grid grid-cols-2 gap-1">
@@ -859,17 +859,17 @@ export function MatchClient({
         >
           <div
             ref={historyOverlayRef}
-            className="relative max-h-[80vh] w-full max-w-lg overflow-y-auto rounded-t-2xl border border-white/10 bg-slate-900 p-4 shadow-2xl sm:rounded-2xl"
+            className="relative max-h-[80vh] w-full max-w-lg overflow-y-auto rounded-t-2xl border border-hair bg-paper p-4 shadow-2xl sm:rounded-2xl"
             role="dialog"
             aria-label="Round history"
             data-testid="history-overlay"
           >
             <div className="mb-3 flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-white">Round History</h2>
+              <h2 className="text-lg font-semibold text-ink">Round History</h2>
               <button
                 type="button"
                 onClick={() => setHistoryOpen(false)}
-                className="rounded-lg px-2 py-1 text-sm text-white/60 transition hover:bg-white/10 hover:text-white"
+                className="rounded-lg px-2 py-1 text-sm text-ink-soft transition hover:bg-paper-2 hover:text-ink"
                 aria-label="Close round history"
                 data-testid="history-close"
               >
@@ -895,15 +895,15 @@ export function MatchClient({
           data-testid="resign-dialog-backdrop"
         >
           <div
-            className="w-full max-w-sm rounded-2xl border border-white/10 bg-slate-900 p-6 shadow-2xl"
+            className="w-full max-w-sm rounded-2xl border border-hair bg-paper p-6 shadow-2xl"
             role="alertdialog"
             aria-label="Confirm resignation"
             data-testid="resign-dialog"
           >
-            <h2 className="text-lg font-semibold text-white">
+            <h2 className="text-lg font-semibold text-ink">
               Resign?
             </h2>
-            <p className="mt-2 text-sm text-white/70">
+            <p className="mt-2 text-sm text-ink-3">
               Are you sure you want to resign? Your opponent will win.
             </p>
             <div className="mt-6 flex gap-3">
@@ -919,7 +919,7 @@ export function MatchClient({
               <button
                 type="button"
                 onClick={() => setShowResignDialog(false)}
-                className="rounded-xl border border-white/20 px-4 py-2 text-sm text-white transition hover:bg-white/10"
+                className="rounded-xl border border-hair-strong px-4 py-2 text-sm text-ink transition hover:bg-paper-2"
                 data-testid="resign-cancel"
               >
                 Cancel

--- a/components/match/MatchShell.tsx
+++ b/components/match/MatchShell.tsx
@@ -13,7 +13,7 @@ export function MatchShell({
 }: MatchShellProps) {
   return (
     <section
-      className="w-full text-white"
+      className="w-full text-ink"
       data-testid="match-shell"
       data-match-id={matchId}
     >
@@ -24,11 +24,11 @@ export function MatchShell({
 
 function PanelSkeleton() {
   return (
-    <div className="flex flex-col items-center gap-3 rounded-xl border border-white/10 bg-gray-900/80 p-4">
-      <div className="h-12 w-12 animate-pulse rounded-full bg-white/10" />
-      <div className="h-4 w-20 animate-pulse rounded bg-white/10" />
-      <div className="h-12 w-full animate-pulse rounded-lg bg-white/10" />
-      <div className="h-8 w-16 animate-pulse rounded bg-white/10" />
+    <div className="flex flex-col items-center gap-3 rounded-xl border border-hair bg-paper-2 p-4">
+      <div className="h-12 w-12 animate-pulse rounded-full bg-paper-3" />
+      <div className="h-4 w-20 animate-pulse rounded bg-paper-3" />
+      <div className="h-12 w-full animate-pulse rounded-lg bg-paper-3" />
+      <div className="h-8 w-16 animate-pulse rounded bg-paper-3" />
     </div>
   );
 }
@@ -43,10 +43,10 @@ function MatchShellSkeleton() {
       <div className="match-layout__board">
         {/* Mobile compact bar skeleton */}
         <div className="match-layout__compact-top">
-          <div className="flex items-center gap-2 rounded-lg bg-white/5 px-3 py-2">
-            <div className="h-8 w-8 animate-pulse rounded-full bg-white/10" />
-            <div className="h-4 w-16 animate-pulse rounded bg-white/10" />
-            <div className="ml-auto h-6 w-14 animate-pulse rounded bg-white/10" />
+          <div className="flex items-center gap-2 rounded-lg bg-paper-2 px-3 py-2">
+            <div className="h-8 w-8 animate-pulse rounded-full bg-paper-3" />
+            <div className="h-4 w-16 animate-pulse rounded bg-paper-3" />
+            <div className="ml-auto h-6 w-14 animate-pulse rounded bg-paper-3" />
           </div>
         </div>
 
@@ -62,10 +62,10 @@ function MatchShellSkeleton() {
 
         {/* Mobile compact bar skeleton */}
         <div className="match-layout__compact-bottom">
-          <div className="flex items-center gap-2 rounded-lg bg-white/5 px-3 py-2">
-            <div className="h-8 w-8 animate-pulse rounded-full bg-white/10" />
-            <div className="h-4 w-16 animate-pulse rounded bg-white/10" />
-            <div className="ml-auto h-6 w-14 animate-pulse rounded bg-white/10" />
+          <div className="flex items-center gap-2 rounded-lg bg-paper-2 px-3 py-2">
+            <div className="h-8 w-8 animate-pulse rounded-full bg-paper-3" />
+            <div className="h-4 w-16 animate-pulse rounded bg-paper-3" />
+            <div className="ml-auto h-6 w-14 animate-pulse rounded bg-paper-3" />
           </div>
         </div>
       </div>

--- a/components/match/PlayerAvatar.tsx
+++ b/components/match/PlayerAvatar.tsx
@@ -36,7 +36,7 @@ export function PlayerAvatar({
   return (
     <div
       data-testid="player-avatar"
-      className="flex items-center justify-center rounded-full font-bold text-white"
+      className="flex items-center justify-center rounded-full font-bold text-ink"
       style={{
         width: `${px}px`,
         height: `${px}px`,

--- a/components/match/PlayerPanel.tsx
+++ b/components/match/PlayerPanel.tsx
@@ -49,7 +49,7 @@ function FullPanel({
   return (
     <div
       data-testid="player-panel"
-      className="flex flex-col items-center gap-3 rounded-xl border border-white/10 bg-gray-900/80 p-4"
+      className="flex flex-col items-center gap-3 rounded-xl border border-hair bg-paper p-4 shadow-wottle-sm"
     >
       <PlayerAvatar
         displayName={player.displayName}
@@ -61,13 +61,13 @@ function FullPanel({
       <div className="flex flex-col items-center gap-0.5">
         <span
           data-testid="player-name"
-          className="max-w-[12rem] truncate text-sm font-semibold text-white"
+          className="max-w-[12rem] truncate text-sm font-semibold text-ink"
         >
           {player.displayName}
         </span>
         <span
           data-testid="elo-rating"
-          className="text-xs text-white/50"
+          className="text-xs text-ink-soft"
         >
           {player.eloRating > 0 ? player.eloRating : "Unrated"}
         </span>
@@ -96,7 +96,7 @@ function FullPanel({
         )}
       </div>
 
-      <span data-testid="round-indicator" className="text-xs text-white/40">
+      <span data-testid="round-indicator" className="text-xs text-ink-soft">
         Round {gameState.currentRound} / {gameState.totalRounds}
       </span>
 
@@ -113,7 +113,7 @@ function FullPanel({
               <button
                 aria-label="History"
                 onClick={controls.onHistoryToggle}
-                className="rounded border border-white/20 px-2 py-1 text-xs text-white/60 hover:bg-white/10"
+                className="rounded border border-hair-strong px-2 py-1 text-xs text-ink-soft hover:bg-paper-2"
               >
                 H {controls.roundHistoryCount}
               </button>
@@ -150,7 +150,7 @@ function CompactPanel({
   return (
     <div
       data-testid="player-panel-compact"
-      className="flex w-full items-center gap-2 rounded-lg border border-white/10 bg-gray-900/80 px-3 py-1.5"
+      className="flex w-full items-center gap-2 rounded-lg border border-hair bg-paper px-3 py-1.5 shadow-wottle-sm"
     >
       <PlayerAvatar
         displayName={player.displayName}
@@ -161,7 +161,7 @@ function CompactPanel({
 
       <span
         data-testid="player-name"
-        className="min-w-0 truncate text-sm font-semibold text-white"
+        className="min-w-0 truncate text-sm font-semibold text-ink"
       >
         {player.displayName}
       </span>
@@ -169,7 +169,7 @@ function CompactPanel({
       <div className="ml-auto flex items-center gap-2">
         <span
           data-testid="round-indicator"
-          className="text-xs text-white/40"
+          className="text-xs text-ink-soft"
         >
           R{gameState.currentRound}
         </span>

--- a/components/match/RematchBanner.tsx
+++ b/components/match/RematchBanner.tsx
@@ -16,7 +16,7 @@ export function RematchBanner({
       className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-4"
       data-testid="rematch-banner"
     >
-      <p className="text-sm font-medium text-white">
+      <p className="text-sm font-medium text-ink">
         {requesterName} wants a rematch!
       </p>
       <div className="mt-3 flex gap-3">
@@ -30,7 +30,7 @@ export function RematchBanner({
         </button>
         <button
           type="button"
-          className="rounded-xl border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10"
+          className="rounded-xl border border-hair-strong px-4 py-2 text-sm font-medium text-ink transition hover:bg-paper-2"
           onClick={onDecline}
           data-testid="rematch-decline"
         >

--- a/components/match/RematchInterstitial.tsx
+++ b/components/match/RematchInterstitial.tsx
@@ -3,10 +3,10 @@
 export function RematchInterstitial() {
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/90"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-paper/90"
       data-testid="rematch-interstitial"
     >
-      <p className="text-xl font-semibold text-white animate-pulse">
+      <p className="text-xl font-semibold text-ink animate-pulse">
         Starting new game...
       </p>
     </div>

--- a/components/match/RoundHistoryInline.tsx
+++ b/components/match/RoundHistoryInline.tsx
@@ -53,13 +53,13 @@ export function RoundHistoryInline({
       {rounds.map((entry) => (
         <div
           key={entry.roundNumber}
-          className="border-t border-white/10 py-1.5 first:border-t-0"
+          className="border-t border-hair py-1.5 first:border-t-0"
         >
-          <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-white/40">
+          <p className="text-[0.65rem] font-semibold uppercase tracking-wider text-ink-soft">
             Round {entry.roundNumber}
           </p>
           {entry.words.length === 0 ? (
-            <p className="text-[0.6rem] italic text-white/30">
+            <p className="text-[0.6rem] italic text-ink-soft/50">
               no words
             </p>
           ) : (
@@ -67,12 +67,12 @@ export function RoundHistoryInline({
               {entry.words.map((w, i) => (
                 <li
                   key={`${w.word}-${i}`}
-                  className="flex items-center justify-between text-[0.7rem] text-white/70"
+                  className="flex items-center justify-between text-[0.7rem] text-ink-3"
                 >
                   <span className="font-mono uppercase tracking-wide">
                     {w.word}
                   </span>
-                  <span className="text-white/50">
+                  <span className="text-ink-soft">
                     +{w.totalPoints}
                   </span>
                 </li>

--- a/components/match/RoundHistoryPanel.tsx
+++ b/components/match/RoundHistoryPanel.tsx
@@ -26,25 +26,25 @@ function WordRow({
 }) {
   return (
     <li
-      className="flex items-center justify-between rounded-lg px-3 py-2 text-sm hover:bg-white/5"
+      className="flex items-center justify-between rounded-lg px-3 py-2 text-sm hover:bg-paper-2"
       onMouseEnter={() => onWordHover?.(word)}
       onMouseLeave={() => onWordHover?.(null)}
       onFocus={() => onWordHover?.(word)}
       onBlur={() => onWordHover?.(null)}
       tabIndex={onWordHover ? 0 : undefined}
     >
-      <span className="font-mono uppercase tracking-wide text-white">
+      <span className="font-mono uppercase tracking-wide text-ink">
         {word.word}
       </span>
-      <span className="ml-4 shrink-0 text-white/60">
-        <span className="text-white/40">{word.word.length}L</span>
+      <span className="ml-4 shrink-0 text-ink-soft">
+        <span className="text-ink-soft">{word.word.length}L</span>
         {" · "}
         <span>{word.lettersPoints}</span>
         {word.bonusPoints > 0 && (
           <span className="text-emerald-400"> +{word.bonusPoints}</span>
         )}
         {" = "}
-        <span className="font-semibold text-white">{word.totalPoints} pts</span>
+        <span className="font-semibold text-ink">{word.totalPoints} pts</span>
       </span>
     </li>
   );
@@ -63,7 +63,7 @@ function PlayerWordSection({
 }) {
   return (
     <div className="mt-2">
-      <p className="text-xs font-semibold uppercase tracking-wider text-white/40">
+      <p className="text-xs font-semibold uppercase tracking-wider text-ink-soft">
         {username}
       </p>
       <ul
@@ -72,7 +72,7 @@ function PlayerWordSection({
         className="mt-1 space-y-1"
       >
         {words.length === 0 ? (
-          <li className="text-sm text-white/30">No words</li>
+          <li className="text-sm text-ink-soft/50">No words</li>
         ) : (
           words.map((w, i) => (
             <WordRow key={`${w.word}-${i}`} word={w} onWordHover={onWordHover} />
@@ -101,28 +101,28 @@ function RoundRow({
   const fmtDelta = (n: number) => (n > 0 ? `+${n}` : `${n}`);
 
   return (
-    <div className="rounded-xl border border-white/10 bg-white/5">
+    <div className="rounded-xl border border-hair bg-paper-2">
       <button
         type="button"
         id={triggerId}
         aria-expanded={expanded}
         aria-controls={panelId}
         onClick={() => setExpanded((v) => !v)}
-        className="flex w-full items-center justify-between rounded-xl px-4 py-3 text-left transition hover:bg-white/5"
+        className="flex w-full items-center justify-between rounded-xl px-4 py-3 text-left transition hover:bg-paper-3"
         data-testid={`round-row-${entry.roundNumber}`}
       >
-        <span className="font-semibold text-white">Round {entry.roundNumber}</span>
+        <span className="font-semibold text-ink">Round {entry.roundNumber}</span>
         <span className="flex items-center gap-4 text-sm">
           <span className="text-blue-400">
             {playerAUsername}: {fmtDelta(entry.playerA.delta)}{" "}
-            <span className="text-white/40">({entry.playerA.cumulative})</span>
+            <span className="text-ink-soft">({entry.playerA.cumulative})</span>
           </span>
           <span className="text-red-400">
             {playerBUsername}: {fmtDelta(entry.playerB.delta)}{" "}
-            <span className="text-white/40">({entry.playerB.cumulative})</span>
+            <span className="text-ink-soft">({entry.playerB.cumulative})</span>
           </span>
           <span
-            className={`ml-2 text-white/40 transition-transform ${expanded ? "rotate-180" : ""}`}
+            className={`ml-2 text-ink-soft transition-transform ${expanded ? "rotate-180" : ""}`}
             aria-hidden="true"
           >
             ▾
@@ -135,7 +135,7 @@ function RoundRow({
           id={panelId}
           role="region"
           aria-labelledby={triggerId}
-          className="border-t border-white/10 px-4 pb-4"
+          className="border-t border-hair px-4 pb-4"
         >
           <PlayerWordSection
             username={playerAUsername}
@@ -172,14 +172,14 @@ export function RoundHistoryPanel({
               <p className="text-xs font-semibold uppercase tracking-wider text-amber-400">
                 Biggest swing
               </p>
-              <p className="mt-1 text-sm text-white">
+              <p className="mt-1 text-sm text-ink">
                 Round {biggestSwing.roundNumber}{" "}
-                <span className="text-white/60">(±{biggestSwing.swingAmount} pts)</span>
+                <span className="text-ink-soft">(±{biggestSwing.swingAmount} pts)</span>
               </p>
             </div>
           ) : (
             biggestSwing === null && (
-              <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/40" data-testid="callout-no-swing">
+              <div className="rounded-xl border border-hair bg-paper-2 px-4 py-3 text-sm text-ink-soft" data-testid="callout-no-swing">
                 No scoring swings
               </div>
             )
@@ -189,16 +189,16 @@ export function RoundHistoryPanel({
               <p className="text-xs font-semibold uppercase tracking-wider text-emerald-400">
                 Top word
               </p>
-              <p className="mt-1 font-mono text-sm font-semibold uppercase text-white">
+              <p className="mt-1 font-mono text-sm font-semibold uppercase text-ink">
                 {highestWord.word}
               </p>
-              <p className="text-xs text-white/60">
+              <p className="text-xs text-ink-soft">
                 {highestWord.username} · Round {highestWord.roundNumber} · {highestWord.totalPoints} pts
               </p>
             </div>
           ) : (
             highestWord === null && (
-              <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/40" data-testid="callout-no-word">
+              <div className="rounded-xl border border-hair bg-paper-2 px-4 py-3 text-sm text-ink-soft" data-testid="callout-no-word">
                 No scored words
               </div>
             )
@@ -207,7 +207,7 @@ export function RoundHistoryPanel({
       )}
 
       {rounds.length === 0 ? (
-        <p className="py-8 text-center text-sm text-white/40" data-testid="round-history-empty">
+        <p className="py-8 text-center text-sm text-ink-soft" data-testid="round-history-empty">
           No rounds completed.
         </p>
       ) : (

--- a/components/match/RoundSummaryPanel.tsx
+++ b/components/match/RoundSummaryPanel.tsx
@@ -94,7 +94,7 @@ export function RoundSummaryPanel({
     return (
         <div
             ref={panelRef}
-            className="w-full overflow-y-auto rounded-2xl border border-hair-strong bg-paper/95 p-6 shadow-2xl shadow-paper-3/60 backdrop-blur-sm lg:max-h-[calc(100vh-8rem)] lg:sticky lg:top-4"
+            className="w-full overflow-y-auto rounded-2xl border border-hair-strong bg-paper/95 p-6 shadow-wottle-lg backdrop-blur-sm lg:max-h-[calc(100vh-8rem)] lg:sticky lg:top-4"
             data-testid="round-summary-panel"
             role="dialog"
             aria-modal="true"
@@ -213,7 +213,7 @@ export function RoundSummaryPanel({
 function WordScoreRow({ wordScore, isOpponent = false }: { wordScore: WordScore; isOpponent?: boolean }) {
     const baseClasses = isOpponent
         ? "border-hair bg-paper-2 text-ink-3"
-        : "border-emerald-500/30 bg-emerald-500/10 text-white";
+        : "border-emerald-500/30 bg-emerald-500/10 text-ink";
 
     return (
         <div className={`rounded-lg border p-3 ${baseClasses}`}>

--- a/components/match/RoundSummaryPanel.tsx
+++ b/components/match/RoundSummaryPanel.tsx
@@ -94,7 +94,7 @@ export function RoundSummaryPanel({
     return (
         <div
             ref={panelRef}
-            className="w-full overflow-y-auto rounded-2xl border border-white/20 bg-slate-900/95 p-6 shadow-2xl shadow-slate-950/60 backdrop-blur-sm lg:max-h-[calc(100vh-8rem)] lg:sticky lg:top-4"
+            className="w-full overflow-y-auto rounded-2xl border border-hair-strong bg-paper/95 p-6 shadow-2xl shadow-paper-3/60 backdrop-blur-sm lg:max-h-[calc(100vh-8rem)] lg:sticky lg:top-4"
             data-testid="round-summary-panel"
             role="dialog"
             aria-modal="true"
@@ -110,14 +110,14 @@ export function RoundSummaryPanel({
                 role="status"
             />
             <div className="flex items-start justify-between mb-4">
-                <h2 id="round-summary-title" className="text-xl font-bold text-white">
+                <h2 id="round-summary-title" className="text-xl font-bold text-ink">
                     Round {summary.roundNumber} Summary
                 </h2>
                 {onDismiss && (
                     <button
                         type="button"
                         onClick={onDismiss}
-                        className="text-white/60 hover:text-white"
+                        className="text-ink-soft hover:text-ink"
                         aria-label="Close summary"
                     >
                         ×
@@ -158,7 +158,7 @@ export function RoundSummaryPanel({
             </div>
 
             {!hasWords ? (
-                <div className="text-center py-4 text-white/70">
+                <div className="text-center py-4 text-ink-3">
                     <p className="text-sm">No new words scored this round</p>
                 </div>
             ) : (
@@ -166,7 +166,7 @@ export function RoundSummaryPanel({
                     {/* Words List */}
                     {currentPlayerWords.length > 0 && (
                         <div>
-                            <h3 className="text-sm font-semibold text-white mb-3">Your Words</h3>
+                            <h3 className="text-sm font-semibold text-ink mb-3">Your Words</h3>
                             <div className="space-y-2">
                                 {currentPlayerWords.map((word, idx) => (
                                     <WordScoreRow key={`${word.word}-${idx}`} wordScore={word} />
@@ -177,7 +177,7 @@ export function RoundSummaryPanel({
 
                     {opponentWords.length > 0 && (
                         <div>
-                            <h3 className="text-sm font-semibold text-white/70 mb-3">
+                            <h3 className="text-sm font-semibold text-ink-soft mb-3">
                                 Opponent&apos;s Words
                             </h3>
                             <div className="space-y-2">
@@ -212,7 +212,7 @@ export function RoundSummaryPanel({
 
 function WordScoreRow({ wordScore, isOpponent = false }: { wordScore: WordScore; isOpponent?: boolean }) {
     const baseClasses = isOpponent
-        ? "border-white/10 bg-white/5 text-white/80"
+        ? "border-hair bg-paper-2 text-ink-3"
         : "border-emerald-500/30 bg-emerald-500/10 text-white";
 
     return (
@@ -220,11 +220,11 @@ function WordScoreRow({ wordScore, isOpponent = false }: { wordScore: WordScore;
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                     <span className="font-mono text-lg font-bold">{wordScore.word.toUpperCase()}</span>
-                    <span className="text-xs text-white/60">({wordScore.length} letters)</span>
+                    <span className="text-xs text-ink-soft">({wordScore.length} letters)</span>
                 </div>
                 <div className="text-right">
                     <p className="font-bold text-lg">+{wordScore.totalPoints}</p>
-                    <p className="text-xs text-white/60">
+                    <p className="text-xs text-ink-soft">
                         {wordScore.lettersPoints} + {wordScore.bonusPoints} bonus
                     </p>
                 </div>

--- a/components/match/TimerDisplay.tsx
+++ b/components/match/TimerDisplay.tsx
@@ -44,7 +44,7 @@ export function TimerDisplay({
       <div
         data-testid="timer-display"
         className={[
-          "timer-display flex items-center justify-center rounded-lg font-mono font-black text-white",
+          "timer-display flex items-center justify-center rounded-lg font-mono font-black text-ink",
           sizeClasses,
           stateClass,
         ]

--- a/components/player/PlayerProfileModal.tsx
+++ b/components/player/PlayerProfileModal.tsx
@@ -93,15 +93,15 @@ export function PlayerProfileModal({
       aria-modal="true"
       aria-label="Player Profile"
     >
-      <div className="w-full max-w-sm rounded-2xl border border-white/10 bg-slate-900 p-6 shadow-2xl">
+      <div className="w-full max-w-sm rounded-2xl border border-hair bg-paper p-6 shadow-2xl">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-white">
+          <h2 className="text-lg font-semibold text-ink">
             Player Profile
           </h2>
           <button
             type="button"
             onClick={onClose}
-            className="text-white/60 hover:text-white"
+            className="text-ink-soft hover:text-ink"
             aria-label="Close"
           >
             ✕
@@ -109,7 +109,7 @@ export function PlayerProfileModal({
         </div>
 
         {loading && (
-          <p className="mt-4 text-sm text-white/60">Loading...</p>
+          <p className="mt-4 text-sm text-ink-soft">Loading...</p>
         )}
 
         {error && (
@@ -128,22 +128,22 @@ function ProfileContent({ profile }: { profile: PlayerProfile }) {
   return (
     <div className="mt-4 space-y-4">
       <div>
-        <p className="text-sm font-semibold text-white">
+        <p className="text-sm font-semibold text-ink">
           {identity.displayName}
         </p>
-        <p className="text-xs text-white/60">
+        <p className="text-xs text-ink-soft">
           @{identity.username}
         </p>
       </div>
 
       <div className="text-center">
         <p
-          className="text-4xl font-bold text-white"
+          className="text-4xl font-bold text-ink"
           data-testid="profile-elo"
         >
           {stats.eloRating}
         </p>
-        <p className="text-xs text-white/50">Elo Rating</p>
+        <p className="text-xs text-ink-soft">Elo Rating</p>
       </div>
 
       <div
@@ -180,8 +180,8 @@ function StatCell({
 }) {
   return (
     <div>
-      <p className="text-lg font-semibold text-white">{value}</p>
-      <p className="text-xs text-white/50">{label}</p>
+      <p className="text-lg font-semibold text-ink">{value}</p>
+      <p className="text-xs text-ink-soft">{label}</p>
     </div>
   );
 }
@@ -195,15 +195,15 @@ function TrendDisplay({ trend }: { trend: number[] }) {
       ? "text-emerald-400"
       : direction === "down"
         ? "text-rose-400"
-        : "text-white/60";
+        : "text-ink-soft";
 
   return (
     <div data-testid="profile-trend">
-      <p className="text-xs text-white/50">
+      <p className="text-xs text-ink-soft">
         Last {trend.length} games
       </p>
       <div className="mt-1 flex items-center gap-2">
-        <div className="flex gap-1 font-mono text-xs text-white/70">
+        <div className="flex gap-1 font-mono text-xs text-ink-3">
           {trend.map((rating, i) => (
             <span key={i}>{rating}</span>
           ))}

--- a/components/ui/GearMenu.tsx
+++ b/components/ui/GearMenu.tsx
@@ -29,7 +29,7 @@ export function GearMenu() {
         aria-label="Open settings"
         aria-expanded={open}
         onClick={handleToggle}
-        className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg p-2 text-white/60 hover:bg-white/10 hover:text-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+        className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg p-2 text-ink-soft hover:bg-paper-2 hover:text-ink-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink-soft"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/components/ui/SettingsPanel.tsx
+++ b/components/ui/SettingsPanel.tsx
@@ -22,7 +22,7 @@ function Toggle({
       className="flex items-center justify-between gap-4"
       style={{ padding: "12px 0" }}
     >
-      <span className="text-sm text-white/80">{label}</span>
+      <span className="text-sm text-ink-3">{label}</span>
       <button
         type="button"
         role="switch"
@@ -49,13 +49,13 @@ export function SettingsPanel({
 }: SettingsPanelProps) {
   return (
     <div
-      className="w-64 rounded-2xl border border-white/10 shadow-2xl"
-      style={{ backgroundColor: "#0f172a", padding: "20px 24px" }}
+      className="w-64 rounded-2xl border border-hair shadow-2xl bg-paper"
+      style={{ padding: "20px 24px" }}
       role="dialog"
       aria-label="Settings"
     >
       <h2
-        className="text-sm font-semibold uppercase tracking-wider text-white/40"
+        className="text-sm font-semibold uppercase tracking-wider text-ink-soft"
         style={{ marginBottom: "8px" }}
       >
         Settings

--- a/components/ui/TopBar.tsx
+++ b/components/ui/TopBar.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export function TopBar() {
+  return (
+    <header
+      data-testid="topbar"
+      className="sticky top-0 z-20 flex items-center justify-between border-b border-hair bg-paper/85 px-7 py-3.5 backdrop-blur-md"
+    >
+      <div className="flex items-baseline gap-2">
+        <span className="font-display text-[22px] italic leading-none tracking-tight text-ink">
+          Wottle
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-soft">
+          word · battle
+        </span>
+      </div>
+      <nav className="flex items-center gap-5 text-[13px] text-ink-3">
+        <Link href="/lobby" className="hover:text-ink">
+          Lobby
+        </Link>
+        <Link href="/profile" className="hover:text-ink">
+          Profile
+        </Link>
+      </nav>
+    </header>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,62 +1,118 @@
 import type { Config } from "tailwindcss";
 
+const INK = "oklch(0.22 0.025 258)";
+const INK_2 = "oklch(0.29 0.027 258)";
+const INK_3 = "oklch(0.38 0.024 258)";
+const INK_SOFT = "oklch(0.52 0.020 258)";
+
+const PAPER = "oklch(0.975 0.012 85)";
+const PAPER_2 = "oklch(0.955 0.014 82)";
+const PAPER_3 = "oklch(0.925 0.016 80)";
+
 const config: Config = {
   content: [
     "./app/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
     "./lib/**/*.{ts,tsx}",
-    "./tests/**/*.{ts,tsx}"
+    "./tests/**/*.{ts,tsx}",
   ],
   theme: {
     extend: {
       colors: {
+        /* New Warm Editorial families */
+        paper: {
+          DEFAULT: PAPER,
+          2: PAPER_2,
+          3: PAPER_3,
+        },
+        ink: {
+          DEFAULT: INK,
+          2: INK_2,
+          3: INK_3,
+          soft: INK_SOFT,
+        },
+        ochre: {
+          DEFAULT: "oklch(0.72 0.13 70)",
+          deep: "oklch(0.58 0.14 60)",
+          tint: "oklch(0.93 0.045 80)",
+        },
+        p1: {
+          DEFAULT: "oklch(0.68 0.14 60)",
+          tint: "oklch(0.92 0.06 70)",
+          deep: "oklch(0.48 0.14 55)",
+        },
+        p2: {
+          DEFAULT: "oklch(0.56 0.08 220)",
+          tint: "oklch(0.92 0.035 220)",
+          deep: "oklch(0.38 0.08 220)",
+        },
+        good: "oklch(0.62 0.12 150)",
+        warn: "oklch(0.70 0.15 40)",
+        bad: "oklch(0.58 0.17 25)",
+        hair: {
+          DEFAULT: `color-mix(in oklab, ${INK} 14%, transparent)`,
+          strong: `color-mix(in oklab, ${INK} 22%, transparent)`,
+        },
+
+        /* Legacy aliases — existing class names resolve to the new light palette */
         board: {
-          background: "#0f172a",
-          cell: "#1e293b",
-          highlight: "#38bdf8",
+          background: PAPER_3,
+          cell: PAPER,
+          highlight: "oklch(0.72 0.13 70)",
         },
         player: {
-          a: "#38BDF8",
-          b: "#EF4444",
+          a: "oklch(0.68 0.14 60)",
+          b: "oklch(0.56 0.08 220)",
         },
         brand: {
-          50: "#FBF3E0",
-          100: "#F5E4B8",
-          200: "#F0D48A",
-          300: "#ECC261",
-          400: "#E8B64C",
-          500: "#D9A130",
-          600: "#B8821F",
-          700: "#96671A",
-          800: "#6F4B12",
-          900: "#4A320C",
-          950: "#2D1E07",
+          50: "oklch(0.97 0.022 80)",
+          100: "oklch(0.94 0.04 80)",
+          200: "oklch(0.90 0.06 75)",
+          300: "oklch(0.84 0.09 72)",
+          400: "oklch(0.78 0.11 70)",
+          500: "oklch(0.72 0.13 70)",
+          600: "oklch(0.62 0.14 65)",
+          700: "oklch(0.52 0.14 60)",
+          800: "oklch(0.42 0.13 55)",
+          900: "oklch(0.32 0.10 50)",
+          950: "oklch(0.22 0.08 45)",
         },
         surface: {
-          0: "#0B1220",
-          1: "#141C2E",
-          2: "#1C2640",
-          3: "#253156",
+          0: PAPER,
+          1: PAPER_2,
+          2: PAPER_3,
+          3: PAPER_3,
         },
         text: {
-          primary: "#F2EAD3",
-          secondary: "#C7BDA3",
-          muted: "#8A8470",
-          inverse: "#0B1220",
+          primary: INK,
+          secondary: INK_3,
+          muted: INK_SOFT,
+          inverse: PAPER,
         },
         accent: {
-          focus: "#E8B64C",
-          warning: "#F59E0B",
-          success: "#10B981",
+          focus: "oklch(0.58 0.14 60)",
+          warning: "oklch(0.70 0.15 40)",
+          success: "oklch(0.62 0.12 150)",
         },
       },
       fontFamily: {
         display: ["var(--font-fraunces)", "serif"],
+        mono: [
+          "var(--font-jetbrains-mono)",
+          "JetBrains Mono",
+          "ui-monospace",
+          "monospace",
+        ],
       },
       transitionDuration: {
         swap: "200ms",
         shake: "350ms",
         highlight: "700ms",
+      },
+      boxShadow: {
+        "wottle-sm": "var(--shadow-sm)",
+        "wottle-md": "var(--shadow-md)",
+        "wottle-lg": "var(--shadow-lg)",
       },
     },
   },

--- a/tests/integration/ui/match-completion.spec.ts
+++ b/tests/integration/ui/match-completion.spec.ts
@@ -100,7 +100,7 @@ test.describe("Match completion — game-over screen (T034)", () => {
         }
 
         // Final summary should be visible
-        const summaryView = pageA.getByTestId("final-summary-view");
+        const summaryView = pageA.getByTestId("final-summary-root");
         await expect(summaryView).toBeVisible({ timeout: 30_000 });
 
         // Winner declaration OR draw banner must be visible

--- a/tests/integration/ui/round-history.spec.ts
+++ b/tests/integration/ui/round-history.spec.ts
@@ -106,7 +106,7 @@ test.describe("Round history panel (post-game)", () => {
       }
 
       // Wait for final summary page
-      const summaryView = pageA.getByTestId("final-summary-view");
+      const summaryView = pageA.getByTestId("final-summary-root");
       await expect(summaryView).toBeVisible({ timeout: 30_000 });
 
       // Verify board is rendered on summary page

--- a/tests/integration/ui/rounds-flow.spec.ts
+++ b/tests/integration/ui/rounds-flow.spec.ts
@@ -170,7 +170,7 @@ test.describe("Round flow", () => {
       }
 
       // After round 10, should see final summary (navigation + render can be slow in CI/Docker)
-      const summaryView = pageA.getByTestId("final-summary-view");
+      const summaryView = pageA.getByTestId("final-summary-root");
       await expect(summaryView).toBeVisible({ timeout: 30_000 });
 
       // Verify match ended properly

--- a/tests/integration/ui/theme-flip.spec.ts
+++ b/tests/integration/ui/theme-flip.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("@theme-flip Warm Editorial theme", () => {
+  test("lobby body background resolves to the paper token", async ({
+    page,
+  }) => {
+    await page.goto("/lobby");
+    const bodyBg = await page.evaluate(() =>
+      window.getComputedStyle(document.body).backgroundColor,
+    );
+    // OKLCH may serialize as an rgb(…) or oklch(…) depending on browser.
+    // Either way, lightness should be high — not the old #0B1220 navy.
+    expect(bodyBg).not.toMatch(/^rgb\(\s*11,\s*18,\s*32\s*\)$/);
+    expect(bodyBg).not.toBe("rgb(11, 18, 32)");
+    // Parse the colour, assert lightness > 0.8 via a simple heuristic:
+    const [, r = "0", g = "0", b = "0"] =
+      bodyBg.match(/rgb\((\d+),\s*(\d+),\s*(\d+)/) ?? [];
+    const luminance = 0.2126 * +r + 0.7152 * +g + 0.0722 * +b;
+    expect(luminance).toBeGreaterThan(200);
+  });
+
+  test("TopBar renders on lobby", async ({ page }) => {
+    await page.goto("/lobby");
+    const topbar = page.getByTestId("topbar");
+    await expect(topbar).toBeVisible();
+    await expect(topbar.getByText("Wottle")).toBeVisible();
+    await expect(topbar.getByText("word · battle")).toBeVisible();
+  });
+
+  test("TopBar is position: sticky", async ({ page }) => {
+    await page.goto("/lobby");
+    const position = await page
+      .getByTestId("topbar")
+      .evaluate((el) => window.getComputedStyle(el).position);
+    expect(position).toBe("sticky");
+  });
+});

--- a/tests/integration/ui/z-final-summary.spec.ts
+++ b/tests/integration/ui/z-final-summary.spec.ts
@@ -121,7 +121,7 @@ test.describe("Final summary recap", () => {
         }
       }
 
-      const summaryView = pageA.getByTestId("final-summary-view");
+      const summaryView = pageA.getByTestId("final-summary-root");
       await expect(summaryView).toBeVisible({ timeout: 30_000 });
 
       await expect(pageA.getByTestId("final-summary-scoreboard")).toBeVisible();

--- a/tests/unit/app/layout.test.tsx
+++ b/tests/unit/app/layout.test.tsx
@@ -23,4 +23,11 @@ describe("app/layout.tsx font wiring", () => {
       /className=\{`\$\{fraunces\.variable\}[^`]*\$\{jetbrainsMono\.variable\}`\}/,
     );
   });
+
+  test("imports and renders TopBar", () => {
+    expect(layoutSource).toMatch(
+      /import\s*\{\s*TopBar\s*\}\s*from\s*"@\/components\/ui\/TopBar"/,
+    );
+    expect(layoutSource).toMatch(/<TopBar\s*\/>/);
+  });
 });

--- a/tests/unit/app/layout.test.tsx
+++ b/tests/unit/app/layout.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const layoutSource = readFileSync(
+  resolve(__dirname, "../../../app/layout.tsx"),
+  "utf-8",
+);
+
+describe("app/layout.tsx font wiring", () => {
+  test("imports JetBrains_Mono from next/font/google", () => {
+    expect(layoutSource).toMatch(
+      /import\s*\{\s*[^}]*JetBrains_Mono[^}]*\}\s*from\s*"next\/font\/google"/,
+    );
+  });
+
+  test("constructs jetbrainsMono with variable --font-jetbrains-mono", () => {
+    expect(layoutSource).toMatch(/variable:\s*"--font-jetbrains-mono"/);
+  });
+
+  test("html element uses both font variables", () => {
+    expect(layoutSource).toMatch(
+      /className=\{`\$\{fraunces\.variable\}[^`]*\$\{jetbrainsMono\.variable\}`\}/,
+    );
+  });
+});

--- a/tests/unit/components/FinalSummary.test.tsx
+++ b/tests/unit/components/FinalSummary.test.tsx
@@ -168,4 +168,12 @@ describe("FinalSummary", () => {
     );
     expect(screen.queryByTestId("series-badge")).not.toBeInTheDocument();
   });
+
+  it("uses paper surface classes, not dark-mode", () => {
+    render(<FinalSummary {...makeProps()} />);
+    const summary = screen.getByTestId("final-summary-root");
+    expect(summary.className).not.toContain("bg-gray-");
+    expect(summary.className).not.toContain("bg-slate-");
+    expect(summary.className).toMatch(/bg-paper|bg-surface-0/);
+  });
 });

--- a/tests/unit/components/PlayerPanel.test.tsx
+++ b/tests/unit/components/PlayerPanel.test.tsx
@@ -32,6 +32,22 @@ describe("PlayerPanel full variant", () => {
     expect(screen.getByText("Alice Wonderland")).toBeInTheDocument();
   });
 
+  test("full variant uses paper surface and hair border", () => {
+    render(
+      <PlayerPanel
+        player={defaultPlayer}
+        gameState={defaultGameState}
+        variant="full"
+      />,
+    );
+
+    const panel = screen.getByTestId("player-panel");
+    expect(panel.className).toContain("bg-paper");
+    expect(panel.className).toContain("border-hair");
+    expect(panel.className).not.toContain("bg-gray-900");
+    expect(panel.className).not.toContain("border-white/10");
+  });
+
   test("truncates display name longer than 20 characters", () => {
     render(
       <PlayerPanel

--- a/tests/unit/components/game/TimerHud.test.tsx
+++ b/tests/unit/components/game/TimerHud.test.tsx
@@ -34,6 +34,6 @@ describe("TimerHud", () => {
     render(<TimerHud {...baseProps} hasSubmitted={true} />);
 
     const timerEl = screen.getByTestId("timer-display");
-    expect(timerEl).toHaveClass("text-slate-400");
+    expect(timerEl).toHaveClass("text-ink-soft");
   });
 });

--- a/tests/unit/components/ui/TopBar.test.tsx
+++ b/tests/unit/components/ui/TopBar.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { TopBar } from "@/components/ui/TopBar";
+
+describe("TopBar", () => {
+  test("renders the Wottle wordmark", () => {
+    render(<TopBar />);
+    expect(screen.getByText("Wottle")).toBeInTheDocument();
+  });
+
+  test("renders the tagline", () => {
+    render(<TopBar />);
+    expect(screen.getByText("word · battle")).toBeInTheDocument();
+  });
+
+  test("renders a link to /lobby labelled 'Lobby'", () => {
+    render(<TopBar />);
+    const lobbyLink = screen.getByRole("link", { name: /lobby/i });
+    expect(lobbyLink).toHaveAttribute("href", "/lobby");
+  });
+
+  test("renders a link to /profile labelled 'Profile'", () => {
+    render(<TopBar />);
+    const profileLink = screen.getByRole("link", { name: /profile/i });
+    expect(profileLink).toHaveAttribute("href", "/profile");
+  });
+
+  test("root element is sticky with top-0", () => {
+    render(<TopBar />);
+    const root = screen.getByTestId("topbar");
+    expect(root.className).toContain("sticky");
+    expect(root.className).toContain("top-0");
+  });
+
+  test("root element uses paper background with backdrop blur", () => {
+    render(<TopBar />);
+    const root = screen.getByTestId("topbar");
+    expect(root.className).toMatch(/bg-paper/);
+    expect(root.className).toMatch(/backdrop-blur/);
+  });
+});

--- a/tests/unit/styles/board-css.test.ts
+++ b/tests/unit/styles/board-css.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const boardCss = readFileSync(
+  resolve(__dirname, "../../../app/styles/board.css"),
+  "utf-8",
+);
+
+describe("board.css theme-flip audit", () => {
+  test("no hard-coded dark navy rgba(15, 23, 42, X) values", () => {
+    const darkNavyRgba = boardCss.match(/rgba\(15,\s*23,\s*42/g);
+    expect(darkNavyRgba).toBeNull();
+  });
+
+  test("no hard-coded cream/light rgba(248, 250, 252, X) values", () => {
+    const creamRgba = boardCss.match(/rgba\(248,\s*250,\s*252/g);
+    expect(creamRgba).toBeNull();
+  });
+
+  test("no hard-coded slate rgba(148, 163, 184, X) values", () => {
+    const slateRgba = boardCss.match(/rgba\(148,\s*163,\s*184/g);
+    expect(slateRgba).toBeNull();
+  });
+
+  test("no hard-coded pure white #fff or #ffffff", () => {
+    const whiteHex = boardCss.match(/#(?:fff|ffffff)/gi);
+    expect(whiteHex).toBeNull();
+  });
+
+  test("no hard-coded amber #ca8a04", () => {
+    const amberHex = boardCss.match(/#ca8a04/i);
+    expect(amberHex).toBeNull();
+  });
+
+  test("references var(--paper), var(--ink), or color-mix at least once", () => {
+    const hasTokens =
+      /var\(--(paper|ink)/.test(boardCss) ||
+      /color-mix\(/.test(boardCss);
+    expect(hasTokens).toBe(true);
+  });
+});

--- a/tests/unit/styles/board-css.test.ts
+++ b/tests/unit/styles/board-css.test.ts
@@ -7,36 +7,73 @@ const boardCss = readFileSync(
   "utf-8",
 );
 
+const DECLARED_TOKENS = new Set([
+  "--paper",
+  "--paper-2",
+  "--paper-3",
+  "--ink",
+  "--ink-2",
+  "--ink-3",
+  "--ink-soft",
+  "--ochre",
+  "--ochre-deep",
+  "--ochre-tint",
+  "--p1",
+  "--p1-tint",
+  "--p1-deep",
+  "--p2",
+  "--p2-tint",
+  "--p2-deep",
+  "--good",
+  "--warn",
+  "--bad",
+  "--hair",
+  "--hair-strong",
+  "--shadow-sm",
+  "--shadow-md",
+  "--shadow-lg",
+  "--font-inter",
+  "--font-fraunces",
+  "--font-jetbrains-mono",
+  "--font-sans",
+]);
+
 describe("board.css theme-flip audit", () => {
-  test("no hard-coded dark navy rgba(15, 23, 42, X) values", () => {
-    const darkNavyRgba = boardCss.match(/rgba\(15,\s*23,\s*42/g);
-    expect(darkNavyRgba).toBeNull();
+  test("no hard-coded navy or slate hex values", () => {
+    const navyHex = boardCss.match(
+      /#(0[Bb]1220|0[aA]1220|07101[Bb]|1[Ee]293[Bb]|0[Ff]172[Aa])/g,
+    );
+    expect(navyHex).toBeNull();
   });
 
-  test("no hard-coded cream/light rgba(248, 250, 252, X) values", () => {
-    const creamRgba = boardCss.match(/rgba\(248,\s*250,\s*252/g);
+  test("no cream-on-dark rgba usage", () => {
+    const creamRgba = boardCss.match(/rgba\(242,\s*234,\s*211/g);
     expect(creamRgba).toBeNull();
   });
 
-  test("no hard-coded slate rgba(148, 163, 184, X) values", () => {
-    const slateRgba = boardCss.match(/rgba\(148,\s*163,\s*184/g);
-    expect(slateRgba).toBeNull();
+  test("references var(--paper) or var(--ink) at least once", () => {
+    expect(boardCss).toMatch(/var\(--(paper|ink)/);
   });
 
-  test("no hard-coded pure white #fff or #ffffff", () => {
-    const whiteHex = boardCss.match(/#(?:fff|ffffff)/gi);
-    expect(whiteHex).toBeNull();
-  });
+  test("every var(--X) reference resolves to a declared token", () => {
+    // Allowlist for local scope variables (computed per-rule, not declared in globals.css)
+    const LOCAL_SCOPE_VARS = new Set([
+      "--board-grid-font-size",
+      "--board-grid-gap",
+      "--board-max-h",
+      "--board-size",
+      "--chrome-height",
+      "--highlight-color",
+    ]);
 
-  test("no hard-coded amber #ca8a04", () => {
-    const amberHex = boardCss.match(/#ca8a04/i);
-    expect(amberHex).toBeNull();
-  });
-
-  test("references var(--paper), var(--ink), or color-mix at least once", () => {
-    const hasTokens =
-      /var\(--(paper|ink)/.test(boardCss) ||
-      /color-mix\(/.test(boardCss);
-    expect(hasTokens).toBe(true);
+    const refs = Array.from(boardCss.matchAll(/var\((--[a-zA-Z0-9-]+)\)/g));
+    const undeclared = refs
+      .map((m) => m[1])
+      .filter(
+        (name) =>
+          !DECLARED_TOKENS.has(name) && !LOCAL_SCOPE_VARS.has(name),
+      );
+    const unique = Array.from(new Set(undeclared)).sort();
+    expect(unique, `Undeclared tokens: ${unique.join(", ")}`).toEqual([]);
   });
 });

--- a/tests/unit/styles/globals.test.ts
+++ b/tests/unit/styles/globals.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const globalsCss = readFileSync(
+  resolve(__dirname, "../../../app/globals.css"),
+  "utf-8",
+);
+
+describe("globals.css token declarations", () => {
+  test.each([
+    ["--paper"],
+    ["--paper-2"],
+    ["--paper-3"],
+    ["--ink"],
+    ["--ink-2"],
+    ["--ink-3"],
+    ["--ink-soft"],
+    ["--ochre"],
+    ["--ochre-deep"],
+    ["--ochre-tint"],
+    ["--p1"],
+    ["--p1-tint"],
+    ["--p1-deep"],
+    ["--p2"],
+    ["--p2-tint"],
+    ["--p2-deep"],
+    ["--good"],
+    ["--warn"],
+    ["--bad"],
+    ["--hair"],
+    ["--hair-strong"],
+    ["--shadow-sm"],
+    ["--shadow-md"],
+    ["--shadow-lg"],
+  ])("declares %s", (token) => {
+    expect(globalsCss).toMatch(new RegExp(`${token}\\s*:`));
+  });
+
+  test("uses light color-scheme", () => {
+    expect(globalsCss).toMatch(/color-scheme:\s*light/);
+  });
+
+  test("sets body background to var(--paper)", () => {
+    expect(globalsCss).toMatch(/background:\s*var\(--paper\)/);
+  });
+});

--- a/tests/unit/styles/lobby-css.test.ts
+++ b/tests/unit/styles/lobby-css.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const lobbyCss = readFileSync(
+  resolve(__dirname, "../../../app/styles/lobby.css"),
+  "utf-8",
+);
+
+describe("lobby.css light-mode flip", () => {
+  test("does not hard-code the dark navy base colour #0B1220", () => {
+    expect(lobbyCss).not.toMatch(/#0B1220/i);
+  });
+
+  test("does not hard-code the intermediate navy #0A1220", () => {
+    expect(lobbyCss).not.toMatch(/#0A1220/i);
+  });
+
+  test("does not hard-code the deep navy #07101B", () => {
+    expect(lobbyCss).not.toMatch(/#07101B/i);
+  });
+
+  test("references var(--paper) at least once", () => {
+    expect(lobbyCss).toMatch(/var\(--paper\)/);
+  });
+
+  test("references var(--ochre-tint) for halos", () => {
+    expect(lobbyCss).toMatch(/var\(--ochre-tint\)/);
+  });
+});

--- a/tests/unit/styles/tailwind-config.test.ts
+++ b/tests/unit/styles/tailwind-config.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+import config from "../../../tailwind.config";
+
+const colors = config.theme?.extend?.colors as Record<
+  string,
+  string | Record<string, string>
+>;
+
+describe("tailwind token extension — new Warm Editorial families", () => {
+  test("paper scale is declared", () => {
+    expect(colors.paper).toEqual({
+      DEFAULT: "oklch(0.975 0.012 85)",
+      2: "oklch(0.955 0.014 82)",
+      3: "oklch(0.925 0.016 80)",
+    });
+  });
+
+  test("ink scale is declared", () => {
+    expect(colors.ink).toMatchObject({
+      DEFAULT: "oklch(0.22 0.025 258)",
+      2: "oklch(0.29 0.027 258)",
+      3: "oklch(0.38 0.024 258)",
+      soft: "oklch(0.52 0.020 258)",
+    });
+  });
+
+  test("ochre family is declared", () => {
+    expect(colors.ochre).toMatchObject({
+      DEFAULT: "oklch(0.72 0.13 70)",
+      deep: "oklch(0.58 0.14 60)",
+      tint: "oklch(0.93 0.045 80)",
+    });
+  });
+
+  test("player families p1 and p2 declared", () => {
+    expect(colors.p1).toMatchObject({
+      DEFAULT: "oklch(0.68 0.14 60)",
+      tint: "oklch(0.92 0.06 70)",
+      deep: "oklch(0.48 0.14 55)",
+    });
+    expect(colors.p2).toMatchObject({
+      DEFAULT: "oklch(0.56 0.08 220)",
+      tint: "oklch(0.92 0.035 220)",
+      deep: "oklch(0.38 0.08 220)",
+    });
+  });
+
+  test("hair line colours declared", () => {
+    expect(colors.hair).toMatchObject({
+      DEFAULT: "color-mix(in oklab, oklch(0.22 0.025 258) 14%, transparent)",
+      strong: "color-mix(in oklab, oklch(0.22 0.025 258) 22%, transparent)",
+    });
+  });
+
+  test("legacy surface alias resolves to paper scale", () => {
+    expect(colors.surface).toMatchObject({
+      0: "oklch(0.975 0.012 85)",
+      1: "oklch(0.955 0.014 82)",
+      2: "oklch(0.925 0.016 80)",
+    });
+  });
+
+  test("legacy text alias resolves to ink scale", () => {
+    expect(colors.text).toMatchObject({
+      primary: "oklch(0.22 0.025 258)",
+      secondary: "oklch(0.38 0.024 258)",
+      muted: "oklch(0.52 0.020 258)",
+      inverse: "oklch(0.975 0.012 85)",
+    });
+  });
+
+  test("mono font family added", () => {
+    const fontFamily = config.theme?.extend?.fontFamily as Record<string, string[]>;
+    expect(fontFamily.mono).toEqual([
+      "var(--font-jetbrains-mono)",
+      "JetBrains Mono",
+      "ui-monospace",
+      "monospace",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1a of the Warm Editorial redesign ([design doc](docs/superpowers/specs/2026-04-19-wottle-design-implementation.md), [plan](docs/superpowers/plans/2026-04-19-phase-1a-theme-flip.md)). Flips the app from the dark-navy palette to the prototype's cream-paper-and-deep-ink light theme, and adds a persistent top bar.

- OKLCH token system in \`:root\` and Tailwind (paper / ink / ochre / p1 / p2 / hair / good / warn / bad + shadow-wottle-\*). Legacy \`surface\` / \`text\` / \`brand\` names aliased to the new light palette so existing class names keep resolving.
- JetBrains Mono wired via \`next/font/google\` → \`font-mono\` utility.
- Lobby ambient background re-painted (paper + ochre-tint halos + ink-tinted grid texture); \`board.css\` audited for hard-coded dark literals; \`PlayerPanel\`, \`FinalSummary\`, plus 15 other components swept for \`bg-gray-900\`/\`border-white/N\`/\`text-white\` and flipped to tokens.
- New sticky \`TopBar\` mounted in \`app/layout.tsx\` (Fraunces-italic "Wottle" + mono "word · battle" + Lobby/Profile nav).

## Test plan

- [x] \`pnpm test -- --run\` — 712 passing (2 skipped)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — zero warnings
- [x] \`pnpm exec playwright test --grep @theme-flip\` — 6/6 passing (chromium + firefox)
- [ ] Visual QA on \`/lobby\`, \`/match/[id]\`, \`/match/[id]/summary\` — look for any text that still reads poorly on paper. Phase 1b will follow up on faint emerald/sky tint text in \`RoundSummaryPanel\` that the reviewer flagged as borderline WCAG contrast.

## Scope note

Phase 1b (letterpress tile gradients, A–J / 1–10 coord labels, HUD classic refresh, round pip bar, left/right rail cards) is intentionally out of scope and will ship as a follow-up PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)