### PR TITLE
fix(match): move TilesClaimedCard to current player's (left) rail

### DIFF
--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -687,7 +687,7 @@ export function MatchClient({
 
       <div className="match-layout">
         {/* Desktop: left panel (current player) */}
-        <div className="match-layout__panel match-layout__panel--left">
+        <div className="match-layout__panel match-layout__panel--left flex flex-col gap-3">
           <PlayerPanel
             player={playerSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB}
             gameState={{
@@ -717,6 +717,10 @@ export function MatchClient({
             }}
             variant="full"
             isDisconnected={matchState.disconnectedPlayerId === currentPlayerId}
+          />
+          <TilesClaimedCard
+            frozenTiles={matchState.frozenTiles ?? {}}
+            currentPlayerSlot={playerSlot}
           />
         </div>
 
@@ -803,7 +807,7 @@ export function MatchClient({
         </div>
 
         {/* Desktop: right panel (opponent) */}
-        <div className="match-layout__panel match-layout__panel--right flex flex-col gap-3">
+        <div className="match-layout__panel match-layout__panel--right">
           <PlayerPanel
             player={opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB}
             gameState={{
@@ -822,10 +826,6 @@ export function MatchClient({
             }}
             variant="full"
             isDisconnected={matchState.disconnectedPlayerId === opponentTimer.playerId}
-          />
-          <TilesClaimedCard
-            frozenTiles={matchState.frozenTiles ?? {}}
-            currentPlayerSlot={playerSlot}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Phase 1b mounted \`TilesClaimedCard\` in the right rail under the opponent panel. The card's labels are from the current player's perspective (\"You: N, Opponent: N\"), so the \"You\" number sat visually on the opponent's side of the board — the thing you're claiming is on the wrong side.

## Fix

Move \`<TilesClaimedCard />\` under the left-rail \`PlayerPanel\` (current player) so \"You\" is visually anchored to the current player's column. Right rail goes back to just the opponent panel.

Also adds \`flex flex-col gap-3\` to the left-rail container to stack cleanly; drops the same classes from the right rail now that it's single-child again.

## Test plan

- [x] \`pnpm test -- --run\` — 732 passing (2 skipped)
- [x] \`pnpm typecheck\` — clean
- [ ] Visual QA on \`/match/[id]\` — card appears under the current player's panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)