### PR TITLE
ci(act): build client bundle with real anon key + host.docker.internal URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,12 +342,20 @@ jobs:
           name: next-build-${{ github.run_id }}-${{ github.run_attempt }}
           path: .next/
       - name: Build Next.js app (act fallback — download was skipped)
+        # Under act: quickstart already ran and wrote real Supabase values
+        # to .env.local. Next.js autoloads .env.local at build time, so the
+        # anon key baked into the client bundle is the real one.
+        #
+        # We *do* override NEXT_PUBLIC_SUPABASE_URL to host.docker.internal
+        # so Firefox/Chromium inside the container can actually reach host
+        # Supabase (localhost:54321 would point at the container's own
+        # loopback). Without this, the browser WebSocket handshake to
+        # Realtime fails with 403 and every two-player test times out.
         if: ${{ env.ACT }}
         run: pnpm build
         env:
           NEXT_TELEMETRY_DISABLED: 1
-          NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key-for-build
+          NEXT_PUBLIC_SUPABASE_URL: http://host.docker.internal:54321
       - name: Verify build artifact integrity
         run: |
           if [ ! -f .next/BUILD_ID ]; then
@@ -696,12 +704,20 @@ jobs:
           name: next-build-${{ github.run_id }}-${{ github.run_attempt }}
           path: .next/
       - name: Build Next.js app (act fallback — download was skipped)
+        # Under act: quickstart already ran and wrote real Supabase values
+        # to .env.local. Next.js autoloads .env.local at build time, so the
+        # anon key baked into the client bundle is the real one.
+        #
+        # We *do* override NEXT_PUBLIC_SUPABASE_URL to host.docker.internal
+        # so Firefox/Chromium inside the container can actually reach host
+        # Supabase (localhost:54321 would point at the container's own
+        # loopback). Without this, the browser WebSocket handshake to
+        # Realtime fails with 403 and every two-player test times out.
         if: ${{ env.ACT }}
         run: pnpm build
         env:
           NEXT_TELEMETRY_DISABLED: 1
-          NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key-for-build
+          NEXT_PUBLIC_SUPABASE_URL: http://host.docker.internal:54321
       - name: Verify build artifact integrity
         run: |
           if [ ! -f .next/BUILD_ID ]; then


### PR DESCRIPTION
## Summary

Follow-up to #124. That PR got server-side Supabase calls working under act. But the client bundle built by the act-fallback \`pnpm build\` step was still baking placeholders in:

\`\`\`
NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder-anon-key-for-build
\`\`\`

From the playwright act log after #124 landed:

\`\`\`
WebSocket connection to 'ws://localhost:54321/realtime/v1/websocket?apikey=placeholder-anon-key-for-build&vsn=2.0.0' failed: Error during WebSocket handshake: Unexpected response code: 403
\`\`\`

Every browser Realtime connection inside the act container fails, which cascades:

- **axe WCAG 2.1 AA contrast failures** on the \`Polling\` fallback badge and \`Presence unavailable\` alert (146 violations in \`lobby-visual.spec.ts\`).
- **\`@two-player-playtest\` tests time out** at 180–300s because matchmaking can't negotiate without Realtime; follow-up tests then fail with \`Page was closed during wait\`.
- **Next.js server \`SIGKILL\`** (exit 137) — OOM after the long hangs hold memory.

## Fix

The act-fallback build step runs *after* quickstart, which has already written real Supabase values to \`.env.local\`. Next.js auto-loads \`.env.local\` at build time, so simply dropping the anon-key override picks up the real key.

Keep a single URL override: \`http://host.docker.internal:54321\` so Firefox/Chromium inside the act container can reach host Supabase (loopback \`127.0.0.1\`/\`localhost\` resolves to the container, not the host).

Real GitHub CI path (download-artifact) is untouched — this step only runs when \`env.ACT\` is truthy.

## Test plan

- [ ] \`bash scripts/act.sh -j playwright --matrix suite:playtest\` — two-player Firefox tests pass past login and matchmaking
- [ ] \`bash scripts/act.sh -j playwright --matrix suite:baseline\` — \`lobby-visual\` axe scan passes (no Polling/Presence-unavailable fallback UI)
- [ ] Real GitHub CI on this PR still uses the artifact handoff (fallback step is skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)