### PR TITLE
fix(lobby): letterpress hero tiles + center letters

### DIFF
--- a/app/styles/lobby.css
+++ b/app/styles/lobby.css
@@ -66,14 +66,25 @@
   pointer-events: none;
 }
 
-/* ---- Hero tile card styling ---- */
+/* ---- Hero tile card styling ----
+ * Letterpress paper treatment that mirrors the in-match board tiles
+ * (app/styles/board.css → .board-grid__cell) — two-stop linear gradient,
+ * inset top highlight + bottom shadow + thin ink outline + soft drop
+ * shadow. A subtle ochre hairline border ties the tiles to the hero's
+ * ORÐUSTA eyebrow and the primary CTA gradient. Dark ink text (set on
+ * the element in LobbyHero.tsx) keeps WCAG AA contrast on paper. */
 .lobby-hero-tile {
-  background: linear-gradient(160deg, #1C2640 0%, #141C2E 100%);
+  background: linear-gradient(
+    180deg,
+    var(--paper) 0%,
+    color-mix(in oklab, var(--paper-2) 95%, var(--paper)) 100%
+  );
+  border: 1px solid color-mix(in oklab, var(--ochre-deep) 28%, transparent);
   box-shadow:
-    inset 0 1px 0 rgba(242, 234, 211, 0.08),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.3),
-    0 8px 16px -8px rgba(0, 0, 0, 0.6);
-  border: 1px solid rgba(232, 182, 76, 0.18);
+    inset 0 1px 0 color-mix(in oklab, #fff 80%, transparent),
+    inset 0 -1px 0 color-mix(in oklab, var(--ink) 10%, transparent),
+    inset 0 0 0 1px color-mix(in oklab, var(--ink) 6%, transparent),
+    0 2px 6px color-mix(in oklab, var(--ink) 12%, transparent);
 }
 
 /* ---- Primary CTA — gradient fill + accent glow ---- */
@@ -196,7 +207,11 @@
 }
 
 .lobby-hero-tile {
-  display: inline-block;
+  /* inline-flex (not inline-block) so the Tailwind items-center + justify-center
+   * utilities on the span actually centre the letter inside the tile. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transform-style: preserve-3d;
   will-change: transform, opacity;
 }

--- a/components/lobby/LobbyHero.tsx
+++ b/components/lobby/LobbyHero.tsx
@@ -75,7 +75,7 @@ export function LobbyHero() {
         {currentWord.letters.map((letter, i) => (
           <span
             key={`${wordIndex}-${i}`}
-            className={`lobby-hero-tile lobby-hero-cascade inline-flex h-12 w-12 items-center justify-center rounded-lg font-display text-2xl font-bold text-text-inverse sm:h-14 sm:w-14 sm:text-3xl md:h-16 md:w-16 md:text-4xl ${
+            className={`lobby-hero-tile lobby-hero-cascade inline-flex h-12 w-12 items-center justify-center rounded-lg font-display text-2xl font-bold text-ink sm:h-14 sm:w-14 sm:text-3xl md:h-16 md:w-16 md:text-4xl ${
               prefersReducedMotion ? "" : "lobby-hero-tile--flipping"
             }`}
             style={


### PR DESCRIPTION
## Summary

Two independent bugs on the \`/lobby\` hero tiles (the animated ORÐUSTA-preview row below the Wottle wordmark):

### 1. Letters weren't centered

\`app/styles/lobby.css\` declared \`.lobby-hero-tile { display: inline-block }\` further down the file than where the Tailwind \`inline-flex items-center justify-center\` utilities sit in the cascade. \`inline-block\` won, so the flex centering utilities were no-ops and the letter floated against the tile's default baseline.

**Fix:** declare \`display: inline-flex; align-items: center; justify-content: center\` directly on \`.lobby-hero-tile\` so the letter centres regardless of source order. \`transform-style: preserve-3d\` (needed for the flip animation) works fine on inline-flex.

### 2. Dark navy gradient felt overwhelming on the paper lobby

Tiles rendered with the spec-019 dark-mode navy gradient (\`linear-gradient(#1C2640 → #141C2E)\`) which looks right on a dark background but shouts on the Phase 1a paper lobby — and the cream \`text-text-inverse\` letter sitting on top compounded it.

**Fix:** swap for the letterpress paper treatment used by the in-match board tiles (\`app/styles/board.css → .board-grid__cell\`):

- \`paper → paper-2\` vertical gradient
- inset white top highlight + ink bottom shadow + thin ink outline
- soft \`0 2px 6px\` drop shadow
- subtle \`ochre-deep\` hairline border that ties the tiles to the hero's ORÐUSTA eyebrow and the primary CTA gradient

Text colour flips from \`text-text-inverse\` (cream) to \`text-ink\` (navy) for proper contrast on paper.

## Test plan

- [x] \`pnpm test -- --run\` — 818 passing (2 skipped)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — zero warnings
- [ ] Visual QA on \`/lobby\`: letters sit dead-centre inside each tile, tiles feel like the board's letterpress tiles but carry the lobby's ochre hairline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)