### PR TITLE
fix(ui): remove gear/TopBar overlap; fold settings into UserMenu

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import { Fraunces, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import "./styles/board.css";
 import "./styles/lobby.css";
-import { GearMenu } from "@/components/ui/GearMenu";
 import { ToastProvider } from "@/components/ui/ToastProvider";
 import { TopBar } from "@/components/ui/TopBar";
 
@@ -40,11 +39,6 @@ export default function RootLayout({
         <ToastProvider>
           <div className="relative flex min-h-screen flex-col">
             <TopBar />
-            <div className="pointer-events-none absolute right-4 top-4 z-30">
-              <div className="pointer-events-auto">
-                <GearMenu />
-              </div>
-            </div>
             {children}
           </div>
         </ToastProvider>

--- a/components/ui/UserMenu.tsx
+++ b/components/ui/UserMenu.tsx
@@ -8,6 +8,7 @@ import { Avatar } from "@/components/ui/Avatar";
 import { LogoutConfirmDialog } from "@/components/ui/LogoutConfirmDialog";
 import type { LobbySession } from "@/lib/matchmaking/profile";
 import { useLobbyPresenceStore } from "@/lib/matchmaking/presenceStore";
+import { useSensoryPreferences } from "@/lib/preferences/useSensoryPreferences";
 
 export interface UserMenuProps {
   session: LobbySession;
@@ -22,6 +23,8 @@ export function UserMenu({ session }: UserMenuProps) {
   const chipRef = useRef<HTMLButtonElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const { player } = session;
+  const { preferences, setSoundEnabled, setHapticsEnabled } =
+    useSensoryPreferences();
 
   const close = useCallback(() => {
     setOpen(false);
@@ -104,11 +107,22 @@ export function UserMenu({ session }: UserMenuProps) {
           ref={menuRef}
           role="menu"
           aria-label="Account"
-          className="absolute right-0 top-full z-40 mt-2 w-[220px] overflow-hidden rounded-md border border-hair bg-paper/95 shadow-lg backdrop-blur-md"
+          className="absolute right-0 top-full z-40 mt-2 w-64 overflow-hidden rounded-md border border-hair bg-paper/95 shadow-lg backdrop-blur-md"
         >
           <div className="px-3 pt-3 pb-2 font-display text-[14px] italic leading-tight text-ink-soft">
             Signed in as {player.displayName}
           </div>
+          <div className="border-t border-hair" aria-hidden />
+          <ToggleMenuItem
+            label="Sound effects"
+            checked={preferences.soundEnabled}
+            onChange={setSoundEnabled}
+          />
+          <ToggleMenuItem
+            label="Haptic feedback"
+            checked={preferences.hapticsEnabled}
+            onChange={setHapticsEnabled}
+          />
           <div className="border-t border-hair" aria-hidden />
           <button
             type="button"
@@ -179,5 +193,41 @@ function LogOutIcon() {
       <polyline points="16 17 21 12 16 7" />
       <line x1="21" y1="12" x2="9" y2="12" />
     </svg>
+  );
+}
+
+interface ToggleMenuItemProps {
+  label: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+}
+
+function ToggleMenuItem({ label, checked, onChange }: ToggleMenuItemProps) {
+  return (
+    <button
+      type="button"
+      role="menuitemcheckbox"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-[13px] text-ink-3 hover:bg-paper-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-focus"
+    >
+      <span>{label}</span>
+      <span
+        aria-hidden="true"
+        className="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-hair transition-colors"
+        style={{
+          backgroundColor: checked
+            ? "oklch(0.62 0.12 150)" /* --good */
+            : "color-mix(in oklab, var(--ink) 8%, transparent)",
+        }}
+      >
+        <span
+          className="inline-block h-3.5 w-3.5 rounded-full bg-paper shadow-sm transition-transform"
+          style={{
+            transform: checked ? "translateX(1.1rem)" : "translateX(0.15rem)",
+          }}
+        />
+      </span>
+    </button>
   );
 }

--- a/tests/integration/ui/sensoryFeedback.spec.ts
+++ b/tests/integration/ui/sensoryFeedback.spec.ts
@@ -1,47 +1,66 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+import { generateTestUsername } from "./helpers/matchmaking";
 
 /**
  * Sensory Feedback E2E tests (015-sensory-feedback)
  *
- * T032: gear icon visible, preferences persist after navigation, sequential reveal fires two steps
- * T033: prefers-reduced-motion bypass — reveal data appears without reveal phase class
+ * Settings used to live behind a floating gear icon. As of PR #131 they
+ * moved into the TopBar UserMenu dropdown (menuitemcheckbox semantics),
+ * so this spec logs in first, opens the chip, and drives the toggles
+ * through their new home.
  */
 
+async function loginAs(page: Page, username: string) {
+  const input = page.getByTestId("lobby-username-input");
+  await expect(input).toBeVisible({ timeout: 10_000 });
+  await input.fill(username);
+  await page.getByTestId("lobby-login-submit").click();
+  await expect(page.getByTestId("lobby-presence-list")).toBeVisible({
+    timeout: 20_000,
+  });
+}
+
+function topbarChip(page: Page, username: string) {
+  return page
+    .getByTestId("topbar")
+    .getByRole("button", { name: new RegExp(username, "i") });
+}
+
 test.describe("Sensory feedback settings", () => {
-  test("gear icon is visible on the lobby page", async ({ page }) => {
+  test("UserMenu exposes sound + haptics toggles after login", async ({
+    page,
+  }) => {
+    const username = generateTestUsername("sfb-a");
     await page.goto("/");
-    const gearButton = page.getByRole("button", { name: /open settings/i });
-    await expect(gearButton).toBeVisible();
+    await loginAs(page, username);
+    await topbarChip(page, username).click();
+
+    const sound = page.getByRole("menuitemcheckbox", {
+      name: /sound effects/i,
+    });
+    const haptics = page.getByRole("menuitemcheckbox", {
+      name: /haptic feedback/i,
+    });
+    await expect(sound).toBeVisible();
+    await expect(haptics).toBeVisible();
   });
 
-  test("clicking gear icon opens settings panel with two toggles", async ({ page }) => {
+  test("disabling sound effects persists toggle state to localStorage", async ({
+    page,
+  }) => {
+    const username = generateTestUsername("sfb-b");
     await page.goto("/");
-    const gearButton = page.getByRole("button", { name: /open settings/i });
-    await gearButton.click();
+    await loginAs(page, username);
+    await topbarChip(page, username).click();
 
-    const panel = page.getByRole("dialog", { name: /settings/i });
-    await expect(panel).toBeVisible();
+    const sound = page.getByRole("menuitemcheckbox", {
+      name: /sound effects/i,
+    });
+    await expect(sound).toHaveAttribute("aria-checked", "true");
+    await sound.click();
+    await expect(sound).toHaveAttribute("aria-checked", "false");
 
-    const soundToggle = panel.getByRole("switch", { name: /sound effects/i });
-    const hapticsToggle = panel.getByRole("switch", { name: /haptic feedback/i });
-    await expect(soundToggle).toBeVisible();
-    await expect(hapticsToggle).toBeVisible();
-  });
-
-  test("disabling sound effects persists toggle state to localStorage", async ({ page }) => {
-    await page.goto("/");
-    const gearButton = page.getByRole("button", { name: /open settings/i });
-    await gearButton.click();
-
-    const soundToggle = page.getByRole("switch", { name: /sound effects/i });
-    // Default is enabled (aria-checked="true")
-    await expect(soundToggle).toHaveAttribute("aria-checked", "true");
-
-    // Disable
-    await soundToggle.click();
-    await expect(soundToggle).toHaveAttribute("aria-checked", "false");
-
-    // Check localStorage was written
     const stored = await page.evaluate(() =>
       localStorage.getItem("wottle-sensory-prefs"),
     );
@@ -50,23 +69,27 @@ test.describe("Sensory feedback settings", () => {
     expect(prefs.soundEnabled).toBe(false);
   });
 
-  test("preferences survive page navigation (persist in localStorage)", async ({ page }) => {
+  test("preferences survive page navigation", async ({ page }) => {
+    const username = generateTestUsername("sfb-c");
     await page.goto("/");
+    await loginAs(page, username);
+    await topbarChip(page, username).click();
 
-    // Disable haptics via settings panel
-    const gearButton = page.getByRole("button", { name: /open settings/i });
-    await gearButton.click();
-    const hapticsToggle = page.getByRole("switch", { name: /haptic feedback/i });
-    await hapticsToggle.click();
-    await expect(hapticsToggle).toHaveAttribute("aria-checked", "false");
+    const haptics = page.getByRole("menuitemcheckbox", {
+      name: /haptic feedback/i,
+    });
+    // Default is enabled; click to disable.
+    await expect(haptics).toHaveAttribute("aria-checked", "true");
+    await haptics.click();
+    await expect(haptics).toHaveAttribute("aria-checked", "false");
 
-    // Navigate away and back
     await page.goto("/");
-    const gearButton2 = page.getByRole("button", { name: /open settings/i });
-    await gearButton2.click();
-    const hapticsToggleAfter = page.getByRole("switch", { name: /haptic feedback/i });
-    // Should still be disabled
-    await expect(hapticsToggleAfter).toHaveAttribute("aria-checked", "false");
+    await topbarChip(page, username).click();
+    const hapticsAfter = page.getByRole("menuitemcheckbox", {
+      name: /haptic feedback/i,
+    });
+    // Should still be disabled after navigation.
+    await expect(hapticsAfter).toHaveAttribute("aria-checked", "false");
   });
 });
 
@@ -79,12 +102,8 @@ test.describe("Sensory feedback — reduced motion", () => {
 
     // The reduced-motion path transitions directly to "showing-summary" without
     // going through the "round-recap" animation phase.
-    // We verify this by checking that there are no board tiles with the reveal class active
-    // after a summary appears in CI. Since we can't easily trigger a full match end here,
-    // we verify the media query is respected by checking the page doesn't apply
-    // CSS transition classes to elements that would be animated.
+    // We verify this by checking that the media query is respected on the page.
     await page.goto("/");
-    // Reduced motion preference should be readable on the page
     const reducedMotion = await page.evaluate(() =>
       window.matchMedia("(prefers-reduced-motion: reduce)").matches,
     );

--- a/tests/unit/components/ui/UserMenu.test.tsx
+++ b/tests/unit/components/ui/UserMenu.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
@@ -12,6 +12,17 @@ vi.mock("@/app/actions/auth/logout", () => ({
 }));
 vi.mock("@/lib/matchmaking/presenceStore", () => ({
   useLobbyPresenceStore: { getState: () => ({ disconnect: vi.fn() }) },
+}));
+
+const setSoundEnabled = vi.fn();
+const setHapticsEnabled = vi.fn();
+const sensoryState = {
+  preferences: { soundEnabled: true, hapticsEnabled: false },
+  setSoundEnabled,
+  setHapticsEnabled,
+};
+vi.mock("@/lib/preferences/useSensoryPreferences", () => ({
+  useSensoryPreferences: () => sensoryState,
 }));
 
 import { UserMenu } from "@/components/ui/UserMenu";
@@ -32,6 +43,12 @@ const session = {
 };
 
 describe("<UserMenu>", () => {
+  beforeEach(() => {
+    setSoundEnabled.mockClear();
+    setHapticsEnabled.mockClear();
+    sensoryState.preferences = { soundEnabled: true, hapticsEnabled: false };
+  });
+
   it("renders the chip as an expandable button with the displayName", () => {
     render(<UserMenu session={session} />);
     const chip = screen.getByRole("button", { name: /ari/i });
@@ -96,5 +113,37 @@ describe("<UserMenu>", () => {
     await waitFor(() =>
       expect(logoutAction).toHaveBeenCalledWith({ resignActiveMatch: true }),
     );
+  });
+
+  it("renders sound + haptics toggles reflecting current preferences", () => {
+    render(<UserMenu session={session} />);
+    fireEvent.click(screen.getByRole("button", { name: /ari/i }));
+
+    const sound = screen.getByRole("menuitemcheckbox", {
+      name: /sound effects/i,
+    });
+    const haptics = screen.getByRole("menuitemcheckbox", {
+      name: /haptic feedback/i,
+    });
+    expect(sound).toHaveAttribute("aria-checked", "true");
+    expect(haptics).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("toggles sound effects off when clicked while enabled", () => {
+    render(<UserMenu session={session} />);
+    fireEvent.click(screen.getByRole("button", { name: /ari/i }));
+    fireEvent.click(
+      screen.getByRole("menuitemcheckbox", { name: /sound effects/i }),
+    );
+    expect(setSoundEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("toggles haptic feedback on when clicked while disabled", () => {
+    render(<UserMenu session={session} />);
+    fireEvent.click(screen.getByRole("button", { name: /ari/i }));
+    fireEvent.click(
+      screen.getByRole("menuitemcheckbox", { name: /haptic feedback/i }),
+    );
+    expect(setHapticsEnabled).toHaveBeenCalledWith(true);
   });
 });


### PR DESCRIPTION
Fixes #132

## Summary

The floating \`<GearMenu />\` mounted at \`right-4 top-4\` in \`app/layout.tsx\` overlapped with the new TopBar UserMenu chip (shipped in #131). Per the reporter's suggestion, the settings are folded into the chip dropdown and the gear is removed.

These commits were pushed to \`040-lobby-logout\` **after** #131 merged, so they never made it into main. This PR brings them across cleanly.

## Change

- The UserMenu chip dropdown grows from 220px → 256px and gains two \`role=\"menuitemcheckbox\"\` rows (Sound Effects, Haptic Feedback) between the \"Signed in as …\" caption and the Sign out item.
- \`<GearMenu />\` is removed from \`app/layout.tsx\`.
- Backing store is unchanged — \`useSensoryPreferences\` / \`wottle-sensory-prefs\` localStorage key still own the state, so existing user preferences survive the move.
- \`tests/integration/ui/sensoryFeedback.spec.ts\` is rewritten to log in first and drive the toggles through the chip dropdown (they now live in an authenticated surface).

\`\`\`
┌──────────────────────────────────┐
│ Signed in as Bong                │
├──────────────────────────────────┤
│ Sound effects          [──●   ]  │   ← menuitemcheckbox
│ Haptic feedback        [●───   ]  │   ← menuitemcheckbox
├──────────────────────────────────┤
│ 🚪 Sign out                       │
└──────────────────────────────────┘
\`\`\`

## Test plan

- [x] \`pnpm test:unit\` — 126 files / 864 passed / 2 skipped / 0 failed. 3 new tests in \`UserMenu.test.tsx\` cover toggle rendering, aria-checked state, and both setter wiring paths.
- [x] \`pnpm typecheck\` — clean.
- [x] \`pnpm lint\` (zero-warnings policy) — clean.
- [x] \`pnpm exec playwright test tests/integration/ui/lobby-logout.spec.ts tests/integration/ui/sensoryFeedback.spec.ts\` — 10/10 pass across Chromium + Firefox.
- [ ] Manual smoke on Vercel preview:
  - [ ] Chip dropdown no longer collides with anything on the right edge of the TopBar.
  - [ ] Toggle sound → close menu → reopen → state persisted.
  - [ ] Toggle haptics → hard-reload → state persisted (localStorage).

## Known follow-up (non-blocker)

Anonymous users (pre-login) lose the ability to touch sensory preferences. Nothing audible plays before login, so this is fine for the playtest. \`GearMenu.tsx\` and \`SettingsPanel.tsx\` remain on disk unreferenced — trivial to delete in a cleanup pass or resurrect if an anonymous settings surface ever matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)