### PR TITLE
fix(lobby): exclude viewer from 'players online' stat

### DIFF
--- a/app/(lobby)/page.tsx
+++ b/app/(lobby)/page.tsx
@@ -37,7 +37,7 @@ export default async function LobbyPage() {
 
       {session ? (
         <>
-          <LobbyStatsStrip />
+          <LobbyStatsStrip selfId={session.player.id} />
           <PlayNowCard currentPlayer={session.player} />
           <section className="space-y-4">
             <div className="flex items-baseline justify-between">

--- a/components/lobby/LobbyStatsStrip.tsx
+++ b/components/lobby/LobbyStatsStrip.tsx
@@ -25,7 +25,11 @@ async function fetchMatchesCount(): Promise<number | null> {
   }
 }
 
-export function LobbyStatsStrip() {
+interface LobbyStatsStripProps {
+  selfId: string;
+}
+
+export function LobbyStatsStrip({ selfId }: LobbyStatsStripProps) {
   const players = useLobbyPresenceStore((state) => state.players);
   const connectionMode = useLobbyPresenceStore(
     (state) => state.connectionMode,
@@ -53,7 +57,10 @@ export function LobbyStatsStrip() {
     };
   }, []);
 
-  const onlineCount = players.length;
+  // Exclude the viewer so this count matches the `LobbyDirectory` empty-state
+  // condition (which also excludes self) and the prototype's empty-lobby
+  // screen, which shows "0 players online" when the viewer is alone.
+  const onlineCount = players.filter((player) => player.id !== selfId).length;
 
   return (
     <div

--- a/tests/unit/components/lobby/LobbyStatsStrip.test.tsx
+++ b/tests/unit/components/lobby/LobbyStatsStrip.test.tsx
@@ -40,13 +40,47 @@ afterEach(() => {
 });
 
 describe("LobbyStatsStrip", () => {
-  test("renders the online count derived from presence store", () => {
+  test("renders the online count excluding the current player", () => {
     mockStoreState.players = makePlayers(3);
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ matchesInProgress: 0 })),
     );
-    render(<LobbyStatsStrip />);
+    render(<LobbyStatsStrip selfId="not-in-list" />);
     expect(screen.getByTestId("lobby-stats-online").textContent).toContain("3");
+  });
+
+  test("subtracts the current player from the online count", () => {
+    mockStoreState.players = makePlayers(3);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ matchesInProgress: 0 })),
+    );
+    render(<LobbyStatsStrip selfId="p0" />);
+    const text = screen.getByTestId("lobby-stats-online").textContent ?? "";
+    expect(text).toContain("2");
+    expect(text).toContain("players online");
+  });
+
+  test("shows 0 players online when the viewer is alone in the lobby", () => {
+    mockStoreState.players = makePlayers(1);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ matchesInProgress: 0 })),
+    );
+    render(<LobbyStatsStrip selfId="p0" />);
+    const text = screen.getByTestId("lobby-stats-online").textContent ?? "";
+    expect(text).toContain("0");
+    expect(text).toContain("players online");
+  });
+
+  test("uses singular copy when exactly one other player is online", () => {
+    mockStoreState.players = makePlayers(2);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ matchesInProgress: 0 })),
+    );
+    render(<LobbyStatsStrip selfId="p0" />);
+    const text = screen.getByTestId("lobby-stats-online").textContent ?? "";
+    expect(text).toContain("1");
+    expect(text).toContain("player online");
+    expect(text).not.toContain("players online");
   });
 
   test("renders matches-in-progress count from the fetched payload", async () => {
@@ -54,7 +88,7 @@ describe("LobbyStatsStrip", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ matchesInProgress: 7 })),
     );
-    render(<LobbyStatsStrip />);
+    render(<LobbyStatsStrip selfId="self" />);
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1);
     });
@@ -71,7 +105,7 @@ describe("LobbyStatsStrip", () => {
         new Response(JSON.stringify({ matchesInProgress: 4 })),
       )
       .mockResolvedValueOnce(new Response("boom", { status: 500 }));
-    render(<LobbyStatsStrip />);
+    render(<LobbyStatsStrip selfId="self" />);
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1);
     });
@@ -92,7 +126,7 @@ describe("LobbyStatsStrip", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ matchesInProgress: 0 })),
     );
-    render(<LobbyStatsStrip />);
+    render(<LobbyStatsStrip selfId="self" />);
     expect(screen.getByTestId("lobby-connection-mode").textContent).toMatch(
       /live/i,
     );
@@ -103,7 +137,7 @@ describe("LobbyStatsStrip", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ matchesInProgress: 0 })),
     );
-    render(<LobbyStatsStrip />);
+    render(<LobbyStatsStrip selfId="self" />);
     expect(screen.getByTestId("lobby-connection-mode").textContent).toMatch(
       /polling/i,
     );


### PR DESCRIPTION
## Summary

- **Bug:** Solo in the lobby, `LobbyStatsStrip` showed **1 PLAYER ONLINE** while `LobbyDirectory` rendered **"The library is empty tonight"**. The two components used different definitions of "online" — stats counted every presence row (including the viewer), while the directory's empty-state check excluded self.
- **Fix:** `LobbyStatsStrip` now takes a required `selfId` prop and filters the viewer out of the count, matching the Warm Editorial prototype (`docs/.../prototype/App.jsx:337` shows **"0 players online"** when the viewer is alone).
- **Result:**
  - Alone → `0 PLAYERS ONLINE` + empty state (consistent)
  - One other online → `1 PLAYER ONLINE` (singular) + their card in the directory
  - N others → `N PLAYERS ONLINE` + N cards

## Test plan

- [x] `pnpm test:unit tests/unit/components/lobby/LobbyStatsStrip.test.tsx` — 3 new tests: exclusion when self present, alone → 0, singular copy for exactly one other.
- [x] Full unit suite: `pnpm test:unit` — 833 pass, 2 skipped.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean (zero-warnings policy).
- [ ] Manual: open `/lobby` solo → stats reads `0 PLAYERS ONLINE`, directory shows `EmptyLobbyState`.
- [ ] Manual: log in with a second browser → stats reads `1 PLAYER ONLINE`, directory shows the other player's card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)