### PR TITLE
fix(realtime): start lobby presence poller only when Realtime fails

### DIFF
--- a/lib/matchmaking/presenceStore.ts
+++ b/lib/matchmaking/presenceStore.ts
@@ -177,13 +177,19 @@ export const useLobbyPresenceStore = create<LobbyPresenceState>((set, get) => ({
                 finalPlayers = merged;
               }
               
+              const isRealtime = source === "realtime";
               return {
                 players: applyLobbyEvent(state.players, {
                   type: "sync",
                   players: finalPlayers,
                 }),
                 status: "ready",
-                connectionMode: source === "poller" ? "polling" : "realtime",
+                connectionMode: isRealtime ? "realtime" : "polling",
+                // When Realtime recovers (after a prior CHANNEL_ERROR set
+                // status=error + error=…), clear the stale error banner so
+                // the UI reflects the live-again state.
+                error: isRealtime ? null : state.error,
+                reconnecting: isRealtime ? false : state.reconnecting,
                 lastEventAt: Date.now(),
               };
             });
@@ -221,7 +227,11 @@ export const useLobbyPresenceStore = create<LobbyPresenceState>((set, get) => ({
         {
           key: self.id,
           poller: fetchPollingSnapshot,
-          pollIntervalMs: 500,
+          // 2 s matches MatchClient's safety-net cadence. Was 500 ms back when
+          // the poller ran unconditionally as the primary transport; now that
+          // it only runs while Realtime is down, there's no UX win from
+          // polling 4× faster and we'd rather not hammer /api/lobby/players.
+          pollIntervalMs: 2_000,
         }
       );
 

--- a/lib/realtime/presenceChannel.ts
+++ b/lib/realtime/presenceChannel.ts
@@ -19,6 +19,12 @@ interface PresenceOptions<TPollState extends object> {
   key?: string;
 }
 
+// Reconnect back-off schedule: 5s → 10s → 20s → 40s, then cap at 60s.
+// Intentionally gentle so a persistently broken Realtime service doesn't
+// hammer Supabase while the polling fallback carries the UI.
+const RECONNECT_BASE_MS = 5_000;
+const RECONNECT_CAP_MS = 60_000;
+
 export function subscribeToLobbyPresence<
   TState extends object = Record<string, unknown>
 >(
@@ -26,16 +32,13 @@ export function subscribeToLobbyPresence<
   callbacks: PresenceCallbacks<TState>,
   options: PresenceOptions<TState> = {}
 ): PresenceSubscription {
-  const channel = client.channel("lobby-presence", {
-    config: {
-      presence: {
-        key: options.key ?? "anonymous",
-      },
-    },
-  });
   let trackedPayload: Record<string, unknown> | null = null;
   let pendingPayload: Record<string, unknown> | null = null;
   let isSubscribed = false;
+  let stopped = false;
+  // Definite-assignment assertion — `attemptSubscribe()` runs synchronously
+  // before the function returns, so `channel` is always set by then.
+  let channel!: RealtimeChannel;
 
   function pushPresence(payload: Record<string, unknown>) {
     trackedPayload = payload;
@@ -47,57 +50,20 @@ export function subscribeToLobbyPresence<
     }
   }
 
-  channel
-    .on("presence", { event: "sync" }, () => {
-      const state = channel.presenceState<TState>();
-      console.log("[Realtime] Presence sync event:", Object.keys(state).length, "users");
-      callbacks.onSync?.(flattenPresence(state), "realtime");
-    })
-    .on("presence", { event: "join" }, ({ newPresences }) => {
-      console.log("[Realtime] Presence join event:", newPresences.length, "users");
-      newPresences.forEach((presence) =>
-        callbacks.onJoin?.(presence as unknown as TState)
-      );
-    })
-    .on("presence", { event: "leave" }, ({ leftPresences }) => {
-      console.log("[Realtime] Presence leave event:", leftPresences.length, "users");
-      leftPresences.forEach((presence) =>
-        callbacks.onLeave?.(presence as unknown as TState)
-      );
-    })
-    .subscribe((status) => {
-      console.log("[Realtime] Channel status changed:", status);
-      
-      if (status === "SUBSCRIBED") {
-        console.log("[Realtime] Successfully subscribed to lobby-presence channel");
-        isSubscribed = true;
-        if (pendingPayload) {
-          console.log("[Realtime] Tracking pending presence payload");
-          channel.track(pendingPayload);
-          pendingPayload = null;
-        } else if (trackedPayload) {
-          console.log("[Realtime] Tracking current presence payload");
-          channel.track(trackedPayload);
-        }
-      } else if (status === "CHANNEL_ERROR") {
-        console.error("[Realtime] CHANNEL_ERROR - Realtime Presence is not working");
-        console.error("[Realtime] This usually means the Realtime service is not properly configured");
-        callbacks.onError?.(new Error("Realtime channel error (lobby-presence)"));
-      } else if (status === "TIMED_OUT") {
-        console.error("[Realtime] TIMED_OUT - Connection never established");
-        callbacks.onError?.(new Error("Realtime connection timed out"));
-      } else if (status === "CLOSED") {
-        console.log("[Realtime] CLOSED - Channel was closed");
-      } else {
-        console.log("[Realtime] Unknown channel status:", status);
-      }
-    });
-
+  // Polling fallback — starts only while Realtime is unavailable. Running
+  // the poller unconditionally corrupts `connectionMode` in the store:
+  // `onSync(_, "poller")` would fire every `pollIntervalMs` and overwrite
+  // the "realtime" flag set by the (rarer) presence sync events, leaving
+  // the UI stuck on "Polling" even when Realtime is fully functional.
   const pollInterval = options.pollIntervalMs ?? 2_000;
   let pollHandle: NodeJS.Timeout | null = null;
 
-  if (options.poller) {
-    const poller = async () => {
+  const startPollingFallback = () => {
+    if (!options.poller || pollHandle) {
+      return;
+    }
+    console.log("[Realtime] Starting polling fallback (Realtime unavailable)");
+    const tick = async () => {
       try {
         const result = await options.poller!();
         callbacks.onSync?.(result, "poller");
@@ -105,17 +71,147 @@ export function subscribeToLobbyPresence<
         callbacks.onError?.(error);
       }
     };
-    poller();
-    pollHandle = setInterval(poller, pollInterval);
-  }
+    void tick();
+    pollHandle = setInterval(tick, pollInterval);
+  };
+
+  const stopPollingFallback = () => {
+    if (pollHandle) {
+      console.log("[Realtime] Stopping polling fallback (Realtime recovered)");
+      clearInterval(pollHandle);
+      pollHandle = null;
+    }
+  };
+
+  // Reconnect loop — runs in parallel with the polling fallback. Keeps
+  // trying to re-establish the WebSocket with exponential back-off until
+  // it succeeds or the subscription is torn down.
+  let reconnectAttempt = 0;
+  let reconnectHandle: NodeJS.Timeout | null = null;
+
+  const scheduleReconnect = () => {
+    if (stopped || reconnectHandle) {
+      return;
+    }
+    const backoffMs = Math.min(
+      RECONNECT_CAP_MS,
+      RECONNECT_BASE_MS * 2 ** reconnectAttempt
+    );
+    reconnectAttempt += 1;
+    console.log(
+      `[Realtime] Scheduling reconnect attempt #${reconnectAttempt} in ${backoffMs}ms`
+    );
+    reconnectHandle = setTimeout(() => {
+      reconnectHandle = null;
+      attemptSubscribe();
+    }, backoffMs);
+  };
+
+  const attemptSubscribe = () => {
+    if (stopped) {
+      return;
+    }
+    isSubscribed = false;
+    // Remove any prior channel so the next `client.channel("lobby-presence")`
+    // call returns a fresh instance (the client caches channels by topic).
+    if (channel) {
+      try {
+        void client.removeChannel(channel);
+      } catch (error) {
+        console.warn("[Realtime] Failed to remove stale channel:", error);
+      }
+    }
+    channel = client.channel("lobby-presence", {
+      config: {
+        presence: {
+          key: options.key ?? "anonymous",
+        },
+      },
+    });
+
+    channel
+      .on("presence", { event: "sync" }, () => {
+        const state = channel.presenceState<TState>();
+        console.log(
+          "[Realtime] Presence sync event:",
+          Object.keys(state).length,
+          "users"
+        );
+        callbacks.onSync?.(flattenPresence(state), "realtime");
+      })
+      .on("presence", { event: "join" }, ({ newPresences }) => {
+        console.log("[Realtime] Presence join event:", newPresences.length, "users");
+        newPresences.forEach((presence) =>
+          callbacks.onJoin?.(presence as unknown as TState)
+        );
+      })
+      .on("presence", { event: "leave" }, ({ leftPresences }) => {
+        console.log(
+          "[Realtime] Presence leave event:",
+          leftPresences.length,
+          "users"
+        );
+        leftPresences.forEach((presence) =>
+          callbacks.onLeave?.(presence as unknown as TState)
+        );
+      })
+      .subscribe((status) => {
+        console.log("[Realtime] Channel status changed:", status);
+
+        if (status === "SUBSCRIBED") {
+          console.log("[Realtime] Successfully subscribed to lobby-presence channel");
+          isSubscribed = true;
+          reconnectAttempt = 0;
+          stopPollingFallback();
+          if (pendingPayload) {
+            console.log("[Realtime] Tracking pending presence payload");
+            channel.track(pendingPayload);
+            pendingPayload = null;
+          } else if (trackedPayload) {
+            console.log("[Realtime] Re-tracking presence after reconnect");
+            channel.track(trackedPayload);
+          }
+        } else if (status === "CHANNEL_ERROR") {
+          console.error("[Realtime] CHANNEL_ERROR - Realtime Presence is not working");
+          console.error(
+            "[Realtime] This usually means the Realtime service is not properly configured"
+          );
+          callbacks.onError?.(new Error("Realtime channel error (lobby-presence)"));
+          startPollingFallback();
+          scheduleReconnect();
+        } else if (status === "TIMED_OUT") {
+          console.error("[Realtime] TIMED_OUT - Connection never established");
+          callbacks.onError?.(new Error("Realtime connection timed out"));
+          startPollingFallback();
+          scheduleReconnect();
+        } else if (status === "CLOSED") {
+          console.log("[Realtime] CLOSED - Channel was closed");
+        } else {
+          console.log("[Realtime] Unknown channel status:", status);
+        }
+      });
+  };
+
+  attemptSubscribe();
 
   return {
-    channel,
+    get channel() {
+      return channel;
+    },
     stopPolling() {
-      if (pollHandle) {
-        clearInterval(pollHandle);
+      stopped = true;
+      stopPollingFallback();
+      if (reconnectHandle) {
+        clearTimeout(reconnectHandle);
+        reconnectHandle = null;
       }
-      channel.unsubscribe();
+      if (channel) {
+        try {
+          void client.removeChannel(channel);
+        } catch (error) {
+          console.warn("[Realtime] Failed to remove channel on teardown:", error);
+        }
+      }
     },
     updatePresence(payload) {
       const merged =


### PR DESCRIPTION
## Summary

The lobby \"Live/Polling\" badge on `wottle.vercel.app` was permanently stuck on **Polling** even though the Supabase Realtime WebSocket was connecting successfully (`SUBSCRIBED` in DevTools, presence syncs firing, no `CHANNEL_ERROR`). Root cause was a code bug in `lib/realtime/presenceChannel.ts`, not env/config.

- The poller was started unconditionally inside `subscribeToLobbyPresence`, polling `/api/lobby/players` every 500 ms from the moment the channel was created.
- Each poll tick called `callbacks.onSync(result, \"poller\")`. The store's `onSync` handler writes `connectionMode = source === \"poller\" ? \"polling\" : \"realtime\"`.
- Because presence sync events are rare and the poller fires every 500 ms, the poller was essentially always the \"last writer,\" so `connectionMode` stayed `\"polling\"` forever.
- `LobbyStatsStrip.tsx:90-91` renders the badge directly from `connectionMode`; `LobbyList.tsx:84` gated realtime-only behaviour on the same flag.

## What changed

**`lib/realtime/presenceChannel.ts`**
- Fallback poller is now started only from the `CHANNEL_ERROR` / `TIMED_OUT` branches of the subscribe-status callback; stopped again on the next `SUBSCRIBED`.
- Added an exponential back-off reconnect loop (5 s → 10 s → 20 s → 40 s, cap 60 s) so a transient Realtime outage self-heals without a page reload.
- Each reconnect removes the stale channel (`client.removeChannel`) before creating a new one, because Supabase caches channels by topic.
- Re-tracks presence after a successful resubscribe so the user reappears in other clients' lobbies.
- `stopPolling()` now tears down both the poll interval and any pending reconnect timer, with a `stopped` guard so no further reconnect fires after teardown.

**`lib/matchmaking/presenceStore.ts`**
- `pollIntervalMs: 500` → `2_000`. Matches `MatchClient`'s safety-net cadence; no reason to hit `/api/lobby/players` 4× a second now that it's a fallback rather than the primary transport.
- On a realtime-sourced `onSync`, clear `error` and `reconnecting` so the \"connection lost\" banner disappears when Realtime recovers.

## State machine after this change

| Event | `connectionMode` | `error` | Poller | Reconnect timer |
|---|---|---|---|---|
| Page load, Realtime OK | `realtime` | `null` | stopped | n/a |
| `CHANNEL_ERROR` fires | `polling` | set | **starts** | scheduled (5 s) |
| Reconnect → `SUBSCRIBED` | `realtime` (next sync) | `null` (next sync) | **stopped** | reset |
| Reconnect → `CHANNEL_ERROR` again | `polling` | set | running | scheduled (10 s, 20 s…) |
| `stopPolling()` (unmount / logout) | — | — | stopped | cleared |

## Verification

Ran locally in the worktree:
- `pnpm typecheck` — clean
- `pnpm lint` (zero-warnings policy) — clean
- `pnpm test:unit` — 120 files / 826 tests pass / 2 skipped / 0 failed

## Test plan

- [ ] Deploy to Vercel preview, open the lobby, confirm `[Realtime] Channel status changed: SUBSCRIBED` and presence sync logs, and **no** `[presenceStore] Polling /api/lobby/players...` logs.
- [ ] Lobby badge shows **Live** (not Polling) with Realtime healthy.
- [ ] Two browsers, log in as different users — both see each other instantly via presence (no 2 s poll delay).
- [ ] Simulate Realtime outage (block `wss://*.supabase.co` in DevTools network conditions). Confirm:
  - Badge flips to **Polling**, error banner appears.
  - Console logs `[Realtime] Starting polling fallback` and later `[Realtime] Scheduling reconnect attempt #1 in 5000ms`.
  - Lobby keeps updating via the 2 s poller.
- [ ] Restore network. Confirm:
  - Console logs `[Realtime] Successfully subscribed to lobby-presence channel` and `[Realtime] Stopping polling fallback (Realtime recovered)`.
  - Badge returns to **Live**, error banner clears.
- [ ] Navigate away / log out — no stray `setInterval`/`setTimeout` left running (check with React DevTools or a leak probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)