### PR TITLE
fix(match): restore frozen-tile visibility after letterpress change

### DIFF
--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -241,10 +241,15 @@
   }
 }
 
-/* Frozen tile: overlay behind text, no hover lift, letter stays readable */
+/* Frozen tile: overlay behind text, no hover lift, letter stays readable.
+ * Clear the letterpress linear-gradient so the inline `backgroundColor` set
+ * by React (FROZEN_COLORS[owner], a semi-transparent player tint) paints
+ * on top of the paper surface instead of being hidden behind the opaque
+ * gradient. Letterpress box-shadows still apply for the pressed-in feel. */
 .board-grid__cell--frozen {
   position: relative;
   cursor: not-allowed;
+  background-image: none;
 }
 
 .board-grid__cell--frozen .board-grid__tile {

--- a/tests/unit/styles/frozen-tile-visibility.test.ts
+++ b/tests/unit/styles/frozen-tile-visibility.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const boardCss = readFileSync(
+  resolve(__dirname, "../../../app/styles/board.css"),
+  "utf-8",
+);
+
+/**
+ * Regression guard for the Phase 1b letterpress change.
+ *
+ * `BoardGrid` sets the frozen-tile tint via an inline React
+ * `style={{ backgroundColor: FROZEN_COLORS[owner] }}`. The Phase 1b
+ * letterpress treatment on `.board-grid__cell` paints an opaque
+ * `linear-gradient(...)` as the cell background, which hides the
+ * inline backgroundColor unless `.board-grid__cell--frozen` explicitly
+ * clears `background-image`.
+ *
+ * If this test fails, frozen tiles will render as plain cream paper
+ * with no player-colour tint — a silent UX regression.
+ */
+describe("frozen-tile visibility", () => {
+  test(".board-grid__cell--frozen clears background-image so inline tint shows", () => {
+    const frozenBlock = boardCss.match(
+      /\.board-grid__cell--frozen\s*\{[^}]*\}/s,
+    );
+    expect(frozenBlock).not.toBeNull();
+    expect(frozenBlock?.[0]).toMatch(/background-image:\s*none/);
+  });
+});


### PR DESCRIPTION
## Summary

Regression from PR #105 (Phase 1b letterpress tiles). Frozen tiles render as plain cream paper with no player-colour indicator, hiding every claimed tile on the board.

## Root cause

\`BoardGrid\` tints frozen tiles via an inline React \`style={{ backgroundColor: FROZEN_COLORS[owner] }}\` — a semi-transparent rgba player colour.

- **Before Phase 1b**, \`.board-grid__cell\` had a semi-transparent radial gradient (\`color-mix(... transparent)\` stops). The inline \`backgroundColor\` painted underneath and bled through.
- **After Phase 1b**, the letterpress change swapped that for an *opaque* \`linear-gradient(var(--paper) → var(--paper-2))\`. The paper gradient completely covers the inline tint, so the frozen colour is set but invisible.

## Fix

Add \`background-image: none\` to \`.board-grid__cell--frozen\` so the inline rgba tint paints on top of the bare paper surface. The letterpress \`box-shadow\` inset stack is unaffected, preserving the pressed-in feel on frozen tiles.

## Regression guard

\`tests/unit/styles/frozen-tile-visibility.test.ts\` asserts the rule stays in place, with an inline comment pointing at the causal chain (inline-backgroundColor + opaque gradient → need for \`background-image: none\`).

## Test plan

- [x] \`pnpm test -- --run\` — 732 passing (2 skipped)
- [x] \`pnpm typecheck\` — clean
- [ ] Visual QA on \`/match/[id]\` after merge: every tile in \`Tiles claimed\` should show the player-colour tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)