### PR TITLE
ci: local pnpm build fallback for act downstream jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,13 @@ jobs:
         with:
           name: next-build-${{ github.run_id }}-${{ github.run_attempt }}
           path: .next/
+      - name: Build Next.js app (act fallback — download was skipped)
+        if: ${{ env.ACT }}
+        run: pnpm build
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+          NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key-for-build
       - name: Verify build artifact integrity
         run: |
           if [ ! -f .next/BUILD_ID ]; then
@@ -688,6 +695,13 @@ jobs:
         with:
           name: next-build-${{ github.run_id }}-${{ github.run_attempt }}
           path: .next/
+      - name: Build Next.js app (act fallback — download was skipped)
+        if: ${{ env.ACT }}
+        run: pnpm build
+        env:
+          NEXT_TELEMETRY_DISABLED: 1
+          NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key-for-build
       - name: Verify build artifact integrity
         run: |
           if [ ! -f .next/BUILD_ID ]; then


### PR DESCRIPTION
## Summary

Follow-up to #120. That PR guarded \`upload-artifact@v7\` / \`download-artifact@v8\` with \`!env.ACT\` so act runs don't hit the \`mime_type\` protobuf decode error. But skipping the download in \`playwright\` and \`perf-gate\` leaves those jobs without a \`.next/\` directory, so the next step (\`Verify build artifact integrity\`) fails under act:

\`\`\`
ERROR: .next/BUILD_ID not found — artifact incomplete or download failed
\`\`\`

This PR adds a local \`pnpm build\` fallback right after the skipped download in both jobs, gated on \`env.ACT\`. Real GitHub CI still uses the upload/download handoff; act populates \`.next/\` locally instead. \`pnpm install\` and \`pnpm quickstart\` already run earlier in both jobs, so dependencies and \`.env.local\` are in place before the fallback build runs.

## Test plan

- [ ] \`bash scripts/act.sh -j perf-gate\` reaches the Artillery step instead of failing at \`Verify build artifact integrity\`
- [ ] \`bash scripts/act.sh -j playwright\` reaches the Next.js server start
- [ ] Real GitHub CI on this PR still uses the artifact handoff (fallback step is skipped because \`env.ACT\` is unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)