### PR TITLE
fix(lobby): harden healStuckInMatchStatus — never throw

### DIFF
--- a/lib/matchmaking/profile.ts
+++ b/lib/matchmaking/profile.ts
@@ -233,37 +233,52 @@ export async function fetchLobbySnapshot(): Promise<PlayerIdentity[]> {
 // (status="available" from the session cookie) every ~500ms poll, so the
 // PlayNowCard button visibly oscillates between "Play Now" and
 // "Already in a match".
+//
+// This runs on every lobby page load, so it must NEVER throw — the lobby
+// page crashing for a transient DB blip would be worse than leaving a stale
+// status in place. All errors are swallowed and logged.
 export async function healStuckInMatchStatus(playerId: string): Promise<void> {
-  const supabase = getServiceRoleClient();
-  const { data: player } = await supabase
-    .from("players")
-    .select("status")
-    .eq("id", playerId)
-    .maybeSingle();
+  try {
+    const supabase = getServiceRoleClient();
+    const { data: player, error: selectError } = await supabase
+      .from("players")
+      .select("status")
+      .eq("id", playerId)
+      .maybeSingle();
 
-  if (player?.status !== "in_match") {
-    return;
-  }
+    if (selectError || player?.status !== "in_match") {
+      return;
+    }
 
-  const activeMatch = await findActiveMatchForPlayer(supabase, playerId).catch(
-    () => null,
-  );
-  if (activeMatch) {
-    return;
-  }
+    const activeMatch = await findActiveMatchForPlayer(
+      supabase,
+      playerId,
+    ).catch(() => null);
+    if (activeMatch) {
+      return;
+    }
 
-  const { error } = await supabase
-    .from("players")
-    .update({ status: "available", last_seen_at: new Date().toISOString() })
-    .eq("id", playerId)
-    .eq("status", "in_match");
+    const { error } = await supabase
+      .from("players")
+      .update({ status: "available", last_seen_at: new Date().toISOString() })
+      .eq("id", playerId)
+      .eq("status", "in_match");
 
-  if (error) {
+    if (error) {
+      console.error(
+        JSON.stringify({
+          event: "player.status.heal.failed",
+          playerId,
+          error: error.message,
+        }),
+      );
+    }
+  } catch (error) {
     console.error(
       JSON.stringify({
-        event: "player.status.heal.failed",
+        event: "player.status.heal.threw",
         playerId,
-        error: error.message,
+        error: error instanceof Error ? error.message : String(error),
       }),
     );
   }


### PR DESCRIPTION
## Summary

Follow-up to #122. Wrap the whole \`healStuckInMatchStatus\` body in try/catch + log-and-swallow so a DB blip, bad env, or schema mismatch can't crash the lobby Server Component. The callers already treat this as best-effort (fire-and-forget on page load), so swallowing is the honest contract.

Also swallow \`selectError\` (not just \`updateError\`), so a transient Supabase failure on the initial read doesn't short-circuit the function in a way that would bypass later recovery.

## Why

This was noticed while investigating a Playwright \`@two-player-playtest\` suite failure under \`pnpm act\` — every test timed out waiting for \`lobby-presence-list\`, which suggested the lobby page might be failing to render. Hardening the heal rules it out as a candidate; if the Playwright failure persists, the root cause is elsewhere (likely Firefox-in-act Docker networking for Realtime/anon-key).

## Test plan

- [x] \`pnpm test:unit\` — 121 files / 830 passing
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)