### PR TITLE
fix(lobby): heal stuck players.status='in_match' on lobby load

### DIFF
--- a/app/(lobby)/page.tsx
+++ b/app/(lobby)/page.tsx
@@ -8,10 +8,18 @@ import { PlayNowCard } from "@/components/lobby/PlayNowCard";
 import { RecentGamesCard } from "@/components/lobby/RecentGamesCard";
 import { TopOfBoardCard } from "@/components/lobby/TopOfBoardCard";
 import { Card } from "@/components/ui/Card";
-import { fetchLobbySnapshot, readLobbySession } from "@/lib/matchmaking/profile";
+import {
+  fetchLobbySnapshot,
+  healStuckInMatchStatus,
+  readLobbySession,
+} from "@/lib/matchmaking/profile";
 
 export default async function LobbyPage() {
   const session = await readLobbySession();
+
+  if (session) {
+    await healStuckInMatchStatus(session.player.id);
+  }
 
   const [initialPlayers, topPlayersResult, recentGamesResult] = session
     ? await Promise.all([

--- a/lib/matchmaking/profile.ts
+++ b/lib/matchmaking/profile.ts
@@ -4,7 +4,11 @@ import { cookies } from "next/headers";
 import { z } from "zod";
 
 import { listCachedPresence, rememberPresence } from "./presenceCache";
-import { upsertLobbyPresence, upsertPlayerIdentity } from "./service";
+import {
+  findActiveMatchForPlayer,
+  upsertLobbyPresence,
+  upsertPlayerIdentity,
+} from "./service";
 import type { LobbyStatus, PlayerIdentity } from "@/lib/types/match";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 
@@ -218,6 +222,51 @@ export async function fetchLobbySnapshot(): Promise<PlayerIdentity[]> {
   const cachedPlayers = listCachedPresence();
 
   return sortPlayers(dedupePlayers([...players, ...cachedPlayers]));
+}
+
+// Heal `players.status` when it's stuck at "in_match" but no pending or
+// in_progress match exists for the player. Root cause mirrors issue #117:
+// lib/match/roundEngine.ts updates matches.state then calls
+// completeMatchInternal() in a separate pass; if the second call errors or
+// the process dies, players.status stays "in_match" forever. That stale row
+// shows up in /api/lobby/players and fights the realtime-tracked value
+// (status="available" from the session cookie) every ~500ms poll, so the
+// PlayNowCard button visibly oscillates between "Play Now" and
+// "Already in a match".
+export async function healStuckInMatchStatus(playerId: string): Promise<void> {
+  const supabase = getServiceRoleClient();
+  const { data: player } = await supabase
+    .from("players")
+    .select("status")
+    .eq("id", playerId)
+    .maybeSingle();
+
+  if (player?.status !== "in_match") {
+    return;
+  }
+
+  const activeMatch = await findActiveMatchForPlayer(supabase, playerId).catch(
+    () => null,
+  );
+  if (activeMatch) {
+    return;
+  }
+
+  const { error } = await supabase
+    .from("players")
+    .update({ status: "available", last_seen_at: new Date().toISOString() })
+    .eq("id", playerId)
+    .eq("status", "in_match");
+
+  if (error) {
+    console.error(
+      JSON.stringify({
+        event: "player.status.heal.failed",
+        playerId,
+        error: error.message,
+      }),
+    );
+  }
 }
 
 function encodeSession(session: LobbySession): string {

--- a/tests/unit/lib/matchmaking/healStuckInMatchStatus.test.ts
+++ b/tests/unit/lib/matchmaking/healStuckInMatchStatus.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({ getServiceRoleClient: vi.fn() }));
+vi.mock("@/lib/matchmaking/service", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/matchmaking/service")
+  >("@/lib/matchmaking/service");
+  return { ...actual, findActiveMatchForPlayer: vi.fn() };
+});
+
+import { healStuckInMatchStatus } from "@/lib/matchmaking/profile";
+import { findActiveMatchForPlayer } from "@/lib/matchmaking/service";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+
+const PLAYER_ID = "player-abc";
+
+type PlayerSelectResult = {
+  data: { status: string } | null;
+  error: { message: string } | null;
+};
+
+type UpdateResult = { error: { message: string } | null };
+
+function buildClient(options: {
+  selectResult: PlayerSelectResult;
+  updateResult?: UpdateResult;
+}) {
+  const selectChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(options.selectResult),
+  };
+
+  const updateEqChain = {
+    eq: vi.fn(),
+  };
+  updateEqChain.eq.mockImplementation(() => updateEqChain);
+
+  const updateResultThenable = {
+    then: (resolve: (v: UpdateResult) => unknown) =>
+      Promise.resolve(options.updateResult ?? { error: null }).then(resolve),
+  };
+
+  const updateChain = {
+    update: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue(updateResultThenable),
+      }),
+    }),
+  };
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table === "players") {
+        return { ...selectChain, ...updateChain };
+      }
+      return selectChain;
+    }),
+    _updateSpy: updateChain.update,
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(findActiveMatchForPlayer).mockReset();
+});
+
+describe("healStuckInMatchStatus", () => {
+  test("does nothing when player status is already 'available'", async () => {
+    const client = buildClient({
+      selectResult: { data: { status: "available" }, error: null },
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(client as never);
+
+    await healStuckInMatchStatus(PLAYER_ID);
+
+    expect(findActiveMatchForPlayer).not.toHaveBeenCalled();
+    expect(client._updateSpy).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when status is 'in_match' AND an active match exists", async () => {
+    const client = buildClient({
+      selectResult: { data: { status: "in_match" }, error: null },
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(client as never);
+    vi.mocked(findActiveMatchForPlayer).mockResolvedValue({
+      id: "match-1",
+      state: "in_progress",
+    });
+
+    await healStuckInMatchStatus(PLAYER_ID);
+
+    expect(findActiveMatchForPlayer).toHaveBeenCalledWith(client, PLAYER_ID);
+    expect(client._updateSpy).not.toHaveBeenCalled();
+  });
+
+  test("resets status to 'available' when stuck 'in_match' with no active match", async () => {
+    const client = buildClient({
+      selectResult: { data: { status: "in_match" }, error: null },
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(client as never);
+    vi.mocked(findActiveMatchForPlayer).mockResolvedValue(null);
+
+    await healStuckInMatchStatus(PLAYER_ID);
+
+    expect(client._updateSpy).toHaveBeenCalledTimes(1);
+    const updatePayload = client._updateSpy.mock.calls[0]?.[0] as {
+      status: string;
+      last_seen_at: string;
+    };
+    expect(updatePayload.status).toBe("available");
+    expect(typeof updatePayload.last_seen_at).toBe("string");
+  });
+
+  test("swallows findActiveMatchForPlayer errors and still heals", async () => {
+    const client = buildClient({
+      selectResult: { data: { status: "in_match" }, error: null },
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(client as never);
+    vi.mocked(findActiveMatchForPlayer).mockRejectedValue(
+      new Error("transient DB error"),
+    );
+
+    await expect(healStuckInMatchStatus(PLAYER_ID)).resolves.toBeUndefined();
+
+    expect(client._updateSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

PlayNowCard renders \"Already in a match\" and flips back to \"Play Now\" every ~500ms for users who are NOT in any active match.

![screenshot showing the stuck state](https://user-images.githubusercontent.com/placeholder)

**Root cause** — same class of bug as #117. \`lib/match/roundEngine.ts\` writes \`matches.state\` in one UPDATE, then calls \`completeMatchInternal()\` in a second pass that resets \`players.status\` to \`\"available\"\`. If the second call errors or the process dies between the two writes, \`players.status\` stays \`\"in_match\"\` indefinitely.

**Oscillation mechanism** — \`/api/lobby/players\` (polled every 500ms by the presence store) returns the stale \`\"in_match\"\` status. The Realtime presence channel tracks the session-cookie snapshot (\`\"available\"\`). They fight on every poll/sync tick, so the button text flips.

**Fix** — add \`healStuckInMatchStatus(playerId)\` to \`lib/matchmaking/profile.ts\` and call it from the lobby Server Component. If DB says the player is in a match but \`findActiveMatchForPlayer\` returns null, reset \`players.status\` to \`\"available\"\`. Guarded with \`.eq(\"status\", \"in_match\")\` on the UPDATE so a concurrent legitimate match-start is not clobbered.

## Test plan

- [x] \`pnpm test:unit\` — 121 files / 830 passing (+4 new tests)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [ ] In-browser: lobby button stays steady at \"Play Now\" for a stuck-status player

## Follow-ups

The underlying two-write pattern in \`roundEngine.ts\` + \`completeMatchInternal\` is still fragile — issue #117 healed \`winner_id\` at read time in the summary page, this PR heals \`players.status\` at read time in the lobby page, but the root cause is the same and would benefit from a single atomic transition. Leaving that for a dedicated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)