### PR TITLE
revert(match): remove BoardCoordLabels wrap (breaks board layout in CI)

### DIFF
--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useRouter, useSearchParams } from "next/navigation";
 
+import { BoardCoordLabels } from "@/components/game/BoardCoordLabels";
 import { BoardGrid } from "@/components/game/BoardGrid";
 import { PlayerPanel } from "@/components/match/PlayerPanel";
 import { PlayerAvatar } from "@/components/match/PlayerAvatar";
@@ -802,38 +803,40 @@ export function MatchClient({
               />
             </div>
 
-            <BoardGrid
-              grid={matchState.board}
-              matchId={matchId}
-              frozenTiles={matchState.frozenTiles ?? {}}
-              playerSlot={playerSlot}
-              disabled={moveLocked}
-              showLockBanner={false}
-              lockedTiles={lockedSwapTiles}
-              opponentRevealTiles={
-                animationPhase === "round-recap" && activeRevealMove
-                  ? [activeRevealMove.from, activeRevealMove.to]
-                  : null
-              }
-              scoredTileHighlights={
-                animationPhase === "round-recap"
-                  ? activeRevealHighlights
-                  : []
-              }
-              highlightPlayerColors={
-                animationPhase === "round-recap"
-                  ? highlightPlayerColors
-                  : {}
-              }
-              highlightDurationMs={animationPhase === "round-recap" ? (matchState.state === "completed" ? 2400 : 1200) : 800}
-              highlightDelayMs={animationPhase === "round-recap" ? 450 : 0}
-              onSwapComplete={handleSwapComplete}
-              onSwapError={({ message }) => handleSwapError(message)}
-              onTileSelect={playTileSelect}
-              onValidSwap={() => { playValidSwap(); vibrateValidSwap(); }}
-              onInvalidMove={() => { playInvalidMove(); vibrateInvalidMove(); }}
-              onSelectionChange={setSelectedTile}
-            />
+            <BoardCoordLabels>
+              <BoardGrid
+                grid={matchState.board}
+                matchId={matchId}
+                frozenTiles={matchState.frozenTiles ?? {}}
+                playerSlot={playerSlot}
+                disabled={moveLocked}
+                showLockBanner={false}
+                lockedTiles={lockedSwapTiles}
+                opponentRevealTiles={
+                  animationPhase === "round-recap" && activeRevealMove
+                    ? [activeRevealMove.from, activeRevealMove.to]
+                    : null
+                }
+                scoredTileHighlights={
+                  animationPhase === "round-recap"
+                    ? activeRevealHighlights
+                    : []
+                }
+                highlightPlayerColors={
+                  animationPhase === "round-recap"
+                    ? highlightPlayerColors
+                    : {}
+                }
+                highlightDurationMs={animationPhase === "round-recap" ? (matchState.state === "completed" ? 2400 : 1200) : 800}
+                highlightDelayMs={animationPhase === "round-recap" ? 450 : 0}
+                onSwapComplete={handleSwapComplete}
+                onSwapError={({ message }) => handleSwapError(message)}
+                onTileSelect={playTileSelect}
+                onValidSwap={() => { playValidSwap(); vibrateValidSwap(); }}
+                onInvalidMove={() => { playInvalidMove(); vibrateInvalidMove(); }}
+                onSelectionChange={setSelectedTile}
+              />
+            </BoardCoordLabels>
 
             {roundAnnounce && (
               <div

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useRouter, useSearchParams } from "next/navigation";
 
-import { BoardCoordLabels } from "@/components/game/BoardCoordLabels";
 import { BoardGrid } from "@/components/game/BoardGrid";
 import { PlayerPanel } from "@/components/match/PlayerPanel";
 import { PlayerAvatar } from "@/components/match/PlayerAvatar";
@@ -803,40 +802,38 @@ export function MatchClient({
               />
             </div>
 
-            <BoardCoordLabels>
-              <BoardGrid
-                grid={matchState.board}
-                matchId={matchId}
-                frozenTiles={matchState.frozenTiles ?? {}}
-                playerSlot={playerSlot}
-                disabled={moveLocked}
-                showLockBanner={false}
-                lockedTiles={lockedSwapTiles}
-                opponentRevealTiles={
-                  animationPhase === "round-recap" && activeRevealMove
-                    ? [activeRevealMove.from, activeRevealMove.to]
-                    : null
-                }
-                scoredTileHighlights={
-                  animationPhase === "round-recap"
-                    ? activeRevealHighlights
-                    : []
-                }
-                highlightPlayerColors={
-                  animationPhase === "round-recap"
-                    ? highlightPlayerColors
-                    : {}
-                }
-                highlightDurationMs={animationPhase === "round-recap" ? (matchState.state === "completed" ? 2400 : 1200) : 800}
-                highlightDelayMs={animationPhase === "round-recap" ? 450 : 0}
-                onSwapComplete={handleSwapComplete}
-                onSwapError={({ message }) => handleSwapError(message)}
-                onTileSelect={playTileSelect}
-                onValidSwap={() => { playValidSwap(); vibrateValidSwap(); }}
-                onInvalidMove={() => { playInvalidMove(); vibrateInvalidMove(); }}
-                onSelectionChange={setSelectedTile}
-              />
-            </BoardCoordLabels>
+            <BoardGrid
+              grid={matchState.board}
+              matchId={matchId}
+              frozenTiles={matchState.frozenTiles ?? {}}
+              playerSlot={playerSlot}
+              disabled={moveLocked}
+              showLockBanner={false}
+              lockedTiles={lockedSwapTiles}
+              opponentRevealTiles={
+                animationPhase === "round-recap" && activeRevealMove
+                  ? [activeRevealMove.from, activeRevealMove.to]
+                  : null
+              }
+              scoredTileHighlights={
+                animationPhase === "round-recap"
+                  ? activeRevealHighlights
+                  : []
+              }
+              highlightPlayerColors={
+                animationPhase === "round-recap"
+                  ? highlightPlayerColors
+                  : {}
+              }
+              highlightDurationMs={animationPhase === "round-recap" ? (matchState.state === "completed" ? 2400 : 1200) : 800}
+              highlightDelayMs={animationPhase === "round-recap" ? 450 : 0}
+              onSwapComplete={handleSwapComplete}
+              onSwapError={({ message }) => handleSwapError(message)}
+              onTileSelect={playTileSelect}
+              onValidSwap={() => { playValidSwap(); vibrateValidSwap(); }}
+              onInvalidMove={() => { playInvalidMove(); vibrateInvalidMove(); }}
+              onSelectionChange={setSelectedTile}
+            />
 
             {roundAnnounce && (
               <div

--- a/tests/integration/ui/hud-classic.spec.ts
+++ b/tests/integration/ui/hud-classic.spec.ts
@@ -108,8 +108,8 @@ test.describe("@hud-classic Phase 1c HUD", () => {
       const cards = pageA.getByTestId("hud-card");
       const firstClass = await cards.nth(0).getAttribute("class");
       const secondClass = await cards.nth(1).getAttribute("class");
-      expect(firstClass).toMatch(/hud-card--opp/);
-      expect(secondClass).toMatch(/hud-card--you/);
+      expect(firstClass).toMatch(/hud-card--you/);
+      expect(secondClass).toMatch(/hud-card--opp/);
     } finally {
       await pageA.close();
       await pageB.close();

--- a/tests/integration/ui/match-surfaces.spec.ts
+++ b/tests/integration/ui/match-surfaces.spec.ts
@@ -39,7 +39,12 @@ async function loginPlayer(
 test.describe.configure({ mode: "serial", retries: 1 });
 
 test.describe("@match-surfaces Phase 1b visuals", () => {
-  test("board edges show A-J and 1-10 coord labels", async ({ browser }) => {
+  // TODO(#142-followup): coord labels require a layout-neutral overlay — the
+  // CSS-grid BoardCoordLabels wrapper collapsed the board inside MatchClient's
+  // flex column (align-items: center), causing 44px hitboxes to overlap and
+  // blocking Playwright clicks on neighbouring tiles. Skipped until we rework
+  // BoardCoordLabels as an absolute-positioned overlay.
+  test.skip("board edges show A-J and 1-10 coord labels", async ({ browser }) => {
     const contextA = await browser.newContext();
     const contextB = await browser.newContext();
     const pageA = await contextA.newPage();

--- a/tests/integration/ui/postgame.spec.ts
+++ b/tests/integration/ui/postgame.spec.ts
@@ -5,7 +5,7 @@ import {
   startMatchWithDirectInvite,
 } from "./helpers/matchmaking";
 
-test.describe.configure({ mode: "serial", retries: 1 });
+test.describe.configure({ mode: "serial", retries: 2, timeout: 240_000 });
 
 async function loginPlayer(page: Page, username: string) {
   await page.goto("/");


### PR DESCRIPTION
## Summary
PR #144's `BoardCoordLabels` wrap around `<BoardGrid>` in `MatchClient.tsx` is the root cause of the `left-rail` test failure (new in today's run) and the persistent `postgame` 240 s timeout.

## Evidence
Playwright log from the left-rail retry:

```
attempting click action on <button data-col="0" data-row="0" data-testid="board-tile">
  - element is visible, enabled and stable
  - <button data-col="4" data-row="1" …> subtree intercepts pointer events
  - retrying click action × 328
```

Tile (0,0) cannot be legitimately overlapped by tile (4,1). It **can** be overlapped by the 44 px touch-target pseudo-element defined on every cell (`app/styles/board.css:100-110`), which expands cells' hitboxes beyond their visual bounds whenever the visual cell is smaller than 44 px.

## Mechanism
`.board-coords` is a CSS grid:

```css
.board-coords {
  display: grid;
  grid-template-columns: auto 1fr;
  grid-template-rows: auto 1fr;
}
```

with no explicit width. Its new parent is `.match-layout__board` — a flex column with `align-items: center`. Flex items under `align-items: center` size to their intrinsic width, and a grid with `auto 1fr` has essentially no intrinsic width (the `1fr` minimum resolves to `min-content = 0`). So the wrapper collapses to ~16 px (the row-label column's content), the board inside gets squeezed to a sliver, every cell falls below 44 px, and the oversized hitboxes from one row overlap into the next. Playwright can never land a click on the real (0,0) tile.

The same squeeze breaks `match-shell` rendering enough that `postgame`'s `hud-resign-button` click also fails to land, and the test burns its 240 s budget inside Playwright's click-retry loop.

## Changes
- Revert the `BoardCoordLabels` import + wrap in `MatchClient.tsx`.
- Mark the `@match-surfaces` "board edges show A-J and 1-10 coord labels" spec as `test.skip()` with a TODO pointing at the follow-up.
- Keep the `hud-classic` assertion flip from #144 (correct — `a873e13` really did swap the you/opp order).
- Keep the `postgame` `retries: 2, timeout: 240_000` config (still a useful guard against real CI contention).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (zero-warnings policy)
- [x] `pnpm test:unit` — 890 passed / 2 skipped across 131 files
- [ ] GitHub Actions Playwright run on this branch — confirm `@left-rail`, `@hud-classic`, `@postgame` all pass

## Follow-up (P1, separate PR)
Reimplement `BoardCoordLabels` as an absolute-positioned overlay (no CSS-grid wrap), so `board-coords-top` / `board-coords-left` exist on the match page without resizing the board. Un-skip the coord-labels spec in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)