### PR TITLE
fix(ci): unblock Playwright — board-coords collapse, act job isolatio…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,13 +250,17 @@ jobs:
           - playtest
     timeout-minutes: 45
     env:
-      APP_PORT: 3000
+      # Per-matrix port so parallel runs (e.g. under `act`, which reuses host
+      # networking for matrix jobs) don't collide on port 3000. In real GitHub
+      # Actions each matrix job gets its own runner so the value is cosmetic,
+      # but it keeps the two environments symmetric.
+      APP_PORT: ${{ matrix.suite == 'playtest' && '3100' || '3000' }}
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       QUICKSTART_DISABLE_STOP: "1"
       RATE_LIMIT_DISABLED_SCOPES: "auth:login"
       RATE_LIMIT_DISABLE_ALL: "1"
       PLAYTEST_SESSION_SECURE: "false"
-      PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000
+      PLAYWRIGHT_BASE_URL: http://127.0.0.1:${{ matrix.suite == 'playtest' && '3100' || '3000' }}
       # PLAYTEST_PRESENCE_TTL_SECONDS removed - using code default of 300s
     steps:
       - name: Install Docker CLI (for act compatibility)
@@ -604,13 +608,24 @@ jobs:
             kill $NODE_PID 2>/dev/null || true
             rm .next-node-pid
           fi
-          # Targeted kill of any remaining server on this port
-          if command -v lsof &> /dev/null; then
-            lsof -ti :${APP_PORT:-3000} | xargs kill -9 2>/dev/null || true
+          # Targeted kill of any remaining server on this port. Skip under act:
+          # `act` shares host networking across parallel matrix jobs, so `lsof`
+          # on port 3000/3100 can see the sibling matrix job's server and the
+          # broad `pkill -f next.*start.*PORT` can match it too — killing the
+          # other job mid-test. Real CI runners are isolated so this is a no-op
+          # there.
+          if [ -z "$ACT" ]; then
+            if command -v lsof &> /dev/null; then
+              lsof -ti :${APP_PORT:-3000} | xargs kill -9 2>/dev/null || true
+            fi
+            pkill -f "next.*start.*${APP_PORT:-3000}" 2>/dev/null || true
           fi
-          pkill -f "next.*start.*${APP_PORT:-3000}" 2>/dev/null || true
       - name: Stop Supabase stack
-        if: always()
+        # Skip under act: both matrix jobs share the host's Supabase stack
+        # (ACT_USE_HOST_SUPABASE=1), so whichever job finishes first would stop
+        # Supabase mid-run for the other. On real CI each job owns its own
+        # Supabase container and this step runs normally.
+        if: ${{ always() && !env.ACT }}
         run: supabase stop || true
       - name: Upload Playwright log
         if: ${{ always() && !env.ACT }}

--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -693,6 +693,13 @@
   grid-template-columns: auto 1fr;
   grid-template-rows: auto 1fr;
   gap: 0.25rem 0.25rem;
+  /* Anchor the outer width so `1fr` has something to resolve against. Without
+     this, the grid collapses to the `auto` column's ~16px content width inside
+     the `align-items: center` flex parent, which shrinks every board cell
+     below 44px and lets the .board-grid__cell::after hitbox (min 44px) overlap
+     neighboring rows — breaking click routing in Playwright. */
+  width: 100%;
+  min-width: 0;
 }
 .board-coords__top {
   grid-column: 2;

--- a/tests/integration/ui/match-completion.spec.ts
+++ b/tests/integration/ui/match-completion.spec.ts
@@ -103,24 +103,24 @@ test.describe("Match completion — game-over screen (T034)", () => {
         const summaryView = pageA.getByTestId("final-summary-root");
         await expect(summaryView).toBeVisible({ timeout: 30_000 });
 
-        // Winner declaration OR draw banner must be visible
-        const hasWinner = await pageA.getByText("Winner").isVisible().catch(() => false);
-        const hasDraw = await pageA.getByText("Draw").isVisible().catch(() => false);
-        expect(hasWinner || hasDraw).toBe(true);
+        // Verdict banner must show one of Victory / Defeat / Draw (Phase 2 redesign).
+        const verdict = pageA.getByTestId("post-game-verdict");
+        await expect(verdict).toBeVisible();
+        await expect(verdict).toContainText(/Victory\.|Defeat\.|Draw\./);
 
-        // Ended reason shown
-        await expect(pageA.getByTestId("final-summary-ended-reason")).toContainText(
-          /10 rounds completed/i,
-        );
+        // Ended reason now lives inside the verdict card ("reasonLabel" prop).
+        await expect(verdict).toContainText(/10 rounds completed/i);
 
         // Scoreboard present
         await expect(pageA.getByTestId("final-summary-scoreboard")).toBeVisible();
 
-        // Word history section present (may be empty if no words scored)
-        await expect(pageA.getByTestId("final-summary-word-history")).toBeVisible();
+        // Words-of-match section present (replaces legacy final-summary-word-history).
+        await expect(pageA.getByTestId("words-of-match")).toBeVisible();
 
-        // Both players see "tiles frozen" text in the player cards (count may be 0)
-        const frozenTexts = await pageA.getByText(/tiles frozen/i).all();
+        // Both player cards in the PostGameScoreboard show "N frozen" (Phase 2
+        // replaced the legacy "tiles frozen" label with the compact "N frozen"
+        // inline stat). Count should be one per player card.
+        const frozenTexts = await pageA.getByText(/\d+ frozen/i).all();
         expect(frozenTexts.length).toBeGreaterThanOrEqual(1);
 
         // Action buttons present

--- a/tests/integration/ui/postgame.spec.ts
+++ b/tests/integration/ui/postgame.spec.ts
@@ -59,9 +59,7 @@ test.describe("@postgame Phase 2 post-game redesign", () => {
 
       // Resign to reach the post-game screen deterministically.
       await pageA.getByTestId("hud-resign-button").click();
-      // The resign dialog has a confirm "Resign" button — click the last one
-      // (the dialog button, not the HUD trigger).
-      await pageA.getByRole("button", { name: /^Resign$/i }).last().click();
+      await pageA.getByTestId("resign-confirm").click();
 
       await expect(pageA.getByTestId("final-summary-root")).toBeVisible({
         timeout: 20_000,
@@ -73,7 +71,9 @@ test.describe("@postgame Phase 2 post-game redesign", () => {
       await expect(
         pageA.getByTestId("final-summary-scoreboard"),
       ).toBeVisible();
-      await expect(pageA.getByTestId("round-by-round-chart")).toBeVisible();
+      // Chart mounts but has zero height when the match ends on round 1 with
+      // no rounds played, so check the component is attached rather than visible.
+      await expect(pageA.getByTestId("round-by-round-chart")).toBeAttached();
     } finally {
       await pageA.close();
       await pageB.close();

--- a/tests/integration/ui/round-summary.spec.ts
+++ b/tests/integration/ui/round-summary.spec.ts
@@ -90,7 +90,13 @@ async function submitSwap(page: import("@playwright/test").Page): Promise<void> 
 }
 
 test.describe("Round summary inline", () => {
-  test("shows inline round history and score delta after round resolves @two-player-playtest", async ({
+  // Phase 1c stopped mounting the PlayerPanel full variant that carried
+  // RoundHistoryInline (see CLAUDE.md "Unused PlayerPanel full variant"),
+  // so `round-history-inline` no longer appears in the live DOM. The overlay
+  // history (`hud-history-button` → `history-overlay` → `round-history-panel`)
+  // is covered by round-history.spec.ts. Unskip or rewrite against the
+  // overlay once the inline surface is either restored or fully removed.
+  test.skip("shows inline round history and score delta after round resolves @two-player-playtest", async ({
     browser,
   }) => {
     const contextA = await browser.newContext();

--- a/tests/integration/ui/rounds-flow.spec.ts
+++ b/tests/integration/ui/rounds-flow.spec.ts
@@ -173,10 +173,9 @@ test.describe("Round flow", () => {
       const summaryView = pageA.getByTestId("final-summary-root");
       await expect(summaryView).toBeVisible({ timeout: 30_000 });
 
-      // Verify match ended properly
-      await expect(pageA.getByTestId("final-summary-ended-reason")).toContainText(
-        /round/i
-      );
+      // Verify match ended properly. Phase 2 redesign moved the ended-reason
+      // text inside the post-game-verdict card as `reasonLabel`.
+      await expect(pageA.getByTestId("post-game-verdict")).toContainText(/round/i);
     } finally {
       await pageA.close();
       await pageB.close();

--- a/tests/integration/ui/z-final-summary.spec.ts
+++ b/tests/integration/ui/z-final-summary.spec.ts
@@ -125,9 +125,12 @@ test.describe("Final summary recap", () => {
       await expect(summaryView).toBeVisible({ timeout: 30_000 });
 
       await expect(pageA.getByTestId("final-summary-scoreboard")).toBeVisible();
-      await expect(pageA.getByTestId("final-summary-word-history")).toBeVisible();
-      await expect(pageA.getByTestId("final-summary-timers")).toBeVisible();
-      await expect(pageA.getByTestId("final-summary-ended-reason")).toContainText(/round/i);
+      // Phase 2 redesign: word history → `words-of-match`; standalone timers
+      // section is gone (duration now lives inside post-game-verdict as
+      // "Match complete · N rounds · Mm SSs"); ended reason is also inside
+      // post-game-verdict as `reasonLabel`.
+      await expect(pageA.getByTestId("words-of-match")).toBeVisible();
+      await expect(pageA.getByTestId("post-game-verdict")).toContainText(/round/i);
 
       await expect(pageA.getByTestId("final-summary-rematch")).toBeVisible();
       await expect(pageA.getByTestId("final-summary-back-lobby")).toBeVisible();


### PR DESCRIPTION
…n, Phase 2 test drift

Three independent issues stacked in the playtest CI job:

1. board-coords CSS collapse (app/styles/board.css) .board-coords is a CSS grid (grid-template-columns: auto 1fr) inside .match-layout__board which is `display: flex; align-items: center`. The flex item took its intrinsic content width, the `1fr` column collapsed to 0 (no external width to resolve against), and the whole board shrank to ~16px. Tiles fell below 44px, the .board-grid__cell::after touch- target hitbox (min 44px, z-index 5) bled across rows, and Playwright clicks on tile (0,0) routed to tile (4,1). Anchor with `width: 100%`.

2. act parallel-matrix infrastructure race (.github/workflows/ci.yml) Both baseline + playtest matrix jobs share host networking under act and use ACT_USE_HOST_SUPABASE=1 → same Supabase stack, contended port
   3000. Whichever job finished first ran `Stop Next.js`/`Stop Supabase` which killed the still-running sibling job mid-test. Per-matrix APP_PORT (3000/3100) + skip the Stop steps when env.ACT is set. Real GitHub Actions behavior (separate VMs per matrix entry) unchanged.

3. Phase 2 post-game test drift (tests/integration/ui/*.spec.ts) Warm Editorial Phase 2 redesign replaced FinalSummary's player cards with PostGameVerdict + PostGameScoreboard + WordsOfMatch. Old testids (final-summary-ended-reason, final-summary-word-history, final-summary-timers) and "Winner"/"Draw"/"tiles frozen" text were removed. Update assertions:
   - match-completion, z-final-summary, rounds-flow → assert against post-game-verdict (which now carries reasonLabel) and words-of-match; drop final-summary-timers (no equivalent surface); "tiles frozen" → /\d+ frozen/ (PostGameScoreboard inline stat).
   - postgame: resign-confirm by testid (not by accessible-name regex that never matched "Resign match" or "Yes, Resign"); chart uses toBeAttached (zero-height when match resigns on round 1).
   - round-summary: skip "round-history-inline" test — Phase 1c stopped mounting the PlayerPanel full variant that carried it (CLAUDE.md "Unused PlayerPanel full variant"). Overlay history surface remains covered by round-history.spec.ts.