### PR TITLE
fix(deploy): remove type:module from package.json to unblock Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@10.28.0",
-  "type": "module",
   "pnpm": {
     "peerDependencyRules": {
       "allowedVersions": {


### PR DESCRIPTION
## Summary

Hotfix for the 500 error on production deploys: the Vercel runtime's CommonJS launcher (\`___next_launcher.cjs\`) \`require()\`s the compiled \`.next/server/app/page.js\`, which is being treated as ESM because of the root-level \`\"type\": \"module\"\` in \`package.json\`. Node refuses the \`require()\` with \`ERR_REQUIRE_ESM\` and every SSR route 500s.

Not introduced by PR #105 (Phase 1b); it's a latent regression from the Next.js 16.2.4 dep-bump on 2026-04-19 (\`9864da4\`). PR #105's deploy is simply the first one that triggered it.

## Fix

Remove \`\"type\": \"module\"\` from \`package.json\`. This is safe because every config file in the repo already uses an explicit extension:

- \`eslint.config.mjs\` — ESM
- \`postcss.config.cjs\` — CJS
- \`stylelint.config.mjs\` — ESM
- \`specs/003-word-engine-scoring/scripts/create-github-issues.mjs\` — ESM

No \`.js\` files we own rely on the implicit ESM-by-package-type behaviour.

## Test plan

- [x] \`pnpm test -- --run\` — 731 passing (2 skipped)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — zero warnings
- [x] \`pnpm build\` — successful production build
- [ ] Merge and watch Vercel deploy — expected to recover

## Follow-up

If we genuinely need ESM-for-\`.js\` in a future feature, switch to targeted \`.mjs\` files or dynamic \`import()\` rather than flipping the whole repo back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)