### PR TITLE
Phase 1d: left-rail instructional cards

### DIFF
--- a/components/game/BoardGrid.tsx
+++ b/components/game/BoardGrid.tsx
@@ -63,6 +63,8 @@ interface BoardGridProps {
   onValidSwap?: () => void;
   /** Called when a swap is rejected or a frozen tile is clicked (for audio feedback). */
   onInvalidMove?: () => void;
+  /** Fired whenever the currently-selected first tile changes (null when deselected). */
+  onSelectionChange?: (selection: Coordinate | null) => void;
 }
 
 type SelectedTile = {
@@ -167,6 +169,7 @@ export function BoardGrid({
   onTileSelect,
   onValidSwap,
   onInvalidMove,
+  onSelectionChange,
 }: BoardGridProps) {
   if (!grid || grid.length === 0) {
     return <BoardGridSkeleton className={className} />;
@@ -193,6 +196,7 @@ export function BoardGrid({
       onTileSelect={onTileSelect}
       onValidSwap={onValidSwap}
       onInvalidMove={onInvalidMove}
+      onSelectionChange={onSelectionChange}
     />
   );
 }
@@ -217,10 +221,15 @@ function BoardGridActive({
   onTileSelect,
   onValidSwap,
   onInvalidMove,
+  onSelectionChange,
 }: BoardGridProps & { grid: BoardGridType }) {
   const [currentGrid, setCurrentGrid] = useState<BoardGridType>(grid);
   const [selected, setSelected] = useState<SelectedTile | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    onSelectionChange?.(selected);
+  }, [selected, onSelectionChange]);
   const [isAnimating, setIsAnimating] = useState(false);
   const [swappingTiles, setSwappingTiles] = useState<[SelectedTile, SelectedTile] | null>(null);
   const [activeHighlights, setActiveHighlights] = useState<Coordinate[][]>([]);

--- a/components/match/HowToPlayCard.tsx
+++ b/components/match/HowToPlayCard.tsx
@@ -1,0 +1,18 @@
+export function HowToPlayCard() {
+  return (
+    <div
+      data-testid="how-to-play-card"
+      className="rounded-xl border border-hair bg-paper p-4 shadow-wottle-sm"
+    >
+      <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-soft">
+        How to play
+      </div>
+      <ol className="mt-2.5 list-decimal pl-5 text-[13px] leading-[1.7] text-ink-3">
+        <li>Tap any unfrozen tile.</li>
+        <li>Tap a second tile to swap.</li>
+        <li>New 3+ letter words in any direction score.</li>
+        <li>Claimed letters freeze in your color.</li>
+      </ol>
+    </div>
+  );
+}

--- a/components/match/LegendCard.tsx
+++ b/components/match/LegendCard.tsx
@@ -1,0 +1,55 @@
+type Slot = "p1" | "p2" | "both";
+
+const SLOT_STYLES: Record<Slot, React.CSSProperties> = {
+  p1: {
+    background: "color-mix(in oklab, var(--p1-tint) 75%, var(--paper))",
+    boxShadow: "inset 3px 0 0 var(--p1)",
+  },
+  p2: {
+    background: "color-mix(in oklab, var(--p2-tint) 75%, var(--paper))",
+    boxShadow: "inset 3px 0 0 var(--p2)",
+  },
+  both: {
+    background:
+      "linear-gradient(135deg, color-mix(in oklab, var(--p1-tint) 80%, var(--paper)) 50%, color-mix(in oklab, var(--p2-tint) 80%, var(--paper)) 50%)",
+  },
+};
+
+function Swatch({ slot }: { slot: Slot }) {
+  return (
+    <span
+      data-testid="legend-swatch"
+      data-slot={slot}
+      aria-hidden="true"
+      className="inline-block h-[22px] w-[22px] flex-shrink-0 rounded-[4px] border border-hair"
+      style={SLOT_STYLES[slot]}
+    />
+  );
+}
+
+export function LegendCard() {
+  return (
+    <div
+      data-testid="legend-card"
+      className="rounded-xl border border-hair bg-paper p-4 shadow-wottle-sm"
+    >
+      <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-soft">
+        Legend
+      </div>
+      <div className="mt-3 flex flex-col gap-2.5 text-[13px] text-ink-3">
+        <div className="flex items-center gap-3">
+          <Swatch slot="p1" />
+          <span>Your territory</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <Swatch slot="p2" />
+          <span>Opponent&apos;s territory</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <Swatch slot="both" />
+          <span>Shared letter</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -30,6 +30,7 @@ import { useSensoryPreferences } from "@/lib/preferences/useSensoryPreferences";
 import { useSoundEffects } from "@/lib/audio/useSoundEffects";
 import { useHapticFeedback } from "@/lib/haptics/useHapticFeedback";
 import { MatchShell } from "./MatchShell";
+import { MatchLeftRail } from "@/components/match/MatchLeftRail";
 
 
 interface MatchClientProps {
@@ -116,6 +117,7 @@ export function MatchClient({
   // Move lock state (US1): after swap, board is locked until next round
   const [moveLocked, setMoveLocked] = useState(false);
   const [lockedSwapTiles, setLockedSwapTiles] = useState<[Coordinate, Coordinate] | null>(null);
+  const [selectedTile, setSelectedTile] = useState<Coordinate | null>(null);
 
   // Sequential reveal state (US1): active player's swap tiles and highlights during reveal phases
   const [activeRevealMove, setActiveRevealMove] = useState<{ from: Coordinate; to: Coordinate } | null>(null);
@@ -767,7 +769,12 @@ export function MatchClient({
           <div
             data-testid="match-layout-rail-left"
             className="match-layout__rail--left"
-          />
+          >
+            <MatchLeftRail
+              selection={selectedTile}
+              submittedMove={moveLocked ? lockedSwapTiles : null}
+            />
+          </div>
 
           <div className="match-layout__board">
             {/* Mobile: compact opponent bar */}
@@ -818,6 +825,7 @@ export function MatchClient({
               onTileSelect={playTileSelect}
               onValidSwap={() => { playValidSwap(); vibrateValidSwap(); }}
               onInvalidMove={() => { playInvalidMove(); vibrateInvalidMove(); }}
+              onSelectionChange={setSelectedTile}
             />
 
             {roundAnnounce && (

--- a/components/match/MatchLeftRail.tsx
+++ b/components/match/MatchLeftRail.tsx
@@ -1,0 +1,20 @@
+import type { Coordinate } from "@/lib/types/board";
+
+import { HowToPlayCard } from "./HowToPlayCard";
+import { LegendCard } from "./LegendCard";
+import { YourMoveCard } from "./YourMoveCard";
+
+interface MatchLeftRailProps {
+  selection: Coordinate | null;
+  submittedMove: [Coordinate, Coordinate] | null;
+}
+
+export function MatchLeftRail({ selection, submittedMove }: MatchLeftRailProps) {
+  return (
+    <>
+      <HowToPlayCard />
+      <LegendCard />
+      <YourMoveCard selection={selection} submittedMove={submittedMove} />
+    </>
+  );
+}

--- a/components/match/YourMoveCard.tsx
+++ b/components/match/YourMoveCard.tsx
@@ -1,0 +1,58 @@
+import type { Coordinate } from "@/lib/types/board";
+import { formatCoord } from "@/lib/util/coord";
+
+interface YourMoveCardProps {
+  selection: Coordinate | null;
+  submittedMove: [Coordinate, Coordinate] | null;
+}
+
+export function YourMoveCard({ selection, submittedMove }: YourMoveCardProps) {
+  return (
+    <div
+      data-testid="your-move-card"
+      className="rounded-xl border border-hair bg-paper p-4 shadow-wottle-sm"
+    >
+      <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-soft">
+        Your move
+      </div>
+      <div className="mt-2.5 text-[13px] leading-[1.6] text-ink-3">
+        {submittedMove ? (
+          <SubmittedState move={submittedMove} />
+        ) : selection ? (
+          <SinglePickState selection={selection} />
+        ) : (
+          <span className="text-ink-soft">Select your first tile.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SinglePickState({ selection }: { selection: Coordinate }) {
+  return (
+    <span>
+      Picked{" "}
+      <b className="font-mono font-medium text-ink">
+        {formatCoord(selection.x, selection.y)}
+      </b>
+      . Pick a second.
+    </span>
+  );
+}
+
+function SubmittedState({ move }: { move: [Coordinate, Coordinate] }) {
+  const [from, to] = move;
+  return (
+    <div>
+      <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-soft">
+        Submitted
+      </div>
+      <div className="mt-1.5 font-mono text-ink">
+        {formatCoord(from.x, from.y)} ↔ {formatCoord(to.x, to.y)}
+      </div>
+      <div className="mt-2 text-[12px] text-ink-soft">
+        Hidden from opponent until both submit.
+      </div>
+    </div>
+  );
+}

--- a/lib/util/coord.ts
+++ b/lib/util/coord.ts
@@ -1,0 +1,11 @@
+const COLUMNS = "ABCDEFGHIJ";
+
+export function formatCoord(x: number, y: number): string {
+  if (x < 0 || x >= COLUMNS.length) {
+    throw new RangeError(`Column index out of range: ${x}`);
+  }
+  if (y < 0 || y >= 10) {
+    throw new RangeError(`Row index out of range: ${y}`);
+  }
+  return `${COLUMNS[x]}${y + 1}`;
+}

--- a/tests/integration/ui/left-rail.spec.ts
+++ b/tests/integration/ui/left-rail.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Phase 1d Left Rail Smoke Test
+ * Verifies that the instructional cards are in place with:
+ * - How to play card
+ * - Legend card
+ * - Your move card
+ * - YourMoveCard updates on tile selection
+ */
+import { expect, test } from "@playwright/test";
+
+import {
+  generateTestUsername,
+  startMatchWithDirectInvite,
+} from "./helpers/matchmaking";
+
+async function loginPlayer(
+  page: import("@playwright/test").Page,
+  username: string,
+) {
+  await page.goto("/");
+  await page.getByTestId("lobby-username-input").fill(username);
+  await page.getByTestId("lobby-login-submit").click();
+  await page.waitForTimeout(1500);
+
+  const lobbyVisible = await page
+    .getByTestId("lobby-presence-list")
+    .isVisible()
+    .catch(() => false);
+
+  if (!lobbyVisible) {
+    await page.goto("/");
+  }
+
+  await expect(page.getByTestId("lobby-presence-list")).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(page.getByTestId("matchmaker-start-button")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe("@left-rail Phase 1d instructional cards", () => {
+  test("renders How to play, Legend, and Your move cards", async ({
+    browser,
+  }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const userA = generateTestUsername("rail-alpha");
+      const userB = generateTestUsername("rail-beta");
+
+      await loginPlayer(pageA, userA);
+      await loginPlayer(pageB, userB);
+
+      const [matchIdA, matchIdB] = await startMatchWithDirectInvite(pageA, pageB, {
+        timeoutMs: 60_000,
+        playerBUsername: userB,
+      });
+      expect(matchIdA).toBeTruthy();
+      expect(matchIdA).toEqual(matchIdB);
+
+      await expect(pageA.getByTestId("match-shell")).toBeVisible({
+        timeout: 10_000,
+      });
+
+      const leftRail = pageA.getByTestId("match-layout-rail-left");
+      await expect(leftRail).toBeVisible();
+      await expect(leftRail.getByTestId("how-to-play-card")).toBeVisible();
+      await expect(leftRail.getByTestId("legend-card")).toBeVisible();
+      await expect(leftRail.getByTestId("your-move-card")).toBeVisible();
+
+      await expect(
+        leftRail.getByText("Select your first tile."),
+      ).toBeVisible();
+    } finally {
+      await pageA.close();
+      await pageB.close();
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+
+  test("YourMoveCard updates when a tile is picked", async ({ browser }) => {
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const pageA = await contextA.newPage();
+    const pageB = await contextB.newPage();
+
+    try {
+      const userA = generateTestUsername("rail-pick-alpha");
+      const userB = generateTestUsername("rail-pick-beta");
+
+      await loginPlayer(pageA, userA);
+      await loginPlayer(pageB, userB);
+
+      await startMatchWithDirectInvite(pageA, pageB, {
+        timeoutMs: 60_000,
+        playerBUsername: userB,
+      });
+
+      await expect(pageA.getByTestId("match-shell")).toBeVisible({
+        timeout: 10_000,
+      });
+
+      const leftRail = pageA.getByTestId("match-layout-rail-left");
+      const tiles = pageA.getByTestId("board-tile");
+      await tiles.nth(0).click();
+
+      await expect(leftRail.getByText("A1")).toBeVisible();
+      await expect(leftRail.getByText(/Pick a second/i)).toBeVisible();
+    } finally {
+      await pageA.close();
+      await pageB.close();
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+});

--- a/tests/unit/components/game/BoardGridSelection.test.tsx
+++ b/tests/unit/components/game/BoardGridSelection.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { BoardGrid } from "@/components/game/BoardGrid";
+
+const grid = Array.from({ length: 10 }, () =>
+  Array.from({ length: 10 }, () => "A"),
+) as string[][];
+
+describe("BoardGrid onSelectionChange", () => {
+  test("fires null initially (no change on mount) and after a pick", async () => {
+    const onSelectionChange = vi.fn();
+    render(
+      <BoardGrid
+        grid={grid}
+        matchId="m-1"
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onSelectionChange).toHaveBeenCalled();
+    });
+    expect(onSelectionChange).toHaveBeenLastCalledWith(null);
+
+    const firstTile = screen.getAllByTestId("board-tile")[0];
+    fireEvent.click(firstTile);
+
+    await waitFor(() => {
+      expect(onSelectionChange).toHaveBeenLastCalledWith({ x: 0, y: 0 });
+    });
+  });
+});

--- a/tests/unit/components/match/HowToPlayCard.test.tsx
+++ b/tests/unit/components/match/HowToPlayCard.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { HowToPlayCard } from "@/components/match/HowToPlayCard";
+
+describe("HowToPlayCard", () => {
+  test("renders the 'How to play' eyebrow", () => {
+    render(<HowToPlayCard />);
+    expect(screen.getByText("How to play")).toBeInTheDocument();
+  });
+
+  test("renders an ordered list with four steps", () => {
+    render(<HowToPlayCard />);
+    const list = screen.getByRole("list");
+    expect(list.tagName).toBe("OL");
+    expect(within(list).getAllByRole("listitem")).toHaveLength(4);
+  });
+
+  test("steps describe the swap-and-form-words flow", () => {
+    render(<HowToPlayCard />);
+    expect(screen.getByText(/Tap any unfrozen tile/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tap a second tile to swap/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/New 3\+ letter words in any direction score/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Claimed letters freeze in your color/i),
+    ).toBeInTheDocument();
+  });
+
+  test("root has the wottle card styling", () => {
+    render(<HowToPlayCard />);
+    const card = screen.getByTestId("how-to-play-card");
+    expect(card.className).toMatch(/bg-paper/);
+    expect(card.className).toMatch(/border-hair/);
+  });
+});

--- a/tests/unit/components/match/LegendCard.test.tsx
+++ b/tests/unit/components/match/LegendCard.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { LegendCard } from "@/components/match/LegendCard";
+
+describe("LegendCard", () => {
+  test("renders the 'Legend' eyebrow", () => {
+    render(<LegendCard />);
+    expect(screen.getByText("Legend")).toBeInTheDocument();
+  });
+
+  test("renders three captions", () => {
+    render(<LegendCard />);
+    expect(screen.getByText("Your territory")).toBeInTheDocument();
+    expect(screen.getByText("Opponent's territory")).toBeInTheDocument();
+    expect(screen.getByText("Shared letter")).toBeInTheDocument();
+  });
+
+  test("renders three swatches", () => {
+    render(<LegendCard />);
+    expect(screen.getAllByTestId("legend-swatch")).toHaveLength(3);
+  });
+
+  test("your-territory swatch uses the p1 slot", () => {
+    render(<LegendCard />);
+    const swatches = screen.getAllByTestId("legend-swatch");
+    expect(swatches[0].dataset.slot).toBe("p1");
+    expect(swatches[1].dataset.slot).toBe("p2");
+    expect(swatches[2].dataset.slot).toBe("both");
+  });
+});

--- a/tests/unit/components/match/MatchLeftRail.test.tsx
+++ b/tests/unit/components/match/MatchLeftRail.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { MatchLeftRail } from "@/components/match/MatchLeftRail";
+
+describe("MatchLeftRail", () => {
+  test("renders all three instructional cards", () => {
+    render(<MatchLeftRail selection={null} submittedMove={null} />);
+    expect(screen.getByTestId("how-to-play-card")).toBeInTheDocument();
+    expect(screen.getByTestId("legend-card")).toBeInTheDocument();
+    expect(screen.getByTestId("your-move-card")).toBeInTheDocument();
+  });
+
+  test("forwards selection to YourMoveCard", () => {
+    render(
+      <MatchLeftRail
+        selection={{ x: 2, y: 4 }}
+        submittedMove={null}
+      />,
+    );
+    expect(screen.getByText("C5")).toBeInTheDocument();
+  });
+
+  test("forwards submittedMove to YourMoveCard", () => {
+    render(
+      <MatchLeftRail
+        selection={null}
+        submittedMove={[{ x: 0, y: 0 }, { x: 1, y: 1 }]}
+      />,
+    );
+    expect(screen.getByText("A1 ↔ B2")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/match/YourMoveCard.test.tsx
+++ b/tests/unit/components/match/YourMoveCard.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { YourMoveCard } from "@/components/match/YourMoveCard";
+
+describe("YourMoveCard", () => {
+  test("renders the 'Your move' eyebrow", () => {
+    render(<YourMoveCard selection={null} submittedMove={null} />);
+    expect(screen.getByText("Your move")).toBeInTheDocument();
+  });
+
+  test("empty state prompts the first pick", () => {
+    render(<YourMoveCard selection={null} submittedMove={null} />);
+    expect(screen.getByText("Select your first tile.")).toBeInTheDocument();
+  });
+
+  test("single selection shows the coordinate", () => {
+    render(
+      <YourMoveCard
+        selection={{ x: 0, y: 0 }}
+        submittedMove={null}
+      />,
+    );
+    expect(screen.getByText(/Picked/i)).toBeInTheDocument();
+    expect(screen.getByText("A1")).toBeInTheDocument();
+    expect(screen.getByText(/Pick a second/i)).toBeInTheDocument();
+  });
+
+  test("submitted state shows both coords joined by ↔", () => {
+    render(
+      <YourMoveCard
+        selection={null}
+        submittedMove={[
+          { x: 0, y: 0 },
+          { x: 1, y: 1 },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Submitted")).toBeInTheDocument();
+    expect(screen.getByText("A1 ↔ B2")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Hidden from opponent until both submit/i),
+    ).toBeInTheDocument();
+  });
+
+  test("submitted state overrides selection", () => {
+    render(
+      <YourMoveCard
+        selection={{ x: 2, y: 3 }}
+        submittedMove={[
+          { x: 4, y: 5 },
+          { x: 6, y: 7 },
+        ]}
+      />,
+    );
+    expect(screen.queryByText(/Select your first tile/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/C4/i)).not.toBeInTheDocument();
+    expect(screen.getByText("E6 ↔ G8")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/lib/util/coord.test.ts
+++ b/tests/unit/lib/util/coord.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+import { formatCoord } from "@/lib/util/coord";
+
+describe("formatCoord", () => {
+  test("returns A1 for (0, 0)", () => {
+    expect(formatCoord(0, 0)).toBe("A1");
+  });
+
+  test("returns J10 for (9, 9)", () => {
+    expect(formatCoord(9, 9)).toBe("J10");
+  });
+
+  test("returns E7 for (4, 6)", () => {
+    expect(formatCoord(4, 6)).toBe("E7");
+  });
+
+  test("throws on out-of-range x", () => {
+    expect(() => formatCoord(10, 0)).toThrow(/column/i);
+    expect(() => formatCoord(-1, 0)).toThrow(/column/i);
+  });
+
+  test("throws on out-of-range y", () => {
+    expect(() => formatCoord(0, 10)).toThrow(/row/i);
+    expect(() => formatCoord(0, -1)).toThrow(/row/i);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1d of the Warm Editorial redesign ([design doc](docs/superpowers/specs/2026-04-19-wottle-design-implementation.md), [plan](docs/superpowers/plans/2026-04-20-phase-1d-left-rail-cards.md)). Fills the Phase 1c left-rail placeholder with three instructional cards so new players get onboarding hints while a match is running.

- **\`formatCoord(x, y)\` helper** (\`lib/util/coord.ts\`) — shared \`A1\`…\`J10\` format with range validation.
- **\`HowToPlayCard\`** — mono eyebrow + 4-step ordered list (tap a tile, tap a second to swap, 3+ letter words score, claimed tiles freeze).
- **\`LegendCard\`** — three rows with p1-tint / p2-tint / diagonal-both swatches plus "Your territory" / "Opponent's territory" / "Shared letter" captions.
- **\`YourMoveCard\`** — four visual states: empty ("Select your first tile."), single-pick ("Picked A1. Pick a second."), submitted ("A1 ↔ B2" + "Hidden from opponent until both submit."), and a submitted-overrides-selection edge case.
- **\`BoardGrid.onSelectionChange\`** — additive callback prop so a sibling (YourMoveCard) can observe the currently-picked first tile without owning the state.
- **\`MatchLeftRail\`** — fragment composer for the three cards; parent \`.match-layout__rail--left\` container (from Phase 1c) already provides the flex column + gap.
- **MatchClient wiring** — new \`selectedTile\` state, \`BoardGrid.onSelectionChange\` → setter, \`submittedMove={moveLocked ? lockedSwapTiles : null}\` so the "Submitted" state kicks in the moment the server confirms the swap.
- **Playwright smoke** \`@left-rail\` — asserts card presence and YourMoveCard's live update from empty prompt → "A1 · Pick a second" after a tile click.

## Test plan

- [x] \`pnpm test -- --run\` — 773 passing (2 skipped)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — zero warnings
- [ ] \`pnpm exec playwright test --grep @left-rail\` — spec committed; local run timed out waiting for Supabase, CI will execute.
- [ ] Visual QA on desktop \`/match/[id]\`: left rail shows three paper-surfaced cards; YourMoveCard updates as tiles are picked and locks to "A1 ↔ B2" after submission.

## Scope note

**Deferred:**
- Inline round log replacing the history overlay portal (Phase 1e territory — the overlay + History button still work).
- Removing the now-unused \`PlayerPanel\` full variant (kept for now — \`RoundHistoryInline\` still lives inside it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)