### PR TITLE
Phase 1b: letterpress tiles, coord labels, pip bar, tiles-claimed card

### DIFF
--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -62,22 +62,24 @@
   aspect-ratio: 1 / 1;
   min-width: 0;
   border-radius: 0.65rem;
-  border: 1px solid color-mix(in oklab, var(--ink) 20%, transparent);
-  background: radial-gradient(
-    circle at 30% 30%,
-    color-mix(in oklab, var(--paper) 14%, transparent),
-    color-mix(in oklab, var(--paper) 85%, transparent)
+  border: 1px solid color-mix(in oklab, var(--ink) 8%, transparent);
+  background: linear-gradient(
+    180deg,
+    var(--paper) 0%,
+    color-mix(in oklab, var(--paper-2) 95%, var(--paper)) 100%
   );
   color: var(--ink);
-  font-weight: 600;
+  font-weight: 500;
   font-size: var(--board-grid-font-size);
-  letter-spacing: 0; /* letter-spacing shifts single chars off-center; no spacing needed on tiles */
+  letter-spacing: 0;
   text-transform: uppercase;
   cursor: pointer;
-  overflow: visible; /* Safari: border-radius on <button> implicitly clips — force off */
+  overflow: visible;
   box-shadow:
-    inset 0 1px 0 color-mix(in oklab, var(--p1) 12%, transparent),
-    inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent);
+    inset 0 1px 0 color-mix(in oklab, #fff 80%, transparent),
+    inset 0 -1px 0 color-mix(in oklab, var(--ink) 10%, transparent),
+    inset 0 0 0 1px color-mix(in oklab, var(--ink) 8%, transparent),
+    0 1px 0 color-mix(in oklab, var(--ink) 6%, transparent);
   transition:
     transform 200ms ease-out,
     border-color 150ms ease,
@@ -112,11 +114,11 @@
 
 .board-grid__cell:hover,
 .board-grid__cell:focus-within {
-  border-color: color-mix(in oklab, var(--p1) 65%, transparent);
+  transform: translateY(-2px);
   box-shadow:
-    inset 0 1px 0 color-mix(in oklab, var(--p1) 18%, transparent),
-    0 12px 22px -18px color-mix(in oklab, var(--p1) 75%, transparent);
-  transform: translateY(-1px);
+    inset 0 1px 0 color-mix(in oklab, #fff 90%, transparent),
+    inset 0 0 0 1px color-mix(in oklab, var(--ochre-deep) 30%, transparent),
+    0 4px 10px color-mix(in oklab, var(--ink) 16%, transparent);
   outline: none;
 }
 

--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -639,3 +639,36 @@
     padding: clamp(0.4rem, 2.8vw, 0.6rem);
   }
 }
+
+/* Board coord labels (A–J columns, 1–10 rows) — Phase 1b */
+.board-coords {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
+  gap: 0.25rem 0.25rem;
+}
+.board-coords__top {
+  grid-column: 2;
+  grid-row: 1;
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  padding: 0 var(--board-grid-gap, 0.5rem);
+}
+.board-coords__left {
+  grid-column: 1;
+  grid-row: 2;
+  display: grid;
+  grid-template-rows: repeat(10, 1fr);
+  padding: var(--board-grid-gap, 0.5rem) 0;
+}
+.board-coords__top > span,
+.board-coords__left > span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.board-coords__board {
+  grid-column: 2;
+  grid-row: 2;
+  min-width: 0;
+}

--- a/components/game/Board.tsx
+++ b/components/game/Board.tsx
@@ -7,6 +7,7 @@ import type {
   MoveRequest,
   MoveResult,
 } from "@/lib/types/board";
+import { BoardCoordLabels } from "./BoardCoordLabels";
 import { BoardGrid } from "./BoardGrid";
 import {
   MoveFeedback,
@@ -95,12 +96,14 @@ export function Board({ initialGrid, matchId }: BoardProps) {
 
   return (
     <div className="space-y-4">
-      <BoardGrid
-        grid={grid}
-        matchId={matchId}
-        onSwapComplete={handleSwapComplete}
-        onSwapError={handleSwapError}
-      />
+      <BoardCoordLabels>
+        <BoardGrid
+          grid={grid}
+          matchId={matchId}
+          onSwapComplete={handleSwapComplete}
+          onSwapError={handleSwapError}
+        />
+      </BoardCoordLabels>
       <MoveFeedback feedback={feedback} onDismiss={dismissFeedback} />
     </div>
   );

--- a/components/game/BoardCoordLabels.tsx
+++ b/components/game/BoardCoordLabels.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+const COLS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"];
+const ROWS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+
+interface BoardCoordLabelsProps {
+  children: ReactNode;
+}
+
+export function BoardCoordLabels({ children }: BoardCoordLabelsProps) {
+  return (
+    <div className="board-coords">
+      <div
+        data-testid="board-coords-top"
+        className="board-coords__top font-mono text-[9px] uppercase tracking-[0.06em] text-ink-soft"
+      >
+        {COLS.map((c) => (
+          <span key={c} role="presentation">
+            {c}
+          </span>
+        ))}
+      </div>
+      <div
+        data-testid="board-coords-left"
+        className="board-coords__left font-mono text-[9px] uppercase tracking-[0.06em] text-ink-soft"
+      >
+        {ROWS.map((r) => (
+          <span key={r} role="presentation">
+            {r}
+          </span>
+        ))}
+      </div>
+      <div className="board-coords__board">{children}</div>
+    </div>
+  );
+}

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -7,6 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { BoardGrid } from "@/components/game/BoardGrid";
 import { PlayerPanel } from "@/components/match/PlayerPanel";
 import { RoundHistoryPanel } from "@/components/match/RoundHistoryPanel";
+import { TilesClaimedCard } from "@/components/match/TilesClaimedCard";
 import type { ScoreDelta } from "@/components/match/ScoreDeltaPopup";
 import { deriveScoreDelta } from "@/components/match/deriveScoreDelta";
 import { deriveHighlightPlayerColors } from "@/components/match/deriveHighlightPlayerColors";
@@ -802,7 +803,7 @@ export function MatchClient({
         </div>
 
         {/* Desktop: right panel (opponent) */}
-        <div className="match-layout__panel match-layout__panel--right">
+        <div className="match-layout__panel match-layout__panel--right flex flex-col gap-3">
           <PlayerPanel
             player={opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB}
             gameState={{
@@ -821,6 +822,10 @@ export function MatchClient({
             }}
             variant="full"
             isDisconnected={matchState.disconnectedPlayerId === opponentTimer.playerId}
+          />
+          <TilesClaimedCard
+            frozenTiles={matchState.frozenTiles ?? {}}
+            currentPlayerSlot={playerSlot}
           />
         </div>
       </div>

--- a/components/match/PlayerPanel.tsx
+++ b/components/match/PlayerPanel.tsx
@@ -2,6 +2,7 @@
 
 import { PlayerAvatar } from "./PlayerAvatar";
 import { TimerDisplay } from "./TimerDisplay";
+import { RoundPipBar } from "./RoundPipBar";
 import type { ScoreDelta } from "./ScoreDeltaPopup";
 import { ScoreDeltaPopup } from "./ScoreDeltaPopup";
 import { RoundHistoryInline } from "./RoundHistoryInline";
@@ -96,9 +97,12 @@ function FullPanel({
         )}
       </div>
 
-      <span data-testid="round-indicator" className="text-xs text-ink-soft">
-        Round {gameState.currentRound} / {gameState.totalRounds}
-      </span>
+      <div data-testid="round-indicator" className="w-full px-4">
+        <RoundPipBar
+          current={gameState.currentRound}
+          total={gameState.totalRounds}
+        />
+      </div>
 
       {isDisconnected && (
         <span className="rounded bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-300">

--- a/components/match/RoundPipBar.tsx
+++ b/components/match/RoundPipBar.tsx
@@ -1,0 +1,42 @@
+interface RoundPipBarProps {
+  current: number;
+  total: number;
+}
+
+function pipState(index: number, current: number): "done" | "current" | "future" {
+  if (index < current - 1) return "done";
+  if (index === current - 1) return "current";
+  return "future";
+}
+
+const PIP_CLASSES: Record<"done" | "current" | "future", string> = {
+  done: "h-[3px] bg-ink-2",
+  current: "h-[5px] bg-ochre-deep",
+  future: "h-[3px] bg-hair-strong",
+};
+
+export function RoundPipBar({ current, total }: RoundPipBarProps) {
+  return (
+    <div
+      data-testid="round-pip-bar"
+      role="progressbar"
+      aria-label={`Round ${current} of ${total}`}
+      aria-valuemin={1}
+      aria-valuemax={total}
+      aria-valuenow={current}
+      className="flex items-center gap-1"
+    >
+      {Array.from({ length: total }, (_, i) => {
+        const state = pipState(i, current);
+        return (
+          <span
+            key={i}
+            data-testid="round-pip"
+            data-state={state}
+            className={`w-[22px] rounded-[2px] transition-colors ${PIP_CLASSES[state]}`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/components/match/TilesClaimedCard.tsx
+++ b/components/match/TilesClaimedCard.tsx
@@ -1,0 +1,94 @@
+import type { FrozenTileMap, FrozenTileOwner } from "@/lib/types/match";
+
+interface TilesClaimedCardProps {
+  frozenTiles: FrozenTileMap;
+  currentPlayerSlot: FrozenTileOwner;
+  boardSize?: number;
+}
+
+function countByOwner(tiles: FrozenTileMap): Record<FrozenTileOwner, number> {
+  let a = 0;
+  let b = 0;
+  for (const key in tiles) {
+    if (tiles[key].owner === "player_a") a += 1;
+    else b += 1;
+  }
+  return { player_a: a, player_b: b };
+}
+
+export function TilesClaimedCard({
+  frozenTiles,
+  currentPlayerSlot,
+  boardSize = 100,
+}: TilesClaimedCardProps) {
+  const counts = countByOwner(frozenTiles);
+  const youCount = counts[currentPlayerSlot];
+  const oppSlot: FrozenTileOwner =
+    currentPlayerSlot === "player_a" ? "player_b" : "player_a";
+  const oppCount = counts[oppSlot];
+  const remaining = Math.max(0, boardSize - youCount - oppCount);
+
+  const youClass =
+    currentPlayerSlot === "player_a" ? "bg-p1" : "bg-p2";
+  const oppClass = currentPlayerSlot === "player_a" ? "bg-p2" : "bg-p1";
+
+  return (
+    <div
+      data-testid="tiles-claimed-card"
+      className="rounded-xl border border-hair bg-paper p-4 shadow-wottle-sm"
+    >
+      <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-soft">
+        Tiles claimed
+      </div>
+      <div className="mt-2 grid grid-cols-2 gap-3">
+        <div data-testid="tiles-claimed-you">
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-soft">
+            You
+          </div>
+          <div
+            className={`font-display text-[32px] italic leading-none ${
+              currentPlayerSlot === "player_a" ? "text-p1-deep" : "text-p2-deep"
+            }`}
+          >
+            {youCount}
+          </div>
+        </div>
+        <div data-testid="tiles-claimed-opponent">
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-soft">
+            Opponent
+          </div>
+          <div
+            className={`font-display text-[32px] italic leading-none ${
+              oppSlot === "player_a" ? "text-p1-deep" : "text-p2-deep"
+            }`}
+          >
+            {oppCount}
+          </div>
+        </div>
+      </div>
+      <div
+        data-testid="tiles-claimed-bar"
+        className="mt-3 flex h-1.5 gap-1 overflow-hidden rounded"
+      >
+        <div
+          data-testid="tiles-claimed-segment"
+          data-count={youCount}
+          className={youClass}
+          style={{ flex: youCount }}
+        />
+        <div
+          data-testid="tiles-claimed-segment"
+          data-count={oppCount}
+          className={oppClass}
+          style={{ flex: oppCount }}
+        />
+        <div
+          data-testid="tiles-claimed-segment"
+          data-count={remaining}
+          className="bg-paper-3"
+          style={{ flex: remaining }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/tests/integration/ui/match-surfaces.spec.ts
+++ b/tests/integration/ui/match-surfaces.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Phase 1b match-surfaces smoke tests
+ * Verifies that coord labels (A-J, 1-10), round pip bar, and tiles-claimed card
+ * are all visible and functional in a live two-player match.
+ */
+import { expect, test } from "@playwright/test";
+
+import {
+  generateTestUsername,
+  startMatchWithDirectInvite,
+} from "./helpers/matchmaking";
+
+async function loginPlayer(
+  page: import("@playwright/test").Page,
+  username: string,
+) {
+  await page.goto("/");
+  await page.getByTestId("lobby-username-input").fill(username);
+  await page.getByTestId("lobby-login-submit").click();
+  await page.waitForTimeout(1500);
+
+  const lobbyVisible = await page
+    .getByTestId("lobby-presence-list")
+    .isVisible()
+    .catch(() => false);
+
+  if (!lobbyVisible) {
+    await page.goto("/");
+  }
+
+  await expect(page.getByTestId("lobby-presence-list")).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(page.getByTestId("matchmaker-start-button")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe("@match-surfaces Phase 1b visuals", () => {
+  test("board edges show A-J and 1-10 coord labels", async ({ browser }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const userA = generateTestUsername("surfaces-alpha");
+      const userB = generateTestUsername("surfaces-beta");
+
+      await loginPlayer(pageA, userA);
+      await loginPlayer(pageB, userB);
+
+      await startMatchWithDirectInvite(pageA, pageB, {
+        timeoutMs: 120_000,
+        playerBUsername: userB,
+      });
+
+      // Verify top coord labels (A-J)
+      const top = pageA.getByTestId("board-coords-top");
+      await expect(top).toBeVisible();
+      await expect(top.getByText("A", { exact: true })).toBeVisible();
+      await expect(top.getByText("J", { exact: true })).toBeVisible();
+
+      // Verify left coord labels (1-10)
+      const left = pageA.getByTestId("board-coords-left");
+      await expect(left).toBeVisible();
+      await expect(left.getByText("1", { exact: true })).toBeVisible();
+      await expect(left.getByText("10", { exact: true })).toBeVisible();
+    } finally {
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+
+  test("player panel shows a pip progress bar", async ({ browser }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const userA = generateTestUsername("surfaces-gamma");
+      const userB = generateTestUsername("surfaces-delta");
+
+      await loginPlayer(pageA, userA);
+      await loginPlayer(pageB, userB);
+
+      await startMatchWithDirectInvite(pageA, pageB, {
+        timeoutMs: 120_000,
+        playerBUsername: userB,
+      });
+
+      // Verify pip bar exists and is visible
+      await expect(pageA.getByLabel(/Round \d+ of \d+/)).toBeVisible();
+      const pips = pageA.getByTestId("round-pip");
+      await expect(pips.first()).toBeVisible();
+    } finally {
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+
+  test("right rail shows the tiles-claimed card", async ({ browser }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const userA = generateTestUsername("surfaces-epsilon");
+      const userB = generateTestUsername("surfaces-zeta");
+
+      await loginPlayer(pageA, userA);
+      await loginPlayer(pageB, userB);
+
+      await startMatchWithDirectInvite(pageA, pageB, {
+        timeoutMs: 120_000,
+        playerBUsername: userB,
+      });
+
+      // Verify tiles-claimed card and its sections
+      const card = pageA.getByTestId("tiles-claimed-card");
+      await expect(card).toBeVisible();
+      await expect(card.getByText("Tiles claimed")).toBeVisible();
+      await expect(card.getByTestId("tiles-claimed-you")).toBeVisible();
+      await expect(card.getByTestId("tiles-claimed-opponent")).toBeVisible();
+    } finally {
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+});

--- a/tests/unit/components/PlayerPanel.test.tsx
+++ b/tests/unit/components/PlayerPanel.test.tsx
@@ -48,6 +48,18 @@ describe("PlayerPanel full variant", () => {
     expect(panel.className).not.toContain("border-white/10");
   });
 
+  test("full variant renders a RoundPipBar for progress", () => {
+    render(
+      <PlayerPanel
+        player={defaultPlayer}
+        gameState={{ ...defaultGameState, currentRound: 7, totalRounds: 10 }}
+        variant="full"
+      />,
+    );
+    expect(screen.getByLabelText("Round 7 of 10")).toBeInTheDocument();
+    expect(screen.queryByText("Round 7 / 10")).not.toBeInTheDocument();
+  });
+
   test("truncates display name longer than 20 characters", () => {
     render(
       <PlayerPanel
@@ -99,8 +111,7 @@ describe("PlayerPanel full variant", () => {
       />,
     );
 
-    expect(screen.getByText(/Round 3/)).toBeInTheDocument();
-    expect(screen.getByText(/10/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Round 3 of 10/)).toBeInTheDocument();
   });
 
   test("renders timer display", () => {

--- a/tests/unit/components/game/BoardCoordLabels.test.tsx
+++ b/tests/unit/components/game/BoardCoordLabels.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { BoardCoordLabels } from "@/components/game/BoardCoordLabels";
+
+describe("BoardCoordLabels", () => {
+  test("renders columns A through J", () => {
+    render(
+      <BoardCoordLabels>
+        <div data-testid="inner">inner</div>
+      </BoardCoordLabels>,
+    );
+    const cols = screen.getByTestId("board-coords-top");
+    expect(within(cols).getByText("A")).toBeInTheDocument();
+    expect(within(cols).getByText("J")).toBeInTheDocument();
+    expect(within(cols).getAllByRole("presentation")).toHaveLength(10);
+  });
+
+  test("renders rows 1 through 10", () => {
+    render(
+      <BoardCoordLabels>
+        <div data-testid="inner">inner</div>
+      </BoardCoordLabels>,
+    );
+    const rows = screen.getByTestId("board-coords-left");
+    expect(within(rows).getByText("1")).toBeInTheDocument();
+    expect(within(rows).getByText("10")).toBeInTheDocument();
+    expect(within(rows).getAllByRole("presentation")).toHaveLength(10);
+  });
+
+  test("renders the board child unchanged", () => {
+    render(
+      <BoardCoordLabels>
+        <div data-testid="inner">inner</div>
+      </BoardCoordLabels>,
+    );
+    expect(screen.getByTestId("inner")).toBeInTheDocument();
+  });
+
+  test("labels use the mono font utility", () => {
+    render(
+      <BoardCoordLabels>
+        <div />
+      </BoardCoordLabels>,
+    );
+    expect(screen.getByTestId("board-coords-top").className).toMatch(/font-mono/);
+    expect(screen.getByTestId("board-coords-left").className).toMatch(/font-mono/);
+  });
+});

--- a/tests/unit/components/game/BoardIntegration.test.tsx
+++ b/tests/unit/components/game/BoardIntegration.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@/components/game/BoardGrid", () => ({
+  BoardGrid: () => <div data-testid="board-grid-stub" />,
+}));
+
+import { Board } from "@/components/game/Board";
+
+const emptyGrid = Array.from({ length: 10 }, () =>
+  Array.from({ length: 10 }, () => "A"),
+) as string[][];
+
+describe("Board composition", () => {
+  test("wraps BoardGrid with BoardCoordLabels", () => {
+    render(<Board initialGrid={emptyGrid} matchId="m-1" />);
+    expect(screen.getByTestId("board-coords-top")).toBeInTheDocument();
+    expect(screen.getByTestId("board-coords-left")).toBeInTheDocument();
+    expect(screen.getByTestId("board-grid-stub")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/match/RoundPipBar.test.tsx
+++ b/tests/unit/components/match/RoundPipBar.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { RoundPipBar } from "@/components/match/RoundPipBar";
+
+describe("RoundPipBar", () => {
+  test("renders a pip per total rounds", () => {
+    render(<RoundPipBar current={1} total={10} />);
+    const bar = screen.getByTestId("round-pip-bar");
+    expect(within(bar).getAllByTestId("round-pip")).toHaveLength(10);
+  });
+
+  test("aria-label describes current/total", () => {
+    render(<RoundPipBar current={7} total={10} />);
+    expect(
+      screen.getByLabelText("Round 7 of 10"),
+    ).toBeInTheDocument();
+  });
+
+  test("pips before `current` have the done state", () => {
+    render(<RoundPipBar current={3} total={10} />);
+    const pips = screen.getAllByTestId("round-pip");
+    expect(pips[0].dataset.state).toBe("done");
+    expect(pips[1].dataset.state).toBe("done");
+  });
+
+  test("pip at index `current - 1` is the current pip", () => {
+    render(<RoundPipBar current={3} total={10} />);
+    const pips = screen.getAllByTestId("round-pip");
+    expect(pips[2].dataset.state).toBe("current");
+  });
+
+  test("pips after `current` have the future state", () => {
+    render(<RoundPipBar current={3} total={10} />);
+    const pips = screen.getAllByTestId("round-pip");
+    expect(pips[3].dataset.state).toBe("future");
+    expect(pips[9].dataset.state).toBe("future");
+  });
+
+  test("accepts total > 10", () => {
+    render(<RoundPipBar current={12} total={15} />);
+    const pips = screen.getAllByTestId("round-pip");
+    expect(pips).toHaveLength(15);
+    expect(pips[11].dataset.state).toBe("current");
+  });
+});

--- a/tests/unit/components/match/TilesClaimedCard.test.tsx
+++ b/tests/unit/components/match/TilesClaimedCard.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { TilesClaimedCard } from "@/components/match/TilesClaimedCard";
+import type { FrozenTileMap } from "@/lib/types/match";
+
+function frozen(ownerByKey: Record<string, "player_a" | "player_b">): FrozenTileMap {
+  return Object.fromEntries(
+    Object.entries(ownerByKey).map(([k, owner]) => [k, { owner }]),
+  );
+}
+
+describe("TilesClaimedCard", () => {
+  test("counts the current player's frozen tiles", () => {
+    const tiles = frozen({ "0,0": "player_a", "1,0": "player_a", "2,0": "player_b" });
+    render(
+      <TilesClaimedCard
+        frozenTiles={tiles}
+        currentPlayerSlot="player_a"
+      />,
+    );
+    const youBlock = screen.getByTestId("tiles-claimed-you");
+    const oppBlock = screen.getByTestId("tiles-claimed-opponent");
+    expect(youBlock).toHaveTextContent("2");
+    expect(oppBlock).toHaveTextContent("1");
+  });
+
+  test("swaps the perspective when current slot is player_b", () => {
+    const tiles = frozen({ "0,0": "player_a", "1,0": "player_a", "2,0": "player_b" });
+    render(
+      <TilesClaimedCard
+        frozenTiles={tiles}
+        currentPlayerSlot="player_b"
+      />,
+    );
+    expect(screen.getByTestId("tiles-claimed-you")).toHaveTextContent("1");
+    expect(screen.getByTestId("tiles-claimed-opponent")).toHaveTextContent("2");
+  });
+
+  test("renders three progress segments sized by count", () => {
+    const tiles = frozen({ "0,0": "player_a", "1,0": "player_a", "2,0": "player_b" });
+    render(
+      <TilesClaimedCard
+        frozenTiles={tiles}
+        currentPlayerSlot="player_a"
+        boardSize={100}
+      />,
+    );
+    const bar = screen.getByTestId("tiles-claimed-bar");
+    const segs = bar.querySelectorAll("[data-testid='tiles-claimed-segment']");
+    expect(segs).toHaveLength(3);
+    expect(segs[0].getAttribute("data-count")).toBe("2");
+    expect(segs[1].getAttribute("data-count")).toBe("1");
+    expect(segs[2].getAttribute("data-count")).toBe("97");
+  });
+
+  test("handles empty frozenTiles", () => {
+    render(
+      <TilesClaimedCard
+        frozenTiles={{}}
+        currentPlayerSlot="player_a"
+      />,
+    );
+    expect(screen.getByTestId("tiles-claimed-you")).toHaveTextContent("0");
+    expect(screen.getByTestId("tiles-claimed-opponent")).toHaveTextContent("0");
+  });
+});

--- a/tests/unit/styles/board-letterpress.test.ts
+++ b/tests/unit/styles/board-letterpress.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const boardCss = readFileSync(
+  resolve(__dirname, "../../../app/styles/board.css"),
+  "utf-8",
+);
+
+describe(".board-grid__cell letterpress treatment", () => {
+  test("uses a linear-gradient background (not radial) on the base cell", () => {
+    const match = boardCss.match(
+      /\.board-grid__cell\s*\{[^}]*?background:\s*linear-gradient\(/s,
+    );
+    expect(match).not.toBeNull();
+  });
+
+  test("declares the letterpress top-highlight inset shadow using #fff", () => {
+    expect(boardCss).toMatch(
+      /inset 0 1px 0 color-mix\(in oklab, #fff 80%, transparent\)/,
+    );
+  });
+
+  test("declares the letterpress bottom-shadow inset using var(--ink)", () => {
+    expect(boardCss).toMatch(
+      /inset 0 -1px 0 color-mix\(in oklab, var\(--ink\) 10%, transparent\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1b of the Warm Editorial redesign ([design doc](docs/superpowers/specs/2026-04-19-wottle-design-implementation.md), [plan](docs/superpowers/plans/2026-04-19-phase-1b-match-surfaces.md)). Additive visual polish on the in-match board; no layout restructuring.

- **Letterpress tile CSS** — `.board-grid__cell` swaps its radial-gradient + player-tinted insets for the prototype's two-stop linear gradient + letterpress inset stack (top #fff highlight, bottom ink shadow, thin ink outline, soft ground shadow). Hover lifts 2px with an ochre-deep accent ring.
- **A–J / 1–10 coord labels** — new `BoardCoordLabels` wrapper renders mono 9px column headers above the board and row labels to its left. Wired in `Board.tsx` so every match screen gets them.
- **`RoundPipBar`** — ten pips (done 3px ink-2, current 5px ochre-deep, future 3px hair-strong), `role="progressbar"` + `aria-label="Round N of M"`. Replaces the "Round N / 10" text in full-variant `PlayerPanel`. Compact variant keeps the text.
- **`TilesClaimedCard`** — derives per-player frozen-tile counts from `matchState.frozenTiles`, italic Fraunces numerals + three-segment (you / opponent / remaining) progress bar tinted to the p1/p2 palette. Mounted below the opponent panel in `MatchClient`'s right rail.

## Test plan

- [x] `pnpm test -- --run` — 731 passing (2 skipped)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — zero warnings
- [ ] `pnpm exec playwright test --grep @match-surfaces` — test file committed; wasn't executed locally because Supabase wasn't started. Will run in CI.
- [ ] Visual QA on `/match/[id]` after merge.

## Scope note

Phase 1c will cover the deferred HUD classic refresh (top-spanning HUD layout with left-stripe accent, italic Fraunces score, mono clock pill) and left-rail instructional cards (How to play, Legend, Your move). Those require `.match-layout` restructuring and are best shipped after this additive Phase 1b lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)