### PR TITLE
Phase 1c: HUD classic + layout restructure

### DIFF
--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -452,27 +452,55 @@
 
 @media (min-width: 900px) {
   .match-layout {
-    flex-direction: row;
-    align-items: flex-start;
-    justify-content: center;
+    display: grid;
+    grid-template-rows: auto 1fr;
     gap: 1rem;
   }
 
-  .match-layout__panel {
-    display: block;
-    width: 16rem;
-    flex-shrink: 0;
+  .match-layout__hud-strip {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 1.125rem;
+    align-items: center;
+  }
+
+  .match-layout__board-row {
+    display: grid;
+    grid-template-columns: 18rem auto 20rem;
+    gap: 1.5rem;
+    align-items: start;
+    justify-content: center;
+  }
+
+  .match-layout__rail--left {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-width: 0;
+  }
+
+  .match-layout__rail--right {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-width: 0;
   }
 
   .match-layout__board {
     --chrome-height: 48px;
     flex: 0 0 auto;
-    width: min(calc(100dvh - var(--chrome-height) - 2rem), calc(100% - 30rem));
+    width: min(calc(100dvh - var(--chrome-height) - 2rem), 38rem);
   }
 
   /* Hide compact bars on desktop */
   .match-layout__compact-top,
   .match-layout__compact-bottom {
+    display: none;
+  }
+
+  /* Legacy left/right panel classes — no longer rendered by MatchClient,
+     but kept so stray consumers render as hidden rather than breaking. */
+  .match-layout__panel {
     display: none;
   }
 }

--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -677,3 +677,98 @@
   grid-row: 2;
   min-width: 0;
 }
+
+/* ─── HUD card (Phase 1c) ───────────────────────────────────────────── */
+
+.hud-card {
+  position: relative;
+  padding: 16px 18px;
+  background: var(--paper);
+  border: 1px solid var(--hair);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.hud-card--you::after,
+.hud-card--opp::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  pointer-events: none;
+}
+
+.hud-card--you::after {
+  background: var(--p1);
+}
+
+.hud-card--opp::after {
+  background: var(--p2);
+}
+
+.hud-card__identity {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.hud-card__name {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--ink);
+  line-height: 1.1;
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hud-card__meta {
+  font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+  font-size: 10px;
+  color: var(--ink-soft);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-top: 3px;
+}
+
+.hud-card__score {
+  margin-left: auto;
+  font-family: var(--font-fraunces), serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 34px;
+  line-height: 1;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.hud-card__clock {
+  font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+  font-size: 15px;
+  letter-spacing: 0.04em;
+  color: var(--ink-2);
+  padding: 5px 10px;
+  border-radius: 6px;
+  background: var(--paper-2);
+  border: 1px solid var(--hair);
+  font-variant-numeric: tabular-nums;
+}
+
+.hud-card__clock--active {
+  background: color-mix(in oklab, var(--good) 15%, var(--paper));
+  color: color-mix(in oklab, var(--good) 80%, var(--ink));
+  border-color: color-mix(in oklab, var(--good) 40%, transparent);
+}
+
+.hud-card__clock--low {
+  background: color-mix(in oklab, var(--bad) 12%, var(--paper));
+  color: var(--bad);
+  border-color: color-mix(in oklab, var(--bad) 40%, transparent);
+}

--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -444,6 +444,20 @@
   display: none;
 }
 
+/* Phase 1c desktop layout pieces — hidden on mobile; desktop
+   media query below re-enables them with the grid/flex rules. */
+.match-layout__hud-strip,
+.match-layout__rail--left,
+.match-layout__rail--right {
+  display: none;
+}
+
+.match-layout__board-row {
+  /* On mobile the board-row is a plain block so the nested
+     board area flows beneath the compact top bar naturally. */
+  display: block;
+}
+
 /* Mobile compact bars (visible by default) */
 .match-layout__compact-top,
 .match-layout__compact-bottom {

--- a/components/match/HudCard.tsx
+++ b/components/match/HudCard.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+
+type ClockState = "idle" | "active" | "low";
+
+interface HudCardProps {
+  slot: "you" | "opp";
+  avatar: ReactNode;
+  name: string;
+  meta: string;
+  clock: string;
+  clockState?: ClockState;
+  score: number;
+  children?: ReactNode;
+}
+
+export function HudCard({
+  slot,
+  avatar,
+  name,
+  meta,
+  clock,
+  clockState = "idle",
+  score,
+  children,
+}: HudCardProps) {
+  const slotClass = slot === "you" ? "hud-card--you" : "hud-card--opp";
+  const clockStateClass =
+    clockState === "active"
+      ? "hud-card__clock--active"
+      : clockState === "low"
+        ? "hud-card__clock--low"
+        : "";
+
+  return (
+    <div data-testid="hud-card" className={`hud-card ${slotClass}`}>
+      {avatar}
+      <div className="hud-card__identity">
+        <span className="hud-card__name" title={name}>
+          {name}
+        </span>
+        <span className="hud-card__meta">{meta}</span>
+      </div>
+      <span
+        data-testid="hud-card-clock"
+        className={`hud-card__clock ${clockStateClass}`.trim()}
+      >
+        {clock}
+      </span>
+      <span className="hud-card__score">{score}</span>
+      {children}
+    </div>
+  );
+}

--- a/components/match/MatchCenterChrome.tsx
+++ b/components/match/MatchCenterChrome.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { RoundPipBar } from "./RoundPipBar";
+
+type MatchStatus = "your-move" | "waiting" | "resolving";
+
+interface MatchCenterChromeProps {
+  currentRound: number;
+  totalRounds: number;
+  status: MatchStatus;
+}
+
+const STATUS_LABELS: Record<MatchStatus, string> = {
+  "your-move": "YOUR MOVE · SWAP TWO TILES",
+  waiting: "WAITING FOR OPPONENT",
+  resolving: "RESOLVING ROUND",
+};
+
+export function MatchCenterChrome({
+  currentRound,
+  totalRounds,
+  status,
+}: MatchCenterChromeProps) {
+  return (
+    <div
+      data-testid="match-center-chrome"
+      className="flex flex-col items-center gap-2.5 px-4"
+    >
+      <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-soft">
+        Round {currentRound} / {totalRounds}
+      </span>
+      <RoundPipBar current={currentRound} total={totalRounds} />
+      <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-soft">
+        {STATUS_LABELS[status]}
+      </span>
+    </div>
+  );
+}

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -6,9 +6,13 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import { BoardGrid } from "@/components/game/BoardGrid";
 import { PlayerPanel } from "@/components/match/PlayerPanel";
+import { PlayerAvatar } from "@/components/match/PlayerAvatar";
 import { RoundHistoryPanel } from "@/components/match/RoundHistoryPanel";
 import { TilesClaimedCard } from "@/components/match/TilesClaimedCard";
+import { HudCard } from "@/components/match/HudCard";
+import { MatchCenterChrome } from "@/components/match/MatchCenterChrome";
 import type { ScoreDelta } from "@/components/match/ScoreDeltaPopup";
+import { ScoreDeltaPopup } from "@/components/match/ScoreDeltaPopup";
 import { deriveScoreDelta } from "@/components/match/deriveScoreDelta";
 import { deriveHighlightPlayerColors } from "@/components/match/deriveHighlightPlayerColors";
 import { deriveRoundHistory } from "@/components/match/deriveRoundHistory";
@@ -40,6 +44,22 @@ const POLL_ENDPOINT = (matchId: string) => `/api/match/${matchId}/state`;
 
 /** Interval for the background safety-net poller (runs alongside Realtime). */
 const SAFETY_POLL_INTERVAL_MS = 2_000;
+
+function formatClockMMSS(seconds: number): string {
+  const clamped = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(clamped / 60);
+  const s = clamped % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function deriveClockState(
+  isRunning: boolean,
+  isLow: boolean,
+): "idle" | "active" | "low" {
+  if (isLow) return "low";
+  if (isRunning) return "active";
+  return "idle";
+}
 
 /**
  * Fetch the latest match state from the REST endpoint.
@@ -547,6 +567,13 @@ export function MatchClient({
   const opponentSlot: "player_a" | "player_b" =
     playerSlot === "player_a" ? "player_b" : "player_a";
 
+  const centerStatus: "your-move" | "waiting" | "resolving" =
+    matchState.state === "resolving"
+      ? "resolving"
+      : currentTimer.status === "paused"
+        ? "waiting"
+        : "your-move";
+
   const playerScore =
     playerSlot === "player_a"
       ? matchState.scores.playerA
@@ -686,147 +713,178 @@ export function MatchClient({
       )}
 
       <div className="match-layout">
-        {/* Desktop: left panel (current player) */}
-        <div className="match-layout__panel match-layout__panel--left flex flex-col gap-3">
-          <PlayerPanel
-            player={playerSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB}
-            gameState={{
-              score: playerScore,
-              timerSeconds: timeLeftSeconds,
-              isPaused,
-              hasSubmitted: currentTimer.status === "paused",
-              currentRound: matchState.currentRound,
-              totalRounds: 10,
-              playerColor: getPlayerColors(playerSlot).hex,
-            }}
-            controls={{
-              scoreDelta,
-              scoreDeltaRound: matchState.lastSummary?.roundNumber,
-              roundHistoryCount: roundHistory.length,
-              onHistoryToggle: () => setHistoryOpen((v) => !v),
-              onResign: () => setShowResignDialog(true),
-              resignDisabled:
-                matchState.state === "resolving" ||
-                matchState.state === "completed" ||
-                isResigning,
-            }}
-            roundHistory={{
-              playerId: currentPlayerId,
-              accumulatedWords,
-              completedRounds,
-            }}
-            variant="full"
-            isDisconnected={matchState.disconnectedPlayerId === currentPlayerId}
+        {/* Desktop: top HUD strip (hidden on mobile) */}
+        <div className="match-layout__hud-strip hidden lg:grid">
+          <HudCard
+            slot="opp"
+            avatar={
+              <PlayerAvatar
+                displayName={(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).displayName}
+                avatarUrl={(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).avatarUrl}
+                playerColor={getPlayerColors(opponentSlot).hex}
+                size="sm"
+              />
+            }
+            name={(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).displayName}
+            meta={`Opponent · ${(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).eloRating || "Unrated"}`}
+            clock={formatClockMMSS(opponentTimeLeft)}
+            clockState={deriveClockState(opponentTimer.status === "running", opponentTimeLeft < 60)}
+            score={opponentScore}
           />
-          <TilesClaimedCard
-            frozenTiles={matchState.frozenTiles ?? {}}
-            currentPlayerSlot={playerSlot}
+          <MatchCenterChrome
+            currentRound={matchState.currentRound}
+            totalRounds={10}
+            status={centerStatus}
           />
+          <HudCard
+            slot="you"
+            avatar={
+              <PlayerAvatar
+                displayName={(playerSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).displayName}
+                avatarUrl={(playerSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).avatarUrl}
+                playerColor={getPlayerColors(playerSlot).hex}
+                size="sm"
+              />
+            }
+            name={(playerSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).displayName}
+            meta={`You · ${(playerSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).eloRating || "Unrated"}`}
+            clock={formatClockMMSS(timeLeftSeconds)}
+            clockState={deriveClockState(!isPaused, timeLeftSeconds < 60)}
+            score={playerScore}
+          >
+            {scoreDelta ? (
+              <ScoreDeltaPopup
+                key={matchState.lastSummary?.roundNumber}
+                delta={scoreDelta}
+              />
+            ) : null}
+          </HudCard>
         </div>
 
-        {/* Board area */}
-        <div className="match-layout__board">
-          {/* Mobile: compact opponent bar */}
-          <div className="match-layout__compact-top" data-testid="game-chrome-opponent">
-            <PlayerPanel
-              player={opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB}
-              gameState={{
-                score: opponentScore,
-                timerSeconds: opponentTimeLeft,
-                isPaused: opponentTimer.status !== "running",
-                hasSubmitted: opponentTimer.status === "paused",
-                currentRound: matchState.currentRound,
-                totalRounds: 10,
-                playerColor: getPlayerColors(opponentSlot).hex,
-              }}
-              variant="compact"
-              isDisconnected={matchState.disconnectedPlayerId === opponentTimer.playerId}
-            />
-          </div>
-
-          <BoardGrid
-            grid={matchState.board}
-            matchId={matchId}
-            frozenTiles={matchState.frozenTiles ?? {}}
-            playerSlot={playerSlot}
-            disabled={moveLocked}
-            showLockBanner={false}
-            lockedTiles={lockedSwapTiles}
-            opponentRevealTiles={
-              animationPhase === "round-recap" && activeRevealMove
-                ? [activeRevealMove.from, activeRevealMove.to]
-                : null
-            }
-            scoredTileHighlights={
-              animationPhase === "round-recap"
-                ? activeRevealHighlights
-                : []
-            }
-            highlightPlayerColors={
-              animationPhase === "round-recap"
-                ? highlightPlayerColors
-                : {}
-            }
-            highlightDurationMs={animationPhase === "round-recap" ? (matchState.state === "completed" ? 2400 : 1200) : 800}
-            highlightDelayMs={animationPhase === "round-recap" ? 450 : 0}
-            onSwapComplete={handleSwapComplete}
-            onSwapError={({ message }) => handleSwapError(message)}
-            onTileSelect={playTileSelect}
-            onValidSwap={() => { playValidSwap(); vibrateValidSwap(); }}
-            onInvalidMove={() => { playInvalidMove(); vibrateInvalidMove(); }}
+        <div className="match-layout__board-row">
+          {/* Left rail placeholder — Phase 1d fills it */}
+          <div
+            data-testid="match-layout-rail-left"
+            className="match-layout__rail--left hidden lg:flex"
           />
 
-          {roundAnnounce && (
-            <div
-              key={`${matchState.currentRound}-${roundAnnounce}`}
-              className={`round-announce${roundAnnounce === "Rounds Complete" ? " round-announce--final" : ""}`}
-              style={{ position: "absolute", top: "50%", left: "50%", zIndex: 25 }}
-              data-testid="round-announce"
-            >
-              {roundAnnounce}
+          <div className="match-layout__board">
+            {/* Mobile: compact opponent bar */}
+            <div className="match-layout__compact-top" data-testid="game-chrome-opponent">
+              <PlayerPanel
+                player={opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB}
+                gameState={{
+                  score: opponentScore,
+                  timerSeconds: opponentTimeLeft,
+                  isPaused: opponentTimer.status !== "running",
+                  hasSubmitted: opponentTimer.status === "paused",
+                  currentRound: matchState.currentRound,
+                  totalRounds: 10,
+                  playerColor: getPlayerColors(opponentSlot).hex,
+                }}
+                variant="compact"
+                isDisconnected={matchState.disconnectedPlayerId === opponentTimer.playerId}
+              />
             </div>
-          )}
 
-          {/* Mobile: compact player bar */}
-          <div className="match-layout__compact-bottom" data-testid="game-chrome-player">
-            <PlayerPanel
-              player={playerSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB}
-              gameState={{
-                score: playerScore,
-                timerSeconds: timeLeftSeconds,
-                isPaused,
-                hasSubmitted: currentTimer.status === "paused",
-                currentRound: matchState.currentRound,
-                totalRounds: 10,
-                playerColor: getPlayerColors(playerSlot).hex,
-              }}
-              variant="compact"
+            <BoardGrid
+              grid={matchState.board}
+              matchId={matchId}
+              frozenTiles={matchState.frozenTiles ?? {}}
+              playerSlot={playerSlot}
+              disabled={moveLocked}
+              showLockBanner={false}
+              lockedTiles={lockedSwapTiles}
+              opponentRevealTiles={
+                animationPhase === "round-recap" && activeRevealMove
+                  ? [activeRevealMove.from, activeRevealMove.to]
+                  : null
+              }
+              scoredTileHighlights={
+                animationPhase === "round-recap"
+                  ? activeRevealHighlights
+                  : []
+              }
+              highlightPlayerColors={
+                animationPhase === "round-recap"
+                  ? highlightPlayerColors
+                  : {}
+              }
+              highlightDurationMs={animationPhase === "round-recap" ? (matchState.state === "completed" ? 2400 : 1200) : 800}
+              highlightDelayMs={animationPhase === "round-recap" ? 450 : 0}
+              onSwapComplete={handleSwapComplete}
+              onSwapError={({ message }) => handleSwapError(message)}
+              onTileSelect={playTileSelect}
+              onValidSwap={() => { playValidSwap(); vibrateValidSwap(); }}
+              onInvalidMove={() => { playInvalidMove(); vibrateInvalidMove(); }}
             />
+
+            {roundAnnounce && (
+              <div
+                key={`${matchState.currentRound}-${roundAnnounce}`}
+                className={`round-announce${roundAnnounce === "Rounds Complete" ? " round-announce--final" : ""}`}
+                style={{ position: "absolute", top: "50%", left: "50%", zIndex: 25 }}
+                data-testid="round-announce"
+              >
+                {roundAnnounce}
+              </div>
+            )}
+
+            {/* Mobile: compact player bar */}
+            <div className="match-layout__compact-bottom" data-testid="game-chrome-player">
+              <PlayerPanel
+                player={playerSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB}
+                gameState={{
+                  score: playerScore,
+                  timerSeconds: timeLeftSeconds,
+                  isPaused,
+                  hasSubmitted: currentTimer.status === "paused",
+                  currentRound: matchState.currentRound,
+                  totalRounds: 10,
+                  playerColor: getPlayerColors(playerSlot).hex,
+                }}
+                variant="compact"
+              />
+            </div>
           </div>
 
-        </div>
-
-        {/* Desktop: right panel (opponent) */}
-        <div className="match-layout__panel match-layout__panel--right">
-          <PlayerPanel
-            player={opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB}
-            gameState={{
-              score: opponentScore,
-              timerSeconds: opponentTimeLeft,
-              isPaused: opponentTimer.status !== "running",
-              hasSubmitted: opponentTimer.status === "paused",
-              currentRound: matchState.currentRound,
-              totalRounds: 10,
-              playerColor: getPlayerColors(opponentSlot).hex,
-            }}
-            roundHistory={{
-              playerId: opponentTimer.playerId,
-              accumulatedWords,
-              completedRounds,
-            }}
-            variant="full"
-            isDisconnected={matchState.disconnectedPlayerId === opponentTimer.playerId}
-          />
+          {/* Right rail — current-player-side widgets */}
+          <div
+            data-testid="match-layout-rail-right"
+            className="match-layout__rail--right hidden lg:flex"
+          >
+            <TilesClaimedCard
+              frozenTiles={matchState.frozenTiles ?? {}}
+              currentPlayerSlot={playerSlot}
+            />
+            <div className="flex gap-2">
+              {roundHistory.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setHistoryOpen((v) => !v)}
+                  className="flex-1 rounded-lg border border-hair-strong px-3 py-2 text-sm text-ink-soft hover:bg-paper-2 hover:text-ink"
+                  data-testid="hud-history-button"
+                  aria-label="Round history"
+                >
+                  History ({roundHistory.length})
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setShowResignDialog(true)}
+                disabled={
+                  matchState.state === "resolving" ||
+                  matchState.state === "completed" ||
+                  isResigning
+                }
+                className="flex-1 rounded-lg border border-red-400/50 px-3 py-2 text-sm text-red-600 hover:bg-red-50 disabled:opacity-40"
+                data-testid="hud-resign-button"
+                aria-label="Resign match"
+              >
+                Resign
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -714,7 +714,7 @@ export function MatchClient({
 
       <div className="match-layout">
         {/* Desktop: top HUD strip (hidden on mobile) */}
-        <div className="match-layout__hud-strip hidden lg:grid">
+        <div className="match-layout__hud-strip">
           <HudCard
             slot="opp"
             avatar={
@@ -765,7 +765,7 @@ export function MatchClient({
           {/* Left rail placeholder — Phase 1d fills it */}
           <div
             data-testid="match-layout-rail-left"
-            className="match-layout__rail--left hidden lg:flex"
+            className="match-layout__rail--left"
           />
 
           <div className="match-layout__board">
@@ -851,7 +851,7 @@ export function MatchClient({
           {/* Right rail — current-player-side widgets */}
           <div
             data-testid="match-layout-rail-right"
-            className="match-layout__rail--right hidden lg:flex"
+            className="match-layout__rail--right"
           >
             <TilesClaimedCard
               frozenTiles={matchState.frozenTiles ?? {}}

--- a/components/match/PlayerPanel.tsx
+++ b/components/match/PlayerPanel.tsx
@@ -2,7 +2,6 @@
 
 import { PlayerAvatar } from "./PlayerAvatar";
 import { TimerDisplay } from "./TimerDisplay";
-import { RoundPipBar } from "./RoundPipBar";
 import type { ScoreDelta } from "./ScoreDeltaPopup";
 import { ScoreDeltaPopup } from "./ScoreDeltaPopup";
 import { RoundHistoryInline } from "./RoundHistoryInline";
@@ -97,12 +96,9 @@ function FullPanel({
         )}
       </div>
 
-      <div data-testid="round-indicator" className="w-full px-4">
-        <RoundPipBar
-          current={gameState.currentRound}
-          total={gameState.totalRounds}
-        />
-      </div>
+      <span data-testid="round-indicator" className="text-xs text-ink-soft">
+        Round {gameState.currentRound} / {gameState.totalRounds}
+      </span>
 
       {isDisconnected && (
         <span className="rounded bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-300">

--- a/tests/integration/ui/hud-classic.spec.ts
+++ b/tests/integration/ui/hud-classic.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Phase 1c HUD Smoke Test
+ * Verifies that the classic HUD layout is in place with:
+ * - Two HUD cards in the top strip (opponent and you)
+ * - Centre chrome between them
+ * - Right rail with tiles-claimed card and History/Resign buttons
+ * - Left rail placeholder (to be filled in Phase 1d)
+ */
+import { expect, test } from "@playwright/test";
+
+import {
+  generateTestUsername,
+  startMatchWithDirectInvite,
+} from "./helpers/matchmaking";
+
+async function loginPlayer(
+  page: import("@playwright/test").Page,
+  username: string,
+) {
+  await page.goto("/");
+  await page.getByTestId("lobby-username-input").fill(username);
+  await page.getByTestId("lobby-login-submit").click();
+  await page.waitForTimeout(1500);
+
+  const lobbyVisible = await page
+    .getByTestId("lobby-presence-list")
+    .isVisible()
+    .catch(() => false);
+
+  if (!lobbyVisible) {
+    await page.goto("/");
+  }
+
+  await expect(page.getByTestId("lobby-presence-list")).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(page.getByTestId("matchmaker-start-button")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe("@hud-classic Phase 1c HUD", () => {
+  test("top strip shows two HUD cards and a centre chrome", async ({
+    browser,
+  }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const userA = generateTestUsername("hud-alpha");
+      const userB = generateTestUsername("hud-beta");
+
+      await loginPlayer(pageA, userA);
+      await loginPlayer(pageB, userB);
+
+      const [matchIdA, matchIdB] = await startMatchWithDirectInvite(pageA, pageB, {
+        timeoutMs: 60_000,
+        playerBUsername: userB,
+      });
+      expect(matchIdA).toBeTruthy();
+      expect(matchIdA).toEqual(matchIdB);
+
+      await expect(pageA.getByTestId("match-shell")).toBeVisible({
+        timeout: 10_000,
+      });
+
+      await expect(pageA.getByTestId("match-center-chrome")).toBeVisible();
+      const hudCards = pageA.getByTestId("hud-card");
+      await expect(hudCards).toHaveCount(2);
+    } finally {
+      await pageA.close();
+      await pageB.close();
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+
+  test("HUD cards carry slot-coloured left stripe classes", async ({
+    browser,
+  }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const userA = generateTestUsername("hud-stripe-alpha");
+      const userB = generateTestUsername("hud-stripe-beta");
+
+      await loginPlayer(pageA, userA);
+      await loginPlayer(pageB, userB);
+
+      const [matchIdA, matchIdB] = await startMatchWithDirectInvite(pageA, pageB, {
+        timeoutMs: 60_000,
+        playerBUsername: userB,
+      });
+      expect(matchIdA).toBeTruthy();
+      expect(matchIdA).toEqual(matchIdB);
+
+      await expect(pageA.getByTestId("match-shell")).toBeVisible({
+        timeout: 10_000,
+      });
+
+      const cards = pageA.getByTestId("hud-card");
+      const firstClass = await cards.nth(0).getAttribute("class");
+      const secondClass = await cards.nth(1).getAttribute("class");
+      expect(firstClass).toMatch(/hud-card--opp/);
+      expect(secondClass).toMatch(/hud-card--you/);
+    } finally {
+      await pageA.close();
+      await pageB.close();
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+
+  test("right rail shows tiles-claimed and History+Resign buttons", async ({
+    browser,
+  }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const userA = generateTestUsername("hud-rail-alpha");
+      const userB = generateTestUsername("hud-rail-beta");
+
+      await loginPlayer(pageA, userA);
+      await loginPlayer(pageB, userB);
+
+      const [matchIdA, matchIdB] = await startMatchWithDirectInvite(pageA, pageB, {
+        timeoutMs: 60_000,
+        playerBUsername: userB,
+      });
+      expect(matchIdA).toBeTruthy();
+      expect(matchIdA).toEqual(matchIdB);
+
+      await expect(pageA.getByTestId("match-shell")).toBeVisible({
+        timeout: 10_000,
+      });
+
+      const rightRail = pageA.getByTestId("match-layout-rail-right");
+      await expect(rightRail).toBeVisible();
+      await expect(rightRail.getByTestId("tiles-claimed-card")).toBeVisible();
+      await expect(rightRail.getByTestId("hud-resign-button")).toBeVisible();
+    } finally {
+      await pageA.close();
+      await pageB.close();
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+
+  test("left rail placeholder is present (Phase 1d will fill it)", async ({
+    browser,
+  }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const userA = generateTestUsername("hud-left-alpha");
+      const userB = generateTestUsername("hud-left-beta");
+
+      await loginPlayer(pageA, userA);
+      await loginPlayer(pageB, userB);
+
+      const [matchIdA, matchIdB] = await startMatchWithDirectInvite(pageA, pageB, {
+        timeoutMs: 60_000,
+        playerBUsername: userB,
+      });
+      expect(matchIdA).toBeTruthy();
+      expect(matchIdA).toEqual(matchIdB);
+
+      await expect(pageA.getByTestId("match-shell")).toBeVisible({
+        timeout: 10_000,
+      });
+
+      await expect(pageA.getByTestId("match-layout-rail-left")).toBeVisible();
+    } finally {
+      await pageA.close();
+      await pageB.close();
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+});

--- a/tests/unit/components/MatchClient.test.tsx
+++ b/tests/unit/components/MatchClient.test.tsx
@@ -420,7 +420,7 @@ describe("MatchClient animation phase machine (US2)", () => {
     expect(screen.queryByTestId("round-summary-panel")).not.toBeInTheDocument();
   });
 
-  test("no overlay is rendered after 1200ms — round data appears inline in player panel", async () => {
+  test("no overlay is rendered after 1200ms — animation phase transitions back to idle", async () => {
     const { MatchClient } = await import("@/components/match/MatchClient");
 
     await act(async () => {
@@ -444,8 +444,9 @@ describe("MatchClient animation phase machine (US2)", () => {
 
     // No overlay
     expect(screen.queryByTestId("round-summary-panel")).not.toBeInTheDocument();
-    // Inline round history appears in player panels
-    expect(screen.getAllByTestId("round-history-inline").length).toBeGreaterThan(0);
+    // Animation phase returned to idle — scored tile highlights cleared
+    const scoredTiles = document.querySelectorAll(".board-grid__cell--scored");
+    expect(scoredTiles).toHaveLength(0);
   });
 
   test("scoredTileHighlights passed to BoardGrid is populated from pendingSummary during highlighting phase", async () => {
@@ -505,7 +506,7 @@ describe("MatchClient reduced-motion bypass (US3)", () => {
     });
   });
 
-  test("no overlay rendered with reduced motion — inline history appears immediately", async () => {
+  test("no overlay rendered with reduced motion — animation phase skipped immediately", async () => {
     const { MatchClient } = await import("@/components/match/MatchClient");
 
     await act(async () => {
@@ -523,9 +524,11 @@ describe("MatchClient reduced-motion bypass (US3)", () => {
       mockMatchCallbacks.onSummary!(mockRoundSummary);
     });
 
-    // No overlay — inline history is shown instead
+    // No overlay — reduced motion skips the animation phase entirely
     expect(screen.queryByTestId("round-summary-panel")).not.toBeInTheDocument();
-    expect(screen.getAllByTestId("round-history-inline").length).toBeGreaterThan(0);
+    // No scored tiles because highlighting phase was bypassed
+    const scoredTiles = document.querySelectorAll(".board-grid__cell--scored");
+    expect(scoredTiles).toHaveLength(0);
   });
 
   test("highlight animation is skipped when reduced motion is active", async () => {
@@ -690,8 +693,9 @@ describe("MatchClient round-recap flash (US1)", () => {
 
     // No overlay ever appears
     expect(screen.queryByTestId("round-summary-panel")).not.toBeInTheDocument();
-    // Inline history shows the round data
-    expect(screen.getAllByTestId("round-history-inline").length).toBeGreaterThan(0);
+    // Animation phase returned to idle — scored tile highlights cleared
+    const scoredTilesAfter = document.querySelectorAll(".board-grid__cell--scored");
+    expect(scoredTilesAfter).toHaveLength(0);
   });
 
   test("T015: opponent's swapped tiles get opponent-reveal class during round-recap phase", async () => {

--- a/tests/unit/components/PlayerPanel.test.tsx
+++ b/tests/unit/components/PlayerPanel.test.tsx
@@ -48,7 +48,7 @@ describe("PlayerPanel full variant", () => {
     expect(panel.className).not.toContain("border-white/10");
   });
 
-  test("full variant renders a RoundPipBar for progress", () => {
+  test("full variant renders 'Round N / M' text (pip bar moved to MatchCenterChrome)", () => {
     render(
       <PlayerPanel
         player={defaultPlayer}
@@ -56,8 +56,8 @@ describe("PlayerPanel full variant", () => {
         variant="full"
       />,
     );
-    expect(screen.getByLabelText("Round 7 of 10")).toBeInTheDocument();
-    expect(screen.queryByText("Round 7 / 10")).not.toBeInTheDocument();
+    expect(screen.getByText("Round 7 / 10")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Round 7 of 10")).not.toBeInTheDocument();
   });
 
   test("truncates display name longer than 20 characters", () => {
@@ -111,7 +111,7 @@ describe("PlayerPanel full variant", () => {
       />,
     );
 
-    expect(screen.getByLabelText(/Round 3 of 10/)).toBeInTheDocument();
+    expect(screen.getByText("Round 3 / 10")).toBeInTheDocument();
   });
 
   test("renders timer display", () => {

--- a/tests/unit/components/match/HudCard.test.tsx
+++ b/tests/unit/components/match/HudCard.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { HudCard } from "@/components/match/HudCard";
+
+describe("HudCard", () => {
+  test("renders name, meta, score, clock", () => {
+    render(
+      <HudCard
+        slot="you"
+        avatar={<div data-testid="avatar" />}
+        name="Ásta Kristín"
+        meta="White · 1728"
+        clock="2:00"
+        score={198}
+      />,
+    );
+    expect(screen.getByText("Ásta Kristín")).toBeInTheDocument();
+    expect(screen.getByText("White · 1728")).toBeInTheDocument();
+    expect(screen.getByText("2:00")).toBeInTheDocument();
+    expect(screen.getByText("198")).toBeInTheDocument();
+    expect(screen.getByTestId("avatar")).toBeInTheDocument();
+  });
+
+  test("applies hud-card--you for current player", () => {
+    render(
+      <HudCard
+        slot="you"
+        avatar={<div />}
+        name="You"
+        meta="m"
+        clock="0:00"
+        score={0}
+      />,
+    );
+    const card = screen.getByTestId("hud-card");
+    expect(card.className).toContain("hud-card--you");
+    expect(card.className).not.toContain("hud-card--opp");
+  });
+
+  test("applies hud-card--opp for opponent", () => {
+    render(
+      <HudCard
+        slot="opp"
+        avatar={<div />}
+        name="Them"
+        meta="m"
+        clock="0:00"
+        score={0}
+      />,
+    );
+    const card = screen.getByTestId("hud-card");
+    expect(card.className).toContain("hud-card--opp");
+  });
+
+  test("supports active/low clock states", () => {
+    const { rerender } = render(
+      <HudCard
+        slot="you"
+        avatar={<div />}
+        name="Y"
+        meta="m"
+        clock="2:00"
+        clockState="active"
+        score={0}
+      />,
+    );
+    expect(screen.getByTestId("hud-card-clock").className).toContain(
+      "hud-card__clock--active",
+    );
+
+    rerender(
+      <HudCard
+        slot="you"
+        avatar={<div />}
+        name="Y"
+        meta="m"
+        clock="0:30"
+        clockState="low"
+        score={0}
+      />,
+    );
+    expect(screen.getByTestId("hud-card-clock").className).toContain(
+      "hud-card__clock--low",
+    );
+  });
+
+  test("renders children below identity block when provided", () => {
+    render(
+      <HudCard
+        slot="you"
+        avatar={<div />}
+        name="Y"
+        meta="m"
+        clock="0:00"
+        score={0}
+      >
+        <button data-testid="extra">Resign</button>
+      </HudCard>,
+    );
+    expect(screen.getByTestId("extra")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/match/MatchCenterChrome.test.tsx
+++ b/tests/unit/components/match/MatchCenterChrome.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { MatchCenterChrome } from "@/components/match/MatchCenterChrome";
+
+describe("MatchCenterChrome", () => {
+  test("renders the eyebrow with current/total rounds", () => {
+    render(
+      <MatchCenterChrome
+        currentRound={3}
+        totalRounds={10}
+        status="your-move"
+      />,
+    );
+    expect(screen.getByText("Round 3 / 10")).toBeInTheDocument();
+  });
+
+  test("renders the shared RoundPipBar", () => {
+    render(
+      <MatchCenterChrome
+        currentRound={3}
+        totalRounds={10}
+        status="your-move"
+      />,
+    );
+    expect(screen.getByLabelText("Round 3 of 10")).toBeInTheDocument();
+  });
+
+  test.each([
+    ["your-move", "YOUR MOVE · SWAP TWO TILES"],
+    ["waiting", "WAITING FOR OPPONENT"],
+    ["resolving", "RESOLVING ROUND"],
+  ] as const)("status=%s renders label %s", (status, expected) => {
+    render(
+      <MatchCenterChrome
+        currentRound={1}
+        totalRounds={10}
+        status={status}
+      />,
+    );
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/styles/hud-card-css.test.ts
+++ b/tests/unit/styles/hud-card-css.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const boardCss = readFileSync(
+  resolve(__dirname, "../../../app/styles/board.css"),
+  "utf-8",
+);
+
+describe(".hud-card CSS", () => {
+  test("declares .hud-card with paper background and hair border", () => {
+    const block = boardCss.match(/\.hud-card\s*\{[^}]*\}/s);
+    expect(block).not.toBeNull();
+    expect(block?.[0]).toMatch(/background:\s*var\(--paper\)/);
+    expect(block?.[0]).toMatch(/border:\s*1px solid var\(--hair\)/);
+  });
+
+  test("declares .hud-card--you::after stripe using var(--p1)", () => {
+    expect(boardCss).toMatch(
+      /\.hud-card--you::after\s*\{[^}]*background:\s*var\(--p1\)/s,
+    );
+  });
+
+  test("declares .hud-card--opp::after stripe using var(--p2)", () => {
+    expect(boardCss).toMatch(
+      /\.hud-card--opp::after\s*\{[^}]*background:\s*var\(--p2\)/s,
+    );
+  });
+
+  test("declares .hud-card__score with font-display italic", () => {
+    const block = boardCss.match(/\.hud-card__score\s*\{[^}]*\}/s);
+    expect(block).not.toBeNull();
+    expect(block?.[0]).toMatch(/font-family:\s*var\(--font-fraunces\)/);
+    expect(block?.[0]).toMatch(/font-style:\s*italic/);
+  });
+
+  test("declares .hud-card__clock with mono font + tabular-nums", () => {
+    const block = boardCss.match(/\.hud-card__clock\s*\{[^}]*\}/s);
+    expect(block).not.toBeNull();
+    expect(block?.[0]).toMatch(/font-variant-numeric:\s*tabular-nums/);
+  });
+});

--- a/tests/unit/styles/match-layout-css.test.ts
+++ b/tests/unit/styles/match-layout-css.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const boardCss = readFileSync(
+  resolve(__dirname, "../../../app/styles/board.css"),
+  "utf-8",
+);
+
+describe(".match-layout Phase 1c structure", () => {
+  test("declares .match-layout__hud-strip for top HUD", () => {
+    expect(boardCss).toMatch(/\.match-layout__hud-strip\s*\{/);
+  });
+
+  test("declares .match-layout__board-row for below the HUD", () => {
+    expect(boardCss).toMatch(/\.match-layout__board-row\s*\{/);
+  });
+
+  test("declares .match-layout__rail--left and --right", () => {
+    expect(boardCss).toMatch(/\.match-layout__rail--left\s*\{/);
+    expect(boardCss).toMatch(/\.match-layout__rail--right\s*\{/);
+  });
+
+  test("hud-strip uses grid 1fr auto 1fr on desktop", () => {
+    const desktopBlock = boardCss.match(
+      /@media\s*\(min-width:\s*900px\)\s*\{[\s\S]*?\n\}/,
+    );
+    expect(desktopBlock).not.toBeNull();
+    expect(desktopBlock?.[0]).toMatch(
+      /\.match-layout__hud-strip\s*\{[^}]*grid-template-columns:\s*1fr auto 1fr/s,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1c of the Warm Editorial redesign ([design doc](docs/superpowers/specs/2026-04-19-wottle-design-implementation.md), [plan](docs/superpowers/plans/2026-04-20-phase-1c-hud-classic.md)). Restructures the match screen into a top-spanning horizontal HUD strip (opponent · centre chrome · current player) plus a bottom row (left-rail placeholder · board · right rail). Delivers the prototype's Warm Editorial \`.hud-card\` look.

- **\`.hud-card\` CSS** — paper surface, hair border, slot-coloured left stripe (\`var(--p1)\` for current player, \`var(--p2)\` for opponent), italic Fraunces 34px score, mono clock pill with active/low states.
- **\`HudCard\` React component** — horizontal layout with avatar, name + meta, mono clock pill, italic Fraunces score, optional children slot for the score-delta popup.
- **\`MatchCenterChrome\`** — eyebrow \`Round N / M\`, shared \`RoundPipBar\` (moved out of \`PlayerPanel\`), and mono status label (\`YOUR MOVE · SWAP TWO TILES\` / \`WAITING FOR OPPONENT\` / \`RESOLVING ROUND\`).
- **\`.match-layout\` rewrite** — desktop (≥ 900px) becomes a two-row CSS grid: \`match-layout__hud-strip\` (\`1fr auto 1fr\`) and \`match-layout__board-row\` (\`18rem auto 20rem\`). Mobile compact bars unchanged.
- **MatchClient rewire** — legacy \`match-layout__panel--left\` / \`--right\` blocks removed; new top HUD strip (\`HudCard\` × 2 + \`MatchCenterChrome\`) over a bottom row with a left-rail placeholder (Phase 1d), the board, and a right rail holding \`TilesClaimedCard\` + History/Resign controls.
- **Visibility fix** — HUD strip and rails are gated via \`.match-layout__*\` CSS default \`display: none\` + \`@media (min-width: 900px)\` override, not Tailwind \`hidden lg:*\` modifiers. Avoids cascade conflict between Tailwind utilities and the custom class at 900–1023px.
- **Playwright smoke** \`@hud-classic\` — asserts two HUD cards, centre chrome, right rail with tiles-claimed + History/Resign, and left-rail placeholder. Test file committed; runs in CI.

## Test plan

- [x] \`pnpm test -- --run\` — 751 passing (2 skipped)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — zero warnings
- [ ] \`pnpm exec playwright test --grep @hud-classic\` — will run in CI (Supabase not available locally in this worktree)
- [ ] Visual QA on \`/match/[id]\` after merge: top HUD strip with paper-surfaced cards + slot-coloured stripes, centre chrome pip bar, right rail showing Tiles claimed + controls, left rail empty (Phase 1d).

## Scope note

**Deferred to Phase 1d:**
- Left-rail instructional cards (How to play / Legend / Your move)
- Inline round log replacing the history overlay portal
- Removing the now-unused \`PlayerPanel\` full variant code

🤖 Generated with [Claude Code](https://claude.com/claude-code)