### PR TITLE
ci: bake real Supabase CLI local anon key into build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,22 @@ jobs:
         run: pnpm build
         env:
           NEXT_TELEMETRY_DISABLED: 1
-          # Placeholder values — no live Supabase instance at build time.
-          # NEXT_PUBLIC_* vars are inlined into the client bundle by Next.js;
-          # the real values are injected at runtime via .env.local in playwright/perf-gate.
+          # NEXT_PUBLIC_* are inlined into the client bundle at build time,
+          # so they cannot be swapped in later at runtime. The downstream
+          # playwright / perf-gate jobs run Supabase via the CLI, which
+          # always issues the same deterministic local anon key (derived
+          # from a fixed JWT secret shipped with the CLI). Baking that exact
+          # value here makes the client bundle authenticate successfully
+          # against the local Supabase Realtime/Auth endpoints — otherwise
+          # every browser-side WebSocket handshake fails with 403, Realtime
+          # falls back to polling, and the resulting "Polling" / "Presence
+          # unavailable" UI trips the axe WCAG contrast check while two-
+          # player matchmaking tests time out.
+          #
+          # This is the published Supabase CLI local anon JWT; it is not a
+          # secret and does not grant access to any deployed project.
           NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key-for-build
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
       - name: Verify build output
         run: |
           echo "=== .next/ contents ==="


### PR DESCRIPTION
## Summary

The \`build\` job was setting \`NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder-anon-key-for-build\`. \`NEXT_PUBLIC_*\` are inlined into the client bundle at build time and **cannot be swapped in at runtime**, so that placeholder ended up baked into every client JS chunk. The downstream \`playwright\` / \`perf-gate\` jobs start a local Supabase, which issues a **different, real** anon key — so every browser WebSocket handshake to Realtime failed with:

\`\`\`
WebSocket connection to 'ws://localhost:54321/realtime/v1/websocket?apikey=placeholder-anon-key-for-build' failed: Error during WebSocket handshake: Unexpected response code: 403
\`\`\`

Downstream symptoms on real GitHub CI:

- **\`lobby-visual.spec.ts:37\`** — axe WCAG 2.1 AA contrast scan fails on the \`Polling\` fallback badge (\`#bb674b\` on \`#f7ddcf\`, ratio 3.14) and \`Presence unavailable\` alert (\`#cb4644\` on \`#f5e4dd\`, ratio 3.78). Both only render when Realtime errors.
- **Two-player \`@*\` Phase tests** (\`hud-classic\`, \`left-rail\`, \`match-surfaces\`, \`postgame\`, \`lobby-finish\`) — time out at 180s because presence negotiation needs Realtime to get both players into the same match.

## Fix

The Supabase CLI issues a **deterministic** local anon JWT derived from a fixed JWT secret shipped with the CLI — same across every local install, published in Supabase docs. Authenticates only against local Supabase instances, grants no access to any deployed project. Baking that exact value into the \`build\` job's env makes the client bundle's anon key match what the playwright job's local Supabase issues at runtime.

## Relation to prior PRs

- #120 / #121 / #124 / #126 fixed the same class of problem for \`pnpm act\` (act-side networking + the \`act\` fallback build step).
- This PR fixes it for real GitHub CI, where the main \`build\` job still baked a placeholder.

## Test plan

- [ ] GitHub Actions CI on this PR: \`Playwright UI (playtest)\` and \`Playwright UI (baseline)\` both green
- [ ] No \`WebSocket ... 403\` browser console errors in the playwright logs
- [ ] No \`Polling\` badge / \`Presence unavailable\` alert rendering → axe scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)