### PR TITLE
fix(match): current player on left + orange 'waiting' clock state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ supabase/.temp
 
 # Claude worktrees
 .claude/worktrees/
+wottle-game-design.zip

--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -814,3 +814,9 @@
   color: var(--bad);
   border-color: color-mix(in oklab, var(--bad) 40%, transparent);
 }
+
+.hud-card__clock--waiting {
+  background: color-mix(in oklab, var(--warn) 16%, var(--paper));
+  color: color-mix(in oklab, var(--warn) 80%, var(--ink));
+  border-color: color-mix(in oklab, var(--warn) 50%, transparent);
+}

--- a/components/match/HudCard.tsx
+++ b/components/match/HudCard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-type ClockState = "idle" | "active" | "low";
+type ClockState = "idle" | "active" | "low" | "waiting";
 
 interface HudCardProps {
   slot: "you" | "opp";
@@ -29,7 +29,9 @@ export function HudCard({
       ? "hud-card__clock--active"
       : clockState === "low"
         ? "hud-card__clock--low"
-        : "";
+        : clockState === "waiting"
+          ? "hud-card__clock--waiting"
+          : "";
 
   return (
     <div data-testid="hud-card" className={`hud-card ${slotClass}`}>

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -53,11 +53,12 @@ function formatClockMMSS(seconds: number): string {
 }
 
 function deriveClockState(
-  isRunning: boolean,
+  status: "running" | "paused" | "expired",
   isLow: boolean,
-): "idle" | "active" | "low" {
-  if (isLow) return "low";
-  if (isRunning) return "active";
+): "idle" | "active" | "low" | "waiting" {
+  if (status === "paused") return "waiting";
+  if (status === "expired" || isLow) return "low";
+  if (status === "running") return "active";
   return "idle";
 }
 
@@ -716,27 +717,6 @@ export function MatchClient({
         {/* Desktop: top HUD strip (hidden on mobile) */}
         <div className="match-layout__hud-strip">
           <HudCard
-            slot="opp"
-            avatar={
-              <PlayerAvatar
-                displayName={(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).displayName}
-                avatarUrl={(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).avatarUrl}
-                playerColor={getPlayerColors(opponentSlot).hex}
-                size="sm"
-              />
-            }
-            name={(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).displayName}
-            meta={`Opponent · ${(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).eloRating || "Unrated"}`}
-            clock={formatClockMMSS(opponentTimeLeft)}
-            clockState={deriveClockState(opponentTimer.status === "running", opponentTimeLeft < 60)}
-            score={opponentScore}
-          />
-          <MatchCenterChrome
-            currentRound={matchState.currentRound}
-            totalRounds={10}
-            status={centerStatus}
-          />
-          <HudCard
             slot="you"
             avatar={
               <PlayerAvatar
@@ -749,7 +729,7 @@ export function MatchClient({
             name={(playerSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).displayName}
             meta={`You · ${(playerSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).eloRating || "Unrated"}`}
             clock={formatClockMMSS(timeLeftSeconds)}
-            clockState={deriveClockState(!isPaused, timeLeftSeconds < 60)}
+            clockState={deriveClockState(currentTimer.status, timeLeftSeconds < 60)}
             score={playerScore}
           >
             {scoreDelta ? (
@@ -759,6 +739,27 @@ export function MatchClient({
               />
             ) : null}
           </HudCard>
+          <MatchCenterChrome
+            currentRound={matchState.currentRound}
+            totalRounds={10}
+            status={centerStatus}
+          />
+          <HudCard
+            slot="opp"
+            avatar={
+              <PlayerAvatar
+                displayName={(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).displayName}
+                avatarUrl={(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).avatarUrl}
+                playerColor={getPlayerColors(opponentSlot).hex}
+                size="sm"
+              />
+            }
+            name={(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).displayName}
+            meta={`Opponent · ${(opponentSlot === "player_a" ? playerProfiles.playerA : playerProfiles.playerB).eloRating || "Unrated"}`}
+            clock={formatClockMMSS(opponentTimeLeft)}
+            clockState={deriveClockState(opponentTimer.status, opponentTimeLeft < 60)}
+            score={opponentScore}
+          />
         </div>
 
         <div className="match-layout__board-row">

--- a/tests/unit/components/match/HudCard.test.tsx
+++ b/tests/unit/components/match/HudCard.test.tsx
@@ -83,6 +83,21 @@ describe("HudCard", () => {
     expect(screen.getByTestId("hud-card-clock").className).toContain(
       "hud-card__clock--low",
     );
+
+    rerender(
+      <HudCard
+        slot="you"
+        avatar={<div />}
+        name="Y"
+        meta="m"
+        clock="1:22"
+        clockState="waiting"
+        score={0}
+      />,
+    );
+    expect(screen.getByTestId("hud-card-clock").className).toContain(
+      "hud-card__clock--waiting",
+    );
   });
 
   test("renders children below identity block when provided", () => {


### PR DESCRIPTION
## Summary

Two regression fixes from Phase 1c (PR #109) that the user flagged before Phase 1d kicks off.

### 1. Current player now sits on the LEFT of the HUD strip

Phase 1c shipped the top HUD as `[ opponent · centre · you ]`, matching the Claude Design prototype. The user's mental model is that *my* HUD is always anchored left, so the order is now `[ you · centre · opponent ]`.

### 2. Paused timer renders with an orange 'waiting' tint

Previously, when a player submitted their move, the clock silently froze with no visual cue. The HudCard clock now supports a new `waiting` state that paints the mono pill with a warm ochre tint driven by `var(--warn)`:

```css
.hud-card__clock--waiting {
  background: color-mix(in oklab, var(--warn) 16%, var(--paper));
  color: color-mix(in oklab, var(--warn) 80%, var(--ink));
  border-color: color-mix(in oklab, var(--warn) 50%, transparent);
}
```

`deriveClockState()` signature now takes the `TimerStatus` literal (`'running' | 'paused' | 'expired'`) directly:
- `paused` → `waiting` (orange)
- `expired` → `low` (red)
- `running` + low remaining → `low`
- `running` → `active` (green)
- else → `idle`

## Test plan

- [x] `pnpm test -- --run` — 751 passing (2 skipped); `HudCard` suite grew a `waiting` assertion.
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — zero warnings
- [ ] Visual QA on `/match/[id]`: your card is on the left, opponent on the right; submit a move → your clock pill turns orange until both players submit.

### Also in this PR

- Adds `wottle-game-design.zip` to `.gitignore` so the handoff bundle is no longer a stray untracked file in the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)