### PR TITLE
feat(match): disconnection modal + claim-win (Phase 6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,8 +118,8 @@ Before implementing any feature:
 | 4a | Landing screen — dedicated `/` route, `LandingScreen` + `LandingTileVignette`, lobby login form removed | Merged |
 | 4b | Matchmaking screen — dedicated `/matchmaking` route, ring + found/starting phases | Merged |
 | 5a | Profile modal refresh — sparkline, best word, form chips, Challenge CTA | Merged |
-| 5b | `/profile` + `/profile/[handle]` pages + rating chart + word cloud | In progress |
-| 6 | Disconnection modal + claim-win Server Action | Planned |
+| 5b | `/profile` + `/profile/[handle]` pages + rating chart + word cloud | Merged |
+| 6 | Disconnection modal + claim-win Server Action | In progress |
 
 ## Architecture
 
@@ -151,7 +151,7 @@ Before implementing any feature:
   - `/data/wordlists` - Icelandic word list (~3.74M inflected forms, full BÍN fresh (1+ chars), loaded at runtime) + letter scoring values
 - `/components` - React Client Components
   - `/components/game` — `Board`, `BoardGrid`, `BoardCoordLabels`, `MoveFeedback`, `TimerHud`, `usePinchZoom`
-  - `/components/match` — core match client (`MatchClient`, `MatchShell`), HUD (`HudCard`, `MatchCenterChrome`, `RoundPipBar`), panels (`PlayerPanel`, `PlayerAvatar`, `TimerDisplay`, `TilesClaimedCard`), left rail (`MatchLeftRail`, `HowToPlayCard`, `LegendCard`, `YourMoveCard`), round recap (`RoundSummaryPanel`, `RoundHistoryPanel`, `RoundHistoryInline`, `ScoreDeltaPopup`, `WordHighlightOverlay`), post-game (`FinalSummary`, `PostGameVerdict`, `PostGameScoreboard`, `RoundByRoundChart`, `WordsOfMatch`), rematch (`RematchBanner`, `RematchInterstitial`, `useRematchNegotiation`)
+  - `/components/match` — core match client (`MatchClient`, `MatchShell`), HUD (`HudCard`, `MatchCenterChrome`, `RoundPipBar`), panels (`PlayerPanel`, `PlayerAvatar`, `TimerDisplay`, `TilesClaimedCard`), left rail (`MatchLeftRail`, `HowToPlayCard`, `LegendCard`, `YourMoveCard`), round recap (`RoundSummaryPanel`, `RoundHistoryPanel`, `RoundHistoryInline`, `ScoreDeltaPopup`, `WordHighlightOverlay`), post-game (`FinalSummary`, `PostGameVerdict`, `PostGameScoreboard`, `RoundByRoundChart`, `WordsOfMatch`), rematch (`RematchBanner`, `RematchInterstitial`, `useRematchNegotiation`), disconnect (`DisconnectionModal`, `useCountdown` — Phase 6)
   - `/components/lobby` — `LobbyHero`, `LobbyList`, `LobbyDirectory`, `LobbyCard`, `LobbyStatsStrip`, `PlayNowCard`, `InviteDialog`, `InviteToast`, `RecentGamesCard`, `TopOfBoardCard`, `EmptyLobbyState` *(`InviteToast`, `RecentGamesCard`, `TopOfBoardCard`, `EmptyLobbyState` ship with Phase 3 / PR #115)*
   - `/components/landing` — `LandingScreen`, `LandingTileVignette` *(Phase 4a)*
   - `/components/matchmaking` — `MatchmakingClient`, `MatchRing`, `MatchmakingVsBlock` *(Phase 4b)*
@@ -261,8 +261,8 @@ RLS policies enforced on all tables: players, lobby_presence, matches, rounds, m
 | Matchmaking       | Complete    | Direct invites, auto-queue, match bootstrap                                     |
 | Round Engine      | Complete    | State machine, conflict resolution, 10-round cycle                              |
 | Realtime          | Complete    | WebSocket channels + HTTP polling fallback                                      |
-| Reconnection      | Complete    | 10s window, timer pause, state restoration                                      |
-| Rate Limiting     | Complete    | 5/min auth, 30/min moves, 429 responses                                         |
+| Reconnection      | Complete    | 90s window, DisconnectionModal + claim-win CTA (Phase 6)                        |
+| Rate Limiting     | Complete    | 5/min auth, 30/min moves, 1/min claim-win, 429 responses                        |
 | Accessibility     | Complete    | Focus traps, aria-live, keyboard nav, 44×44 touch targets, WCAG 2.1 AA axe clean |
 | Observability     | Complete    | Structured logs, perf marks, analytics hooks                                    |
 | Word Finding      | Complete    | Set-based dictionary (3.74M entries), 8-directional scanner, delta detection    |
@@ -276,11 +276,8 @@ RLS policies enforced on all tables: players, lobby_presence, matches, rounds, m
 
 ### Remaining Gaps
 
-1. **Warm Editorial Phase 4** — dedicated Landing (`/`) + Matchmaking (`/matchmaking`) screens; routing change to pull the login form off `/lobby`.
-2. **Warm Editorial Phase 5** — player Profile modal and full `/profile` page with rating-history chart, word cloud, match history.
-3. **Warm Editorial Phase 6** — centered disconnection modal with 90s countdown + `claimWin` Server Action (currently just a text banner).
-4. **Legacy Endpoints** — `api/board`, `api/swap`, `actions/getBoard.ts`, `actions/swapTiles.ts` remain from early prototyping and should be removed in a cleanup pass.
-5. **Unused `PlayerPanel` full variant** — Phase 1c stopped mounting it on desktop; the code path still powers `RoundHistoryInline` surfaces. Audit and delete once verified unused.
+1. **Legacy Endpoints** — `api/board`, `api/swap`, `actions/getBoard.ts`, `actions/swapTiles.ts` remain from early prototyping and should be removed in a cleanup pass.
+2. **Unused `PlayerPanel` full variant** — Phase 1c stopped mounting it on desktop; the code path still powers `RoundHistoryInline` surfaces. Audit and delete once verified unused.
 
 ## Code Standards
 
@@ -368,9 +365,9 @@ RLS policies enforced on all tables: players, lobby_presence, matches, rounds, m
 
 **Disconnect Handling:**
 
-- Player marked disconnected in match state
-- Other player sees banner
-- Reconnection clears flag
+- Player marked disconnected in match state (realtime broadcast)
+- Other player sees centered `DisconnectionModal` with 90s countdown + Claim win CTA (Phase 6)
+- Reconnection within 90s clears the flag; past 90s `claimWinAction` or the auto-finalise awards the non-disconnected player (forced-winner path on `completeMatchInternal`)
 
 ## Key Entities
 
@@ -481,22 +478,7 @@ Playtest configuration:
 
 ## Next Steps (Recommended Priority Order)
 
-### P0 — Warm Editorial Phase 4: Landing + Matchmaking screens
-
-Dedicated `/` landing (username form → `/lobby`) and `/matchmaking` (ring spinner, rating-window expansion, found / starting states). Requires minor routing changes to pull the login form off `/lobby`.
-
-### P1 — Warm Editorial Phase 5: Profile modal + `/profile` page
-
-- `PlayerProfileDialog` opens from `LobbyDirectory` card clicks; shows sparkline + form chips + Challenge CTA.
-- `/profile` full page with sidebar, stats grid, SVG rating chart, word cloud, match history.
-- New Server Action `getPlayerProfile(handle)` aggregating stats + rating history (start derived from `match_ratings`; migrate to dedicated `rating_history` table only if the derivation gets expensive).
-
-### P2 — Warm Editorial Phase 6: Disconnection modal + claim-win
-
-- Replace the current text banner with a centered modal (pulse indicator, 90s countdown, Keep-waiting / Claim-win buttons).
-- New Server Action `claimWin(matchId)` — forfeits the opponent once `last_seen_at ≥ 90s`, awards the caller the truncated-score win, broadcasts match-completed via Realtime.
-
-### P3 — Legacy Cleanup + Production Readiness
+### P0 — Legacy Cleanup + Production Readiness
 
 - Remove legacy endpoints: `api/board`, `api/swap`, `actions/getBoard.ts`, `actions/swapTiles.ts`.
 - Audit + delete the unused `PlayerPanel` full variant once `RoundHistoryInline` is confirmed not to need it.

--- a/app/actions/match/claimWin.ts
+++ b/app/actions/match/claimWin.ts
@@ -1,0 +1,83 @@
+"use server";
+
+import "server-only";
+import { z } from "zod";
+
+import { completeMatchInternal } from "@/app/actions/match/completeMatch";
+import {
+  RECONNECT_WINDOW_MS_EXPORT,
+  getDisconnectedAt,
+} from "@/app/actions/match/handleDisconnect";
+import { readLobbySession } from "@/lib/matchmaking/profile";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+
+export type ClaimWinResult =
+  | { status: "ok"; matchId: string }
+  | { status: "too_early"; remainingMs: number }
+  | { status: "not_disconnected" }
+  | { status: "already_completed"; matchId: string }
+  | { status: "forbidden" }
+  | { status: "unauthenticated" }
+  | { status: "error"; message: string };
+
+const inputSchema = z.object({ matchId: z.string().uuid() });
+
+export async function claimWinAction(
+  matchId: string,
+): Promise<ClaimWinResult> {
+  const session = await readLobbySession();
+  if (!session) {
+    return { status: "unauthenticated" };
+  }
+
+  const parsed = inputSchema.safeParse({ matchId });
+  if (!parsed.success) {
+    return { status: "error", message: "Invalid matchId." };
+  }
+
+  try {
+    const supabase = getServiceRoleClient();
+    const { data: match } = await supabase
+      .from("matches")
+      .select("state, player_a_id, player_b_id")
+      .eq("id", parsed.data.matchId)
+      .maybeSingle();
+
+    if (!match) {
+      return { status: "error", message: "Match not found." };
+    }
+
+    if (match.state === "completed") {
+      return { status: "already_completed", matchId: parsed.data.matchId };
+    }
+
+    const selfId = session.player.id;
+    if (match.player_a_id !== selfId && match.player_b_id !== selfId) {
+      return { status: "forbidden" };
+    }
+
+    const opponentId =
+      match.player_a_id === selfId ? match.player_b_id : match.player_a_id;
+
+    const disconnectedAt = getDisconnectedAt(parsed.data.matchId, opponentId);
+    if (disconnectedAt === null) {
+      return { status: "not_disconnected" };
+    }
+
+    const elapsed = Date.now() - disconnectedAt;
+    if (elapsed < RECONNECT_WINDOW_MS_EXPORT) {
+      return {
+        status: "too_early",
+        remainingMs: RECONNECT_WINDOW_MS_EXPORT - elapsed,
+      };
+    }
+
+    await completeMatchInternal(parsed.data.matchId, "disconnect");
+    return { status: "ok", matchId: parsed.data.matchId };
+  } catch (error) {
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : "Claim win failed.",
+    };
+  }
+}

--- a/app/actions/match/claimWin.ts
+++ b/app/actions/match/claimWin.ts
@@ -9,6 +9,10 @@ import {
   getDisconnectedAt,
 } from "@/app/actions/match/handleDisconnect";
 import { readLobbySession } from "@/lib/matchmaking/profile";
+import {
+  assertWithinRateLimit,
+  RateLimitExceededError,
+} from "@/lib/rate-limiting/middleware";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 
 export type ClaimWinResult =
@@ -18,6 +22,7 @@ export type ClaimWinResult =
   | { status: "already_completed"; matchId: string }
   | { status: "forbidden" }
   | { status: "unauthenticated" }
+  | { status: "rate_limited"; retryAfterSeconds: number }
   | { status: "error"; message: string };
 
 const inputSchema = z.object({ matchId: z.string().uuid() });
@@ -28,6 +33,24 @@ export async function claimWinAction(
   const session = await readLobbySession();
   if (!session) {
     return { status: "unauthenticated" };
+  }
+
+  try {
+    assertWithinRateLimit({
+      identifier: session.player.id,
+      scope: "match:claim-win",
+      limit: 1,
+      windowMs: 60_000,
+      errorMessage: "Slow down — you can only claim one win per minute.",
+    });
+  } catch (error) {
+    if (error instanceof RateLimitExceededError) {
+      return {
+        status: "rate_limited",
+        retryAfterSeconds: error.retryAfterSeconds,
+      };
+    }
+    throw error;
   }
 
   const parsed = inputSchema.safeParse({ matchId });
@@ -72,7 +95,7 @@ export async function claimWinAction(
       };
     }
 
-    await completeMatchInternal(parsed.data.matchId, "disconnect");
+    await completeMatchInternal(parsed.data.matchId, "disconnect", selfId);
     return { status: "ok", matchId: parsed.data.matchId };
   } catch (error) {
     return {

--- a/app/actions/match/completeMatch.ts
+++ b/app/actions/match/completeMatch.ts
@@ -100,6 +100,7 @@ async function resetPlayerStatuses(
 export async function completeMatchInternal(
   matchId: string,
   reason: MatchEndedReason,
+  forcedWinnerId?: string,
 ): Promise<CompleteMatchResult> {
   const supabase = getServiceRoleClient();
   const match = await fetchMatch(supabase, matchId);
@@ -120,7 +121,24 @@ export async function completeMatchInternal(
   const frozenCounts = computeFrozenTileCountByPlayer(
     (match.frozen_tiles as FrozenTileMap) ?? {},
   );
-  const result = determineMatchWinner(scores, match.player_a_id, match.player_b_id, frozenCounts);
+  // Disconnect flows award the still-connected / claiming player regardless of
+  // score: loss of connection is treated as forfeit per Phase 6 spec §6.
+  const result =
+    forcedWinnerId !== undefined
+      ? {
+          winnerId: forcedWinnerId,
+          loserId:
+            forcedWinnerId === match.player_a_id
+              ? match.player_b_id
+              : match.player_a_id,
+          isDraw: false,
+        }
+      : determineMatchWinner(
+          scores,
+          match.player_a_id,
+          match.player_b_id,
+          frozenCounts,
+        );
 
   await supabase
     .from("matches")

--- a/app/actions/match/handleDisconnect.ts
+++ b/app/actions/match/handleDisconnect.ts
@@ -6,7 +6,7 @@ import { readLobbySession } from "@/lib/matchmaking/profile";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 import { writeMatchLog } from "@/lib/match/logWriter";
 
-const RECONNECT_WINDOW_MS = 10_000; // 10 seconds fixed constant per FR-012
+const RECONNECT_WINDOW_MS = 90_000; // 90 seconds per Phase 6 disconnect-modal spec
 
 interface DisconnectRecord {
   matchId: string;
@@ -62,7 +62,7 @@ export async function handlePlayerDisconnect(matchId: string, playerId: string):
   setTimeout(async () => {
     const record = disconnectStore.get(disconnectKey);
     if (record) {
-      // Player did not reconnect within 10 seconds
+      // Player did not reconnect within 90 seconds
       disconnectStore.delete(disconnectKey);
       await finalizeMatchOnDisconnectTimeout(supabase, matchId, playerId);
     }
@@ -178,6 +178,24 @@ async function loadMatchStateWithDisconnect(
     disconnectedPlayerId: null,
   };
 }
+
+/**
+ * Returns the timestamp (ms since epoch) when the player first lost their
+ * connection for this match, or null if they are currently connected.
+ *
+ * Used by claimWinAction to check whether the 90s window has elapsed.
+ */
+export function getDisconnectedAt(
+  matchId: string,
+  playerId: string,
+): number | null {
+  const key = `${matchId}:${playerId}`;
+  const record = disconnectStore.get(key);
+  if (!record) return null;
+  return new Date(record.disconnectedAt).getTime();
+}
+
+export const RECONNECT_WINDOW_MS_EXPORT = RECONNECT_WINDOW_MS;
 
 async function finalizeMatchOnDisconnectTimeout(
   supabase: ReturnType<typeof getServiceRoleClient>,

--- a/app/actions/match/handleDisconnect.ts
+++ b/app/actions/match/handleDisconnect.ts
@@ -203,5 +203,18 @@ async function finalizeMatchOnDisconnectTimeout(
   disconnectedPlayerId: string,
 ): Promise<void> {
   const { completeMatchInternal } = await import("./completeMatch");
-  await completeMatchInternal(matchId, "disconnect");
+
+  const { data: match } = await supabase
+    .from("matches")
+    .select("player_a_id, player_b_id")
+    .eq("id", matchId)
+    .maybeSingle();
+
+  const nonDisconnectedId = match
+    ? match.player_a_id === disconnectedPlayerId
+      ? match.player_b_id
+      : match.player_a_id
+    : undefined;
+
+  await completeMatchInternal(matchId, "disconnect", nonDisconnectedId);
 }

--- a/components/match/DisconnectionModal.tsx
+++ b/components/match/DisconnectionModal.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useId, useState } from "react";
+
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { useCountdown } from "@/components/match/useCountdown";
+
+interface DisconnectionModalProps {
+  opponentDisplayName: string;
+  disconnectedAt: number;
+  windowMs: number;
+  onClose: () => void;
+  onClaimWin: () => void;
+  isClaiming: boolean;
+}
+
+function formatCountdown(remaining: number): string {
+  const clamped = Math.max(0, remaining);
+  const minutes = Math.floor(clamped / 60);
+  const seconds = (clamped % 60).toString().padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}
+
+export function DisconnectionModal({
+  opponentDisplayName,
+  disconnectedAt,
+  windowMs,
+  onClose,
+  onClaimWin,
+  isClaiming,
+}: DisconnectionModalProps) {
+  const titleId = useId();
+  // Snap Date.now() once at mount so the countdown anchor is stable across
+  // re-renders (Date.now() inside the render body would be impure per React 19).
+  const [startSeconds] = useState(() =>
+    Math.max(0, Math.round((disconnectedAt + windowMs - Date.now()) / 1000)),
+  );
+  const { remaining, expired } = useCountdown(startSeconds);
+  const canClaim = expired && !isClaiming;
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      ariaLabelledBy={titleId}
+      bottomSheetOnMobile={false}
+    >
+      <div
+        data-testid="disconnection-modal"
+        className="flex flex-col items-center gap-5 text-center"
+      >
+        <div className="relative flex h-10 w-10 items-center justify-center">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-warn/60" />
+          <span className="relative inline-flex h-3 w-3 rounded-full bg-warn" />
+        </div>
+        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-warn">
+          Connection lost
+        </p>
+        <h2
+          id={titleId}
+          className="font-display text-2xl font-semibold italic text-ink sm:text-3xl"
+        >
+          {opponentDisplayName} dropped out.
+        </h2>
+        <p className="max-w-xs text-sm text-ink-3">
+          The match is paused. We&apos;ll wait up to 90 seconds for them to
+          reconnect, or you can claim the win.
+        </p>
+        <p
+          className="font-mono text-3xl tabular-nums tracking-[0.04em] text-ink"
+          aria-live="polite"
+        >
+          {formatCountdown(remaining)}
+        </p>
+        <div className="mt-2 grid w-full grid-cols-2 gap-2">
+          <Button variant="ghost" onClick={onClose} disabled={isClaiming}>
+            Keep waiting
+          </Button>
+          <Button onClick={onClaimWin} disabled={!canClaim}>
+            {isClaiming ? "Claiming\u2026" : "Claim win"}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -24,6 +24,8 @@ import type { MatchPlayerProfiles, MatchState, TimerState, Coordinate } from "@/
 import { getPlayerColors } from "@/lib/constants/playerColors";
 import { getBrowserSupabaseClient } from "@/lib/supabase/browser";
 import { subscribeToMatchChannel } from "@/lib/realtime/matchChannel";
+import { claimWinAction } from "@/app/actions/match/claimWin";
+import { DisconnectionModal } from "@/components/match/DisconnectionModal";
 import { handlePlayerDisconnect } from "@/app/actions/match/handleDisconnect";
 import { resignMatch } from "@/app/actions/match/resignMatch";
 import { triggerTimeoutCheck } from "@/app/actions/match/triggerTimeoutCheck";
@@ -102,6 +104,13 @@ export function MatchClient({
   const [disconnectedPlayerId, setDisconnectedPlayerId] = useState<
     string | null
   >(null);
+  // Phase 6 — disconnection modal state. disconnectStartedAt anchors the 90s
+  // countdown on the wall clock when the opponent first drops.
+  const [disconnectStartedAt, setDisconnectStartedAt] = useState<number | null>(
+    null,
+  );
+  const [showDisconnectModal, setShowDisconnectModal] = useState(true);
+  const [isClaimingWin, setIsClaimingWin] = useState(false);
 
   // In-game round history accumulation (US4)
   const [accumulatedWords, setAccumulatedWords] = useState<WordHistoryRow[]>([]);
@@ -567,6 +576,40 @@ export function MatchClient({
     }
   }, [matchId]);
 
+  const handleClaimWin = useCallback(async () => {
+    setIsClaimingWin(true);
+    try {
+      const result = await claimWinAction(matchId);
+      if (result.status === "ok" || result.status === "already_completed") {
+        // Realtime broadcast will drive both clients to the post-game screen.
+        return;
+      }
+      if (result.status === "too_early") {
+        setSwapError(
+          `Opponent still has ${Math.ceil(result.remainingMs / 1000)}s to reconnect.`,
+        );
+      } else if (result.status === "rate_limited") {
+        setSwapError(
+          `Too many claim attempts. Try again in ${result.retryAfterSeconds}s.`,
+        );
+      } else if (result.status === "not_disconnected") {
+        setSwapError("Your opponent is still connected.");
+      } else if (result.status === "forbidden") {
+        setSwapError("You are not a participant in this match.");
+      } else if (result.status === "unauthenticated") {
+        setSwapError("Please log in again.");
+      } else if (result.status === "error") {
+        setSwapError(result.message);
+      }
+    } catch (e) {
+      setSwapError(
+        e instanceof Error ? e.message : "Failed to claim win.",
+      );
+    } finally {
+      setIsClaimingWin(false);
+    }
+  }, [matchId]);
+
   // Derive opponent timer
   const opponentTimer: TimerState = useMemo(() => {
     if (matchState.timers.playerA.playerId === currentPlayerId) {
@@ -574,6 +617,22 @@ export function MatchClient({
     }
     return matchState.timers.playerA;
   }, [currentPlayerId, matchState.timers.playerA, matchState.timers.playerB]);
+
+  // Phase 6 — capture the wall-clock moment the opponent drops so the modal's
+  // countdown stays in sync across re-renders. Clears when the opponent
+  // reconnects (disconnectedPlayerId flips back to null).
+  const opponentDisconnected =
+    disconnectedPlayerId !== null &&
+    disconnectedPlayerId === opponentTimer.playerId;
+  useEffect(() => {
+    if (opponentDisconnected && disconnectStartedAt === null) {
+      setDisconnectStartedAt(Date.now());
+      setShowDisconnectModal(true);
+    } else if (!opponentDisconnected && disconnectStartedAt !== null) {
+      setDisconnectStartedAt(null);
+      setShowDisconnectModal(true);
+    }
+  }, [opponentDisconnected, disconnectStartedAt]);
 
   const opponentSlot: "player_a" | "player_b" =
     playerSlot === "player_a" ? "player_b" : "player_a";
@@ -685,16 +744,33 @@ export function MatchClient({
 
   return (
     <MatchShell matchId={matchId}>
-      {isReconnecting && (
+      {isReconnecting && disconnectedPlayerId === currentPlayerId && (
         <div
           className="mt-4 rounded-2xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200"
           data-testid="reconnect-banner"
         >
-          {disconnectedPlayerId === currentPlayerId
-            ? "Reconnecting... Please wait."
-            : "Opponent disconnected. Waiting for reconnection..."}
+          Reconnecting... Please wait.
         </div>
       )}
+
+      {opponentDisconnected &&
+      showDisconnectModal &&
+      disconnectStartedAt !== null &&
+      matchState.state !== "completed" ? (
+        <DisconnectionModal
+          opponentDisplayName={
+            (opponentSlot === "player_a"
+              ? playerProfiles.playerA
+              : playerProfiles.playerB
+            ).displayName
+          }
+          disconnectedAt={disconnectStartedAt}
+          windowMs={90_000}
+          onClose={() => setShowDisconnectModal(false)}
+          onClaimWin={handleClaimWin}
+          isClaiming={isClaimingWin}
+        />
+      ) : null}
 
       {usePolling && !isReconnecting && (
         <div

--- a/components/match/useCountdown.ts
+++ b/components/match/useCountdown.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export interface CountdownState {
+  remaining: number;
+  expired: boolean;
+}
+
+export function useCountdown(startSeconds: number): CountdownState {
+  const [remaining, setRemaining] = useState(startSeconds);
+
+  useEffect(() => {
+    setRemaining(startSeconds);
+    if (startSeconds <= 0) return;
+
+    const id = setInterval(() => {
+      setRemaining((prev) => (prev > 0 ? prev - 1 : 0));
+    }, 1_000);
+
+    return () => clearInterval(id);
+  }, [startSeconds]);
+
+  return { remaining, expired: remaining <= 0 };
+}

--- a/components/match/useCountdown.ts
+++ b/components/match/useCountdown.ts
@@ -7,19 +7,34 @@ export interface CountdownState {
   expired: boolean;
 }
 
+interface State {
+  start: number;
+  remaining: number;
+}
+
 export function useCountdown(startSeconds: number): CountdownState {
-  const [remaining, setRemaining] = useState(startSeconds);
+  const [state, setState] = useState<State>({
+    start: startSeconds,
+    remaining: startSeconds,
+  });
+
+  // Derived-state reset: when the prop changes, React calls setState during
+  // render, bails the current render, and restarts with the new state.
+  // See https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  if (state.start !== startSeconds) {
+    setState({ start: startSeconds, remaining: startSeconds });
+  }
 
   useEffect(() => {
-    setRemaining(startSeconds);
-    if (startSeconds <= 0) return;
-
+    if (state.remaining <= 0) return;
     const id = setInterval(() => {
-      setRemaining((prev) => (prev > 0 ? prev - 1 : 0));
+      setState((prev) => ({
+        ...prev,
+        remaining: prev.remaining > 0 ? prev.remaining - 1 : 0,
+      }));
     }, 1_000);
-
     return () => clearInterval(id);
-  }, [startSeconds]);
+  }, [state.remaining]);
 
-  return { remaining, expired: remaining <= 0 };
+  return { remaining: state.remaining, expired: state.remaining <= 0 };
 }

--- a/docs/superpowers/plans/2026-04-22-phase-6-disconnect-modal.md
+++ b/docs/superpowers/plans/2026-04-22-phase-6-disconnect-modal.md
@@ -1,0 +1,1017 @@
+# Phase 6 — Disconnection Modal + Claim-Win Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## Context
+
+**Why this change is being made.** Today's match screen signals an opponent disconnect only as a tiny flag on the `PlayerPanel` (`components/match/MatchClient.tsx:339–350` + `PlayerPanel.tsx:39+`). The backend has a **10s** reconnect window (`app/actions/match/handleDisconnect.ts:9` — `RECONNECT_WINDOW_MS = 10_000`). If the opponent's Realtime channel dies transiently, the match auto-finalizes with barely any chance to reconnect; if the player is on a sketchy network that's a terrible UX.
+
+Phase 6 delivers what the Warm Editorial spec §6 and prototype (`docs/design_documentation/wottle-game-design/project/prototype/screens/Overlays.jsx`) describe: a centered modal with pulse indicator, a 90-second countdown, and a primary **Claim win** button. The reconnect window extends from 10s to 90s; the `claimWin` Server Action lets the still-connected player manually forfeit the opponent once the window has elapsed.
+
+**Intended outcome.** When your opponent drops out, a centered modal appears with a 90-second countdown. You can hit "Keep waiting" (closes the modal but leaves the timer running in the background) or wait for the countdown to enable the "Claim win" button, which ends the match in your favour.
+
+## Goal
+
+1. Extend the server-side reconnect window from **10s → 90s** via one constant change.
+2. Ship a new `claimWinAction(matchId)` Server Action that forfeits the opponent once they've been disconnected for ≥90s — **awarding the caller the win regardless of current score**.
+3. Replace the existing passive disconnect banner with a dedicated `DisconnectionModal` component, wired into `MatchClient`.
+
+## Architecture
+
+1. **Server side (tiny):**
+   - Bump `RECONNECT_WINDOW_MS` from `10_000` to `90_000` in `handleDisconnect.ts`.
+   - Extend `completeMatchInternal(matchId, reason, forcedWinnerId?)` with a third optional argument that skips `determineMatchWinner` and uses the forced id. Preserves Elo + publish + reset paths unchanged.
+   - New `app/actions/match/claimWin.ts` passes the **caller** as `forcedWinnerId`, so the player who waited is unconditionally awarded the win. Rate-limited under `match:claim-win` (1/min per player).
+   - `finalizeMatchOnDisconnectTimeout` (the 90s auto-finaliser already in `handleDisconnect.ts`) passes the **still-connected player** as `forcedWinnerId` for the same reason — consistent semantics whether the user clicks Claim win or the timer self-fires.
+   - Idempotent: if the match is already `completed`, the action returns `already_completed` without mutation.
+2. **Client side:** one new component `DisconnectionModal`, composed of the existing `<Dialog>` primitive + a new `useCountdown(fromSeconds)` hook. The modal owns its timer and enables its primary button when the countdown hits zero. `MatchClient` conditionally mounts the modal when `matchState.disconnectedPlayerId === opponent.id`.
+3. **No database migrations.** Disconnect tracking still lives in the existing in-memory `disconnectStore` + realtime `disconnectedPlayerId` broadcast. The 90s-elapsed check inside `claimWinAction` reads the same store (exported getter).
+
+## Tech Stack
+
+TypeScript 5.x, React 19 Client Components, Next.js 16 Server Actions, Supabase JS v2, Zod, Tailwind CSS 4, Vitest + React Testing Library, Playwright.
+
+## Branch
+
+`027-disconnect-modal-phase-6`, branched from `origin/main` (commit `7ff02ee`, Phase 5b merged).
+
+---
+
+## Scope decisions
+
+**In scope:**
+
+1. Extend `RECONNECT_WINDOW_MS` to 90_000 in `app/actions/match/handleDisconnect.ts`.
+2. Expose an internal `getDisconnectedAt(matchId, playerId): number | null` helper from the same module so the new Server Action can query disconnect duration without duplicating state.
+3. Add optional `forcedWinnerId` param to `completeMatchInternal` so disconnect flows award the still-connected player regardless of score. (Behaviour change: `finalizeMatchOnDisconnectTimeout` now also forces the non-disconnected player — consistent with the claim-win CTA.)
+4. New `claimWinAction(matchId)` Server Action: auth + 90s-elapsed gate + rate-limited `match:claim-win` 1/min + idempotent (`already_completed` on re-call).
+5. New `useCountdown` hook (small, well-tested) that ticks every 1s and reports remaining seconds + "expired" boolean.
+6. New `DisconnectionModal` component with: pulse indicator, heading (`{opponent} dropped out.`), body copy, countdown display, "Keep waiting" (ghost) + "Claim win" (primary, disabled until countdown expires) buttons.
+7. Wire `DisconnectionModal` into `MatchClient` — mounts when `disconnectedPlayerId === opponent.id`; unmounts when the flag clears.
+8. Keep the existing `isDisconnected` flag on `PlayerPanel` — the modal is additive (you can close it; the badge stays). This preserves the subtle at-a-glance signal on the panel while adding the actionable modal.
+9. Playwright `@disconnect-modal` smoke — simulates a disconnect via `page.context().close()` on the opponent's context, asserts the active player sees the modal.
+
+**Deferred:**
+
+- Persisting `last_seen_at` to the DB on every round advance (current in-memory store is fine for single-server deployment; when scaling out to multiple server instances, persist then).
+- Sending an Ably/Supabase presence ping independent of Realtime channel health (current approach binds to the channel's disconnect event).
+- Audio cue when the modal appears (post-launch).
+
+**Explicitly not in scope:**
+
+- `ended_reason` enum additions (we reuse the existing `"disconnect"` reason).
+- Rating-adjustment changes for claim-win outcomes beyond the forced-winner plumb — the existing `applyRatingChanges` continues to award full Elo credit based on whoever ends up in `matches.winner_id`.
+
+---
+
+## File Structure
+
+**Read (reference only):**
+
+- `app/actions/match/handleDisconnect.ts` — extend; exports a getter in Task 1.
+- `app/actions/match/completeMatch.ts` — reused by the claim-win action via `completeMatchInternal(matchId, "disconnect")`.
+- `lib/match/statePublisher.ts` — `publishMatchState(matchId)` for the broadcast.
+- `components/match/MatchClient.tsx:339–350` — existing disconnect state machine. Phase 6 adds a modal mount block.
+- `components/ui/Dialog.tsx` — reuse with `bottomSheetOnMobile={false}` for centered-everywhere.
+- `docs/design_documentation/wottle-game-design/project/prototype/screens/Overlays.jsx` — visual reference.
+
+**Create:**
+
+- `app/actions/match/claimWin.ts`
+- `tests/unit/app/actions/claimWin.test.ts`
+- `components/match/useCountdown.ts`
+- `tests/unit/components/match/useCountdown.test.ts`
+- `components/match/DisconnectionModal.tsx`
+- `tests/unit/components/match/DisconnectionModal.test.tsx`
+- `tests/integration/ui/disconnect-modal.spec.ts`
+
+**Modify:**
+
+- `app/actions/match/handleDisconnect.ts` — 1-line constant bump + export a getter.
+- `components/match/MatchClient.tsx` — mount the modal conditionally.
+- `CLAUDE.md` — flip Phase 6 status + index the new files.
+
+---
+
+## Test commands (run after every task)
+
+- `pnpm lint` — zero warnings.
+- `pnpm typecheck` — exit 0.
+- `pnpm test -- --run` — unit suite.
+- `pnpm exec playwright test --grep @disconnect-modal` — smoke (new tag in Task 6).
+
+---
+
+## Task 1: Extend reconnect window to 90s + expose getter
+
+**Files:**
+- Modify: `app/actions/match/handleDisconnect.ts`
+
+Read the file first. It has:
+- `const RECONNECT_WINDOW_MS = 10_000;` (line ~9)
+- `disconnectStore: Map<string, DisconnectRecord>` (line ~18) — keyed by `${matchId}:${playerId}`.
+
+### Step 1: Bump the window + export a helper
+
+- [ ] Change the constant to `90_000` (ninety seconds). Update any inline comment referencing 10 seconds.
+
+- [ ] Add an exported getter at the bottom of the file (above `finalizeMatchOnDisconnectTimeout`):
+
+```ts
+/**
+ * Returns the timestamp (ms since epoch) when the player first lost their
+ * connection for this match, or null if they are currently connected.
+ *
+ * Used by claimWinAction to check whether the 90s window has elapsed.
+ */
+export function getDisconnectedAt(
+  matchId: string,
+  playerId: string,
+): number | null {
+  const key = `${matchId}:${playerId}`;
+  const record = disconnectStore.get(key);
+  return record?.disconnectedAt ?? null;
+}
+
+export const RECONNECT_WINDOW_MS_EXPORT = RECONNECT_WINDOW_MS;
+```
+
+(The `_EXPORT` alias keeps the module's original internal name untouched while giving tests + the claim-win action a public handle.)
+
+### Step 2: Run typecheck
+
+```bash
+pnpm typecheck
+```
+
+Clean.
+
+### Step 3: Commit
+
+```bash
+git add app/actions/match/handleDisconnect.ts
+git commit -m "feat(match): extend disconnect window to 90s + export getDisconnectedAt"
+```
+
+---
+
+## Task 1b: Forced-winner plumb on `completeMatchInternal`
+
+**Files:**
+- Modify: `app/actions/match/completeMatch.ts`
+- Modify: `app/actions/match/handleDisconnect.ts` (call site only)
+
+### Why
+
+Per the Warm Editorial spec §6: *"marks match completed, writes final MatchState with calling player as winner, awards truncated score (current scores stand)."* The existing `completeMatchInternal(matchId, reason)` uses `determineMatchWinner(scores, frozenCounts)` — so a disconnected player who happens to be leading would still win. Phase 6 treats loss-of-connection as forfeit; the still-connected / claiming player must win unconditionally.
+
+### Step 1: Extend signature
+
+Add a third optional parameter. If present, skip `determineMatchWinner` and build the result object from the forced id.
+
+```ts
+export async function completeMatchInternal(
+  matchId: string,
+  reason: MatchEndedReason,
+  forcedWinnerId?: string,
+): Promise<CompleteMatchResult> {
+  // ... fetch match, early-return on already-completed ...
+
+  const scores = await fetchLatestScores(supabase, matchId);
+  const frozenCounts = computeFrozenTileCountByPlayer(
+    (match.frozen_tiles as FrozenTileMap) ?? {},
+  );
+
+  const result =
+    forcedWinnerId !== undefined
+      ? {
+          winnerId: forcedWinnerId,
+          loserId:
+            forcedWinnerId === match.player_a_id
+              ? match.player_b_id
+              : match.player_a_id,
+          isDraw: false,
+        }
+      : determineMatchWinner(
+          scores,
+          match.player_a_id,
+          match.player_b_id,
+          frozenCounts,
+        );
+
+  // ... rest unchanged: update, applyRatingChanges(…, result), reset, log, publish, track.
+}
+```
+
+### Step 2: Update `finalizeMatchOnDisconnectTimeout`
+
+```ts
+async function finalizeMatchOnDisconnectTimeout(
+  supabase: ReturnType<typeof getServiceRoleClient>,
+  matchId: string,
+  disconnectedPlayerId: string,
+): Promise<void> {
+  const { completeMatchInternal } = await import("./completeMatch");
+
+  const { data: match } = await supabase
+    .from("matches")
+    .select("player_a_id, player_b_id")
+    .eq("id", matchId)
+    .maybeSingle();
+
+  const nonDisconnectedId = match
+    ? match.player_a_id === disconnectedPlayerId
+      ? match.player_b_id
+      : match.player_a_id
+    : undefined;
+
+  await completeMatchInternal(matchId, "disconnect", nonDisconnectedId ?? undefined);
+}
+```
+
+### Step 3: Test
+
+Add `tests/unit/app/actions/completeMatch.test.ts` (or extend if present) with:
+
+```ts
+test("uses forcedWinnerId over determineMatchWinner when provided", async () => {
+  // Seed scores with player_b leading 30-10, but pass forcedWinnerId = player_a.
+  // Assert matches.update() was called with winner_id = player_a.
+});
+```
+
+### Step 4: Run tests + typecheck + lint
+
+```bash
+pnpm test -- --run tests/unit/app/actions/completeMatch.test.ts
+pnpm typecheck
+pnpm lint
+```
+
+All green.
+
+### Step 5: Commit
+
+```bash
+git add app/actions/match/completeMatch.ts app/actions/match/handleDisconnect.ts tests/unit/app/actions/completeMatch.test.ts
+git commit -m "feat(match): force winner on disconnect paths (claim-win + 90s auto-finalise)"
+```
+
+---
+
+## Task 2: `claimWinAction` Server Action
+
+**Files:**
+- Create: `app/actions/match/claimWin.ts`
+- Create: `tests/unit/app/actions/claimWin.test.ts`
+
+### Behavior
+
+```ts
+claimWinAction(matchId: string) → Promise<ClaimWinResult>
+
+type ClaimWinResult =
+  | { status: "ok"; matchId: string }
+  | { status: "too_early"; remainingMs: number }
+  | { status: "not_disconnected" }
+  | { status: "already_completed"; matchId: string }
+  | { status: "forbidden" }
+  | { status: "unauthenticated" }
+  | { status: "error"; message: string };
+```
+
+Logic:
+1. `readLobbySession()` — returns `unauthenticated` if null.
+2. `assertWithinRateLimit({ scope: "match:claim-win", limit: 1, windowMs: 60_000, identifier: session.player.id })` — prevents rapid-fire claim attempts. Catches `RateLimitExceededError` and returns `{ status: "rate_limited", retryAfterSeconds }`.
+3. Zod-validate `matchId: z.string().uuid()`.
+4. Look up `matches` row. If state is already `"completed"`, return `{ status: "already_completed", matchId }`.
+5. If caller's id is neither `player_a_id` nor `player_b_id`, return `forbidden`.
+6. Identify the opponent id. If `getDisconnectedAt(matchId, opponentId)` is null, return `not_disconnected`.
+7. Compute `elapsed = Date.now() - disconnectedAt`. If `elapsed < RECONNECT_WINDOW_MS_EXPORT` (90s), return `{ status: "too_early", remainingMs: RECONNECT_WINDOW_MS_EXPORT - elapsed }`.
+8. Call `completeMatchInternal(matchId, "disconnect", session.player.id)` — pass the caller as `forcedWinnerId` so the still-connected player always wins.
+9. Return `{ status: "ok", matchId }`.
+
+### Step 1: Failing test
+
+Create `tests/unit/app/actions/claimWin.test.ts` using the established `vi.mock` + `buildChain` pattern (reference `tests/unit/app/actions/getPlayerProfile.test.ts`). Mock:
+
+- `@/lib/matchmaking/profile` → `readLobbySession` returns session for `player-a`.
+- `@/lib/supabase/server` → `getServiceRoleClient` with a `matches` chain for `.select("state, player_a_id, player_b_id").eq("id", matchId).maybeSingle()`.
+- `@/app/actions/match/handleDisconnect` → `{ getDisconnectedAt: vi.fn(), RECONNECT_WINDOW_MS_EXPORT: 90_000 }`.
+- `@/app/actions/match/completeMatch` → `completeMatchInternal: vi.fn()`.
+
+Test cases (8):
+
+1. Unauthenticated → `{ status: "unauthenticated" }`; `completeMatchInternal` not called.
+2. Invalid matchId (not UUID) → `{ status: "error", message: "Invalid matchId." }`.
+3. Match not found (`maybeSingle` returns `{ data: null }`) → `{ status: "error", message: "Match not found." }`.
+4. Caller not in `player_a_id/player_b_id` → `{ status: "forbidden" }`.
+5. Match already `state: "completed"` → `{ status: "already_completed", matchId }`.
+6. Opponent not disconnected (`getDisconnectedAt` returns null) → `{ status: "not_disconnected" }`.
+7. Opponent disconnected 30s ago → `{ status: "too_early", remainingMs: 60_000 }` (approximately — use `expect(result.remainingMs).toBeGreaterThan(59_000).toBeLessThan(61_000)`).
+8. Opponent disconnected 95s ago → `{ status: "ok", matchId }`; `completeMatchInternal` called with `(matchId, "disconnect")`.
+
+### Step 2: Verify FAIL, then implement
+
+Create `app/actions/match/claimWin.ts`:
+
+```ts
+"use server";
+
+import "server-only";
+import { z } from "zod";
+
+import { completeMatchInternal } from "@/app/actions/match/completeMatch";
+import {
+  RECONNECT_WINDOW_MS_EXPORT,
+  getDisconnectedAt,
+} from "@/app/actions/match/handleDisconnect";
+import { readLobbySession } from "@/lib/matchmaking/profile";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+
+export type ClaimWinResult =
+  | { status: "ok"; matchId: string }
+  | { status: "too_early"; remainingMs: number }
+  | { status: "not_disconnected" }
+  | { status: "already_completed"; matchId: string }
+  | { status: "forbidden" }
+  | { status: "unauthenticated" }
+  | { status: "rate_limited"; retryAfterSeconds: number }
+  | { status: "error"; message: string };
+
+const inputSchema = z.object({ matchId: z.string().uuid() });
+
+export async function claimWinAction(
+  matchId: string,
+): Promise<ClaimWinResult> {
+  const session = await readLobbySession();
+  if (!session) {
+    return { status: "unauthenticated" };
+  }
+
+  const parsed = inputSchema.safeParse({ matchId });
+  if (!parsed.success) {
+    return { status: "error", message: "Invalid matchId." };
+  }
+
+  try {
+    const supabase = getServiceRoleClient();
+    const { data: match } = await supabase
+      .from("matches")
+      .select("state, player_a_id, player_b_id")
+      .eq("id", parsed.data.matchId)
+      .maybeSingle();
+
+    if (!match) {
+      return { status: "error", message: "Match not found." };
+    }
+
+    if (match.state === "completed") {
+      return { status: "already_completed", matchId: parsed.data.matchId };
+    }
+
+    const selfId = session.player.id;
+    if (match.player_a_id !== selfId && match.player_b_id !== selfId) {
+      return { status: "forbidden" };
+    }
+
+    const opponentId =
+      match.player_a_id === selfId ? match.player_b_id : match.player_a_id;
+
+    const disconnectedAt = getDisconnectedAt(parsed.data.matchId, opponentId);
+    if (disconnectedAt === null) {
+      return { status: "not_disconnected" };
+    }
+
+    const elapsed = Date.now() - disconnectedAt;
+    if (elapsed < RECONNECT_WINDOW_MS_EXPORT) {
+      return {
+        status: "too_early",
+        remainingMs: RECONNECT_WINDOW_MS_EXPORT - elapsed,
+      };
+    }
+
+    await completeMatchInternal(parsed.data.matchId, "disconnect");
+    return { status: "ok", matchId: parsed.data.matchId };
+  } catch (error) {
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : "Claim win failed.",
+    };
+  }
+}
+```
+
+### Step 3: Run tests, typecheck, lint
+
+All green.
+
+### Step 4: Commit
+
+```bash
+git add app/actions/match/claimWin.ts tests/unit/app/actions/claimWin.test.ts
+git commit -m "feat(match): add claimWinAction for 90s-disconnect forfeit"
+```
+
+---
+
+## Task 3: `useCountdown` hook
+
+**Files:**
+- Create: `components/match/useCountdown.ts`
+- Create: `tests/unit/components/match/useCountdown.test.ts`
+
+### Behavior
+
+```ts
+useCountdown(startSeconds: number): { remaining: number; expired: boolean }
+```
+
+- On mount: starts at `startSeconds`, ticks once per 1000ms, floors to 0.
+- `remaining` is the whole-second value; `expired === remaining === 0`.
+- Respects `startSeconds` changes (resets on change).
+- Cleanup on unmount (no memory leaks).
+
+### Step 1: Failing test
+
+Create `tests/unit/components/match/useCountdown.test.ts`:
+
+```ts
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { useCountdown } from "@/components/match/useCountdown";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useCountdown", () => {
+  test("starts at the initial seconds", () => {
+    const { result } = renderHook(() => useCountdown(90));
+    expect(result.current.remaining).toBe(90);
+    expect(result.current.expired).toBe(false);
+  });
+
+  test("decrements every second", () => {
+    const { result } = renderHook(() => useCountdown(5));
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(result.current.remaining).toBe(3);
+  });
+
+  test("flips `expired` to true when remaining reaches 0", () => {
+    const { result } = renderHook(() => useCountdown(2));
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(result.current.remaining).toBe(0);
+    expect(result.current.expired).toBe(true);
+  });
+
+  test("resets when startSeconds changes", () => {
+    const { result, rerender } = renderHook(({ s }) => useCountdown(s), {
+      initialProps: { s: 10 },
+    });
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    expect(result.current.remaining).toBe(7);
+    rerender({ s: 90 });
+    expect(result.current.remaining).toBe(90);
+  });
+});
+```
+
+### Step 2: Verify FAIL
+
+### Step 3: Implement `components/match/useCountdown.ts`
+
+```ts
+"use client";
+
+import { useEffect, useState } from "react";
+
+export interface CountdownState {
+  remaining: number;
+  expired: boolean;
+}
+
+export function useCountdown(startSeconds: number): CountdownState {
+  const [remaining, setRemaining] = useState(startSeconds);
+
+  useEffect(() => {
+    setRemaining(startSeconds);
+    if (startSeconds <= 0) return;
+
+    const id = setInterval(() => {
+      setRemaining((prev) => (prev > 0 ? prev - 1 : 0));
+    }, 1_000);
+
+    return () => clearInterval(id);
+  }, [startSeconds]);
+
+  return { remaining, expired: remaining <= 0 };
+}
+```
+
+### Step 4: Verify PASS
+
+### Step 5: Commit
+
+```bash
+git add components/match/useCountdown.ts tests/unit/components/match/useCountdown.test.ts
+git commit -m "feat(match): add useCountdown hook"
+```
+
+---
+
+## Task 4: `DisconnectionModal` component
+
+**Files:**
+- Create: `components/match/DisconnectionModal.tsx`
+- Create: `tests/unit/components/match/DisconnectionModal.test.tsx`
+
+### Visual spec (from `Overlays.jsx:5–34`)
+
+- `<Dialog open onClose={...} bottomSheetOnMobile={false}>` — centered always.
+- Pulse indicator: `<span>` with Tailwind animation (reuse `animate-ping` on a small coloured dot).
+- Eyebrow (mono, `text-warn` or `text-ochre-deep`, uppercase): "Connection lost".
+- Heading: `{opponentDisplayName} dropped out.` — Fraunces italic, 24–26px.
+- Body: "The match is paused. We'll wait up to 90 seconds for them to reconnect, or you can claim the win."
+- Countdown: mono, tabular-nums, large (32px), format `m:ss` (so `1:30 → 0:29 → 0:00`).
+- Two buttons side-by-side:
+  - "Keep waiting" (ghost) — calls `onClose`.
+  - "Claim win" (primary) — calls `onClaimWin`; disabled while `expired === false`.
+- `data-testid="disconnection-modal"` on the outer wrapper.
+
+### API
+
+```ts
+interface DisconnectionModalProps {
+  opponentDisplayName: string;
+  disconnectedAt: number;        // ms since epoch
+  windowMs: number;              // expected 90_000
+  onClose: () => void;
+  onClaimWin: () => void;
+  isClaiming: boolean;           // disable Claim button while the action is in-flight
+}
+```
+
+The modal computes `startSeconds = Math.max(0, Math.round((disconnectedAt + windowMs - Date.now()) / 1000))` on render — so if the parent re-mounts after a poll refresh, the countdown picks up from the right place.
+
+### Step 1: Failing test
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { DisconnectionModal } from "@/components/match/DisconnectionModal";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const WINDOW_MS = 90_000;
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof DisconnectionModal>> = {}) {
+  const baseTime = Date.now();
+  return render(
+    <DisconnectionModal
+      opponentDisplayName="Birna"
+      disconnectedAt={overrides.disconnectedAt ?? baseTime}
+      windowMs={overrides.windowMs ?? WINDOW_MS}
+      onClose={overrides.onClose ?? vi.fn()}
+      onClaimWin={overrides.onClaimWin ?? vi.fn()}
+      isClaiming={overrides.isClaiming ?? false}
+    />,
+  );
+}
+
+describe("DisconnectionModal", () => {
+  test("renders opponent name + Connection lost eyebrow", () => {
+    renderModal();
+    expect(screen.getByText(/Connection lost/i)).toBeInTheDocument();
+    expect(screen.getByText(/Birna dropped out/i)).toBeInTheDocument();
+  });
+
+  test("shows countdown starting near 90 seconds", () => {
+    renderModal();
+    expect(screen.getByText(/1:30/)).toBeInTheDocument();
+  });
+
+  test("Claim win is disabled while countdown has remaining time", () => {
+    renderModal();
+    const btn = screen.getByRole("button", { name: /Claim win/i });
+    expect(btn).toBeDisabled();
+  });
+
+  test("Claim win becomes enabled after the window elapses", () => {
+    renderModal();
+    const btn = screen.getByRole("button", { name: /Claim win/i });
+    expect(btn).toBeDisabled();
+    // Advance just past 90s.
+    // (useCountdown ticks each 1s; 91 iterations to reach 0.)
+    for (let i = 0; i < 91; i += 1) {
+      // advanceTimersByTime step; wrapped in act via the library.
+      // @ts-expect-error — vi typing for fake timers
+      vi.advanceTimersByTime(1_000);
+    }
+    expect(btn).not.toBeDisabled();
+  });
+
+  test("Claim win click invokes onClaimWin", () => {
+    const onClaimWin = vi.fn();
+    renderModal({
+      disconnectedAt: Date.now() - WINDOW_MS - 1_000, // already expired
+      onClaimWin,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Claim win/i }));
+    expect(onClaimWin).toHaveBeenCalledTimes(1);
+  });
+
+  test("Keep waiting click invokes onClose", () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    fireEvent.click(screen.getByRole("button", { name: /Keep waiting/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("Claim win button shows spinner copy while isClaiming", () => {
+    renderModal({
+      disconnectedAt: Date.now() - WINDOW_MS - 1_000,
+      isClaiming: true,
+    });
+    expect(
+      screen.getByRole("button", { name: /Claiming/i }),
+    ).toBeDisabled();
+  });
+});
+```
+
+Note: the "advances timers" idiom above should actually use `act(() => vi.advanceTimersByTime(...))` from React Testing Library. Reference the existing `MatchmakingClient.test.tsx` for the exact pattern. If `act` requires you to wrap differently, adapt.
+
+### Step 2: Verify FAIL
+
+### Step 3: Implement `components/match/DisconnectionModal.tsx`
+
+```tsx
+"use client";
+
+import { useId } from "react";
+
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { useCountdown } from "@/components/match/useCountdown";
+
+interface DisconnectionModalProps {
+  opponentDisplayName: string;
+  disconnectedAt: number;
+  windowMs: number;
+  onClose: () => void;
+  onClaimWin: () => void;
+  isClaiming: boolean;
+}
+
+function formatCountdown(remaining: number): string {
+  const clamped = Math.max(0, remaining);
+  const minutes = Math.floor(clamped / 60);
+  const seconds = (clamped % 60).toString().padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}
+
+export function DisconnectionModal({
+  opponentDisplayName,
+  disconnectedAt,
+  windowMs,
+  onClose,
+  onClaimWin,
+  isClaiming,
+}: DisconnectionModalProps) {
+  const titleId = useId();
+  const startSeconds = Math.max(
+    0,
+    Math.round((disconnectedAt + windowMs - Date.now()) / 1000),
+  );
+  const { remaining, expired } = useCountdown(startSeconds);
+  const canClaim = expired && !isClaiming;
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      ariaLabelledBy={titleId}
+      bottomSheetOnMobile={false}
+    >
+      <div
+        data-testid="disconnection-modal"
+        className="flex flex-col items-center gap-5 text-center"
+      >
+        <div className="relative flex h-10 w-10 items-center justify-center">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-warn/60" />
+          <span className="relative inline-flex h-3 w-3 rounded-full bg-warn" />
+        </div>
+        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-warn">
+          Connection lost
+        </p>
+        <h2
+          id={titleId}
+          className="font-display text-2xl font-semibold italic text-ink sm:text-3xl"
+        >
+          {opponentDisplayName} dropped out.
+        </h2>
+        <p className="max-w-xs text-sm text-ink-3">
+          The match is paused. We&apos;ll wait up to 90 seconds for them to
+          reconnect, or you can claim the win.
+        </p>
+        <p
+          className="font-mono text-3xl tabular-nums tracking-[0.04em] text-ink"
+          aria-live="polite"
+        >
+          {formatCountdown(remaining)}
+        </p>
+        <div className="mt-2 grid w-full grid-cols-2 gap-2">
+          <Button variant="ghost" onClick={onClose} disabled={isClaiming}>
+            Keep waiting
+          </Button>
+          <Button onClick={onClaimWin} disabled={!canClaim}>
+            {isClaiming ? "Claiming…" : "Claim win"}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+```
+
+### Step 4: Verify PASS, typecheck + lint clean
+
+### Step 5: Commit
+
+```bash
+git add components/match/DisconnectionModal.tsx tests/unit/components/match/DisconnectionModal.test.tsx
+git commit -m "feat(match): add DisconnectionModal with 90s countdown + claim-win CTA"
+```
+
+---
+
+## Task 5: Wire `DisconnectionModal` into `MatchClient`
+
+**Files:**
+- Modify: `components/match/MatchClient.tsx`
+
+### Changes
+
+1. Import `DisconnectionModal`, `claimWinAction`, and the `RECONNECT_WINDOW_MS_EXPORT` constant (to pass as `windowMs`).
+2. Add local state:
+   - `const [showDisconnectModal, setShowDisconnectModal] = useState(true);` — so the user can close it via "Keep waiting" and not be pestered by re-opens on every state broadcast while the opponent is still away.
+   - `const [claiming, setClaiming] = useState(false);`
+   - `const [disconnectStartedAt, setDisconnectStartedAt] = useState<number | null>(null);` — records local wall-clock when the opponent first drops, so the countdown stays consistent across re-renders.
+3. In the existing `onState` handler, when `snapshot.disconnectedPlayerId` matches the opponent and `disconnectStartedAt === null`, call `setDisconnectStartedAt(Date.now())` and `setShowDisconnectModal(true)`. When the flag clears, reset both to `null`/`false`.
+4. Add a `handleClaim` callback that calls `claimWinAction(matchId)`, toasts any error, and on success clears local state (the realtime broadcast will navigate the client to the post-game screen naturally).
+5. Mount the modal conditionally:
+
+```tsx
+{matchState.disconnectedPlayerId === opponentId &&
+ showDisconnectModal &&
+ disconnectStartedAt ? (
+  <DisconnectionModal
+    opponentDisplayName={opponentDisplayName}
+    disconnectedAt={disconnectStartedAt}
+    windowMs={90_000}
+    onClose={() => setShowDisconnectModal(false)}
+    onClaimWin={handleClaim}
+    isClaiming={claiming}
+  />
+) : null}
+```
+
+`windowMs` is hard-coded to `90_000` here; if we ever need to tune it dynamically we can re-export from the Server Action side.
+
+- [ ] **Step 1: Implement the wiring** — read the file first to learn where `opponentId` / `opponentDisplayName` are derived. They should already be computed (see the existing `PlayerPanel` `isDisconnected` wiring around line 802).
+
+- [ ] **Step 2: Write a focused MatchClient test** covering the new mount block. Mock `claimWinAction` and assert:
+  - The modal renders when `matchState.disconnectedPlayerId === opponentId` after state broadcast.
+  - Clicking "Keep waiting" hides the modal.
+  - Clicking "Claim win" after the countdown expires calls `claimWinAction` once.
+
+Existing MatchClient tests likely live at `tests/unit/components/match/MatchClient.test.tsx` (if present) — extend there. If no MatchClient test exists, create one scoped just to the disconnect-modal behaviour.
+
+- [ ] **Step 3: Run typecheck + unit suite**
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test -- --run
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/match/MatchClient.tsx tests/unit/components/match/MatchClient.test.tsx
+git commit -m "feat(match): mount DisconnectionModal when opponent drops"
+```
+
+(If no pre-existing MatchClient test file, include whatever new test file you create in the `git add`.)
+
+---
+
+## Task 6: `@disconnect-modal` Playwright smoke
+
+**Files:**
+- Create: `tests/integration/ui/disconnect-modal.spec.ts`
+
+### Approach
+
+Simulating a real disconnect end-to-end is expensive. A pragmatic smoke test:
+
+1. Two players log in and start a match via `startMatchWithDirectInvite` helper.
+2. Close Player B's context mid-match.
+3. On Player A, wait for the `disconnection-modal` testid (the backend broadcasts `disconnectedPlayerId` within ~1-2s of channel closure).
+4. Assert the countdown and the disabled Claim-win button.
+5. Optional: inject fake time via `page.evaluate` to advance the countdown past 90s, then click Claim-win and confirm match completion.
+
+Full-scale claim-win flow tested at unit level (server action), so the Playwright smoke can stop at step 3-4.
+
+- [ ] **Step 1: Write the spec** (scope to chromium, pattern from `matchmaking-phase-4b.spec.ts`)
+
+```ts
+import { test, expect, type BrowserContext } from "@playwright/test";
+
+import {
+  generateTestUsername,
+  startMatchWithDirectInvite,
+} from "./helpers/matchmaking";
+
+test.describe.configure({ mode: "serial", retries: 1 });
+
+test.skip(
+  ({ browserName }) => browserName !== "chromium",
+  "Phase 6 disconnect-modal runs on chromium only",
+);
+
+async function loginAs(context: BrowserContext, prefix: string) {
+  const page = await context.newPage();
+  const username = generateTestUsername(prefix);
+  await page.goto("/");
+  await page.getByTestId("landing-username-input").fill(username);
+  await page.getByTestId("landing-login-submit").click();
+  await expect(page).toHaveURL(/\/lobby$/, { timeout: 15_000 });
+  return { page, username };
+}
+
+test.describe("@disconnect-modal Phase 6", () => {
+  test("opponent disconnect shows the modal on the remaining player's page", async ({
+    browser,
+  }) => {
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    try {
+      const [a, b] = await Promise.all([
+        loginAs(ctxA, "dc-alpha"),
+        loginAs(ctxB, "dc-beta"),
+      ]);
+
+      await startMatchWithDirectInvite(a.page, b.page, {
+        playerBUsername: b.username,
+      });
+
+      // Player B "disconnects" — close their context.
+      await ctxB.close();
+
+      // Player A should see the disconnection modal within a few seconds.
+      await expect(a.page.getByTestId("disconnection-modal")).toBeVisible({
+        timeout: 15_000,
+      });
+      // Claim win is disabled while the 90s countdown is running.
+      await expect(
+        a.page.getByRole("button", { name: /Claim win/i }),
+      ).toBeDisabled();
+    } finally {
+      await ctxA.close();
+      // ctxB already closed
+    }
+  });
+
+  test("Keep waiting dismisses the modal but the banner/badge stays", async ({
+    browser,
+  }) => {
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    try {
+      const [a, b] = await Promise.all([
+        loginAs(ctxA, "dc-keep-a"),
+        loginAs(ctxB, "dc-keep-b"),
+      ]);
+
+      await startMatchWithDirectInvite(a.page, b.page, {
+        playerBUsername: b.username,
+      });
+
+      await ctxB.close();
+
+      const modal = a.page.getByTestId("disconnection-modal");
+      await expect(modal).toBeVisible({ timeout: 15_000 });
+
+      await a.page.getByRole("button", { name: /Keep waiting/i }).click();
+      await expect(modal).toBeHidden({ timeout: 5_000 });
+    } finally {
+      await ctxA.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+pnpm exec playwright test --grep @disconnect-modal tests/integration/ui/disconnect-modal.spec.ts
+```
+
+Expected: 2 chromium pass + 2 skipped on firefox.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/ui/disconnect-modal.spec.ts
+git commit -m "test(match): add @disconnect-modal Playwright smoke"
+```
+
+---
+
+## Task 7: CLAUDE.md + PR
+
+- [ ] **Step 1: Update CLAUDE.md**
+
+```
+| 5b | `/profile` + `/profile/[handle]` pages + rating chart + word cloud | Merged |
+| 6  | Disconnection modal + claim-win Server Action | In progress |
+```
+
+Under `components/match` in the Directory Structure section, extend the existing line:
+
+```
+`/components/match` — ...existing list..., `DisconnectionModal`, `useCountdown` *(Phase 6)*
+```
+
+- [ ] **Step 2: Commit docs + plan**
+
+```bash
+git add CLAUDE.md docs/superpowers/plans/2026-04-22-phase-6-disconnect-modal.md
+git commit -m "docs(claude): reflect Phase 6 disconnection modal"
+```
+
+- [ ] **Step 3: Push + open PR**
+
+```bash
+git push -u origin 027-disconnect-modal-phase-6
+gh pr create --title "feat(match): disconnection modal + claimWinAction (Phase 6)" --body "..."
+```
+
+PR body should include: 10s → 90s reconnect window bump, new `claimWinAction`, new `DisconnectionModal` + `useCountdown`, replaced passive banner with centered modal.
+
+---
+
+## Verification (end-to-end)
+
+After all commits land locally:
+
+1. `pnpm build && pnpm start` (or `pnpm dev`).
+2. Log in two browsers, start a match.
+3. Close one browser window — the remaining player should see the disconnection modal within a few seconds.
+4. "Keep waiting" dismisses the modal; wait a few more seconds, nothing should break.
+5. Wait for the 90-second auto-finalize: the match page should navigate to the post-game summary on the remaining player's side.
+6. As a follow-up (manual test with system clock manipulation, or by adjusting `RECONNECT_WINDOW_MS` to e.g. 10s temporarily): click Claim win after countdown expires; confirm match completes with `ended_reason = "disconnect"` and the clicker is the winner.
+
+## Acceptance criteria
+
+- [x] `RECONNECT_WINDOW_MS` bumped to 90_000.
+- [x] `getDisconnectedAt(matchId, playerId)` exported from `handleDisconnect.ts`.
+- [x] `claimWinAction(matchId)` implements auth + 90s gate + idempotent completion.
+- [x] `useCountdown` ticks every second, handles re-init, cleans up on unmount.
+- [x] `DisconnectionModal` renders Warm Editorial design: pulse, copy, countdown, Keep-waiting + Claim-win (disabled while ticking).
+- [x] `MatchClient` mounts the modal when `disconnectedPlayerId === opponentId` and unmounts when cleared.
+- [x] Playwright `@disconnect-modal` green on chromium.
+- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test -- --run` all clean.
+- [x] CLAUDE.md Phase table + directory index updated.
+
+---
+
+## Critical files referenced
+
+- `app/actions/match/handleDisconnect.ts` — 1-line constant change + export in Task 1.
+- `app/actions/match/completeMatch.ts` — `completeMatchInternal(matchId, "disconnect")` reused.
+- `lib/match/statePublisher.ts` — broadcast on state change (already in place).
+- `components/ui/Dialog.tsx` — centered modal primitive.
+- `components/match/MatchClient.tsx:339–350` — existing disconnect state-machine site.
+- `docs/design_documentation/wottle-game-design/project/prototype/screens/Overlays.jsx` — pixel reference.
+- `docs/superpowers/specs/2026-04-19-wottle-design-implementation.md` §6 — design spec.

--- a/tests/integration/match/forcedWinner.spec.ts
+++ b/tests/integration/match/forcedWinner.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Integration test for the Phase 6 forced-winner path in completeMatchInternal.
+ *
+ * Disconnect flows (claim-win + 90s auto-finalise) award the still-connected /
+ * claiming player regardless of current score. This guards against the earlier
+ * behaviour where a disconnected leader would still win based on the scoreboard.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/server", () => ({ getServiceRoleClient: vi.fn() }));
+vi.mock("@/lib/match/statePublisher", () => ({
+  publishMatchState: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/match/logWriter", () => ({
+  writeMatchLog: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/observability/log", () => ({
+  trackMatchResult: vi.fn(),
+  trackRoundCompleted: vi.fn(),
+}));
+vi.mock("@/lib/rating/persistRatingChanges", () => ({
+  persistRatingChanges: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { completeMatchInternal } from "@/app/actions/match/completeMatch";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+
+const MATCH_ID = "match-forced-winner-test";
+const PLAYER_A = "player-a";
+const PLAYER_B = "player-b";
+
+function setupMocks(scores: { playerA: number; playerB: number }) {
+  let matchUpdatePayload: Record<string, unknown> | null = null;
+
+  const matchChain = {
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({
+      data: {
+        id: MATCH_ID,
+        state: "in_progress",
+        player_a_id: PLAYER_A,
+        player_b_id: PLAYER_B,
+        winner_id: null,
+        ended_reason: null,
+        round_limit: 10,
+        frozen_tiles: {},
+      },
+      error: null,
+    }),
+  };
+
+  const scoreboardChain = {
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: {
+        round_number: 10,
+        player_a_score: scores.playerA,
+        player_b_score: scores.playerB,
+      },
+    }),
+  };
+
+  const playersSelectChain = {
+    in: vi.fn().mockResolvedValue({
+      data: [
+        { id: PLAYER_A, elo_rating: 1200, games_played: 10 },
+        { id: PLAYER_B, elo_rating: 1200, games_played: 10 },
+      ],
+      error: null,
+    }),
+  };
+
+  const matchesUpdate = vi.fn().mockImplementation((payload: unknown) => {
+    matchUpdatePayload = payload as Record<string, unknown>;
+    return { eq: vi.fn().mockResolvedValue({ error: null }) };
+  });
+
+  vi.mocked(getServiceRoleClient).mockReturnValue({
+    from: vi.fn((table: string) => {
+      if (table === "matches")
+        return { select: vi.fn(() => matchChain), update: matchesUpdate };
+      if (table === "scoreboard_snapshots")
+        return { select: vi.fn(() => scoreboardChain) };
+      if (table === "players")
+        return {
+          select: vi.fn(() => playersSelectChain),
+          update: vi
+            .fn()
+            .mockReturnValue({
+              in: vi.fn().mockResolvedValue({ error: null }),
+            }),
+        };
+      if (table === "lobby_presence")
+        return {
+          update: vi
+            .fn()
+            .mockReturnValue({
+              in: vi.fn().mockResolvedValue({ error: null }),
+            }),
+        };
+      if (table === "match_logs")
+        return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      return {};
+    }),
+  } as never);
+
+  return { getMatchUpdatePayload: () => matchUpdatePayload };
+}
+
+describe("completeMatchInternal forcedWinnerId (Phase 6)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses forcedWinnerId over determineMatchWinner when the disconnected player is leading on score", async () => {
+    // Player B has 30-10 lead, but A is claiming the win after B disconnected.
+    const { getMatchUpdatePayload } = setupMocks({ playerA: 10, playerB: 30 });
+
+    const result = await completeMatchInternal(MATCH_ID, "disconnect", PLAYER_A);
+
+    expect(getMatchUpdatePayload()).toMatchObject({
+      winner_id: PLAYER_A,
+      ended_reason: "disconnect",
+    });
+    expect(result.winnerId).toBe(PLAYER_A);
+    expect(result.loserId).toBe(PLAYER_B);
+    expect(result.isDraw).toBe(false);
+  });
+
+  it("falls back to determineMatchWinner when no forcedWinnerId is passed", async () => {
+    // Score-based path: playerB leads → playerB wins.
+    const { getMatchUpdatePayload } = setupMocks({ playerA: 10, playerB: 30 });
+
+    const result = await completeMatchInternal(MATCH_ID, "round_limit");
+
+    expect(getMatchUpdatePayload()).toMatchObject({ winner_id: PLAYER_B });
+    expect(result.winnerId).toBe(PLAYER_B);
+  });
+});

--- a/tests/integration/ui/disconnect-modal.spec.ts
+++ b/tests/integration/ui/disconnect-modal.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type BrowserContext, type Page } from "@playwright/test";
+
+import {
+  generateTestUsername,
+  startMatchWithDirectInvite,
+} from "./helpers/matchmaking";
+
+test.describe.configure({ mode: "serial", retries: 1 });
+
+// Dual-context disconnect smoke shares presence + match-channel state across
+// Playwright projects. Scope to chromium only to avoid realtime races with
+// the parallel playtest-firefox project.
+test.skip(
+  ({ browserName }) => browserName !== "chromium",
+  "Phase 6 disconnect-modal runs on chromium only",
+);
+
+async function loginAs(context: BrowserContext, prefix: string) {
+  const page = await context.newPage();
+  const username = generateTestUsername(prefix);
+  await page.goto("/");
+  await page.getByTestId("landing-username-input").fill(username);
+  await page.getByTestId("landing-login-submit").click();
+  await expect(page).toHaveURL(/\/lobby$/, { timeout: 15_000 });
+  return { page, username };
+}
+
+async function waitForMatch(page: Page) {
+  await expect(page).toHaveURL(/\/match\/[0-9a-f-]+/, { timeout: 20_000 });
+  await expect(page.getByTestId("board-grid")).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe("@disconnect-modal Phase 6", () => {
+  test("opponent disconnect shows modal with Claim win disabled during countdown", async ({
+    browser,
+  }) => {
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    try {
+      const [a, b] = await Promise.all([
+        loginAs(ctxA, "dc-show-a"),
+        loginAs(ctxB, "dc-show-b"),
+      ]);
+
+      await startMatchWithDirectInvite(a.page, b.page, {
+        playerBUsername: b.username,
+      });
+      await Promise.all([waitForMatch(a.page), waitForMatch(b.page)]);
+
+      // Player B disconnects — closing the context tears down the Realtime
+      // channel, which the server observes and broadcasts.
+      await ctxB.close();
+
+      // Modal should render on A within a few seconds.
+      await expect(a.page.getByTestId("disconnection-modal")).toBeVisible({
+        timeout: 20_000,
+      });
+
+      // Claim win is disabled while the 90s countdown is running.
+      await expect(
+        a.page.getByRole("button", { name: /Claim win/i }),
+      ).toBeDisabled();
+    } finally {
+      await ctxA.close();
+      // ctxB already closed above
+    }
+  });
+
+  test("Keep waiting dismisses the modal", async ({ browser }) => {
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    try {
+      const [a, b] = await Promise.all([
+        loginAs(ctxA, "dc-keep-a"),
+        loginAs(ctxB, "dc-keep-b"),
+      ]);
+
+      await startMatchWithDirectInvite(a.page, b.page, {
+        playerBUsername: b.username,
+      });
+      await Promise.all([waitForMatch(a.page), waitForMatch(b.page)]);
+
+      await ctxB.close();
+
+      const modal = a.page.getByTestId("disconnection-modal");
+      await expect(modal).toBeVisible({ timeout: 20_000 });
+
+      await a.page.getByRole("button", { name: /Keep waiting/i }).click();
+      await expect(modal).toBeHidden({ timeout: 5_000 });
+    } finally {
+      await ctxA.close();
+    }
+  });
+});

--- a/tests/unit/app/actions/claimWin.test.ts
+++ b/tests/unit/app/actions/claimWin.test.ts
@@ -14,6 +14,7 @@ import { claimWinAction } from "@/app/actions/match/claimWin";
 import { completeMatchInternal } from "@/app/actions/match/completeMatch";
 import { getDisconnectedAt } from "@/app/actions/match/handleDisconnect";
 import { readLobbySession } from "@/lib/matchmaking/profile";
+import { resetRateLimitStoreForTests } from "@/lib/rate-limiting/middleware";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 
 const MATCH_ID = "00000000-0000-0000-0000-000000000001";
@@ -56,6 +57,7 @@ function buildSupabase(matchData: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetRateLimitStoreForTests();
   vi.mocked(readLobbySession).mockResolvedValue(SESSION as never);
   vi.mocked(getServiceRoleClient).mockReturnValue(
     buildSupabase({
@@ -148,13 +150,35 @@ describe("claimWinAction", () => {
     expect(remaining).toBeLessThan(61_000);
   });
 
-  test("returns ok and calls completeMatchInternal when opponent disconnected 95s ago", async () => {
+  test("returns ok and forces caller as winner when opponent disconnected 95s ago", async () => {
     vi.mocked(getDisconnectedAt).mockReturnValue(Date.now() - 95_000);
 
     const result = await claimWinAction(MATCH_ID);
 
     expect(result.status).toBe("ok");
     expect((result as { status: "ok"; matchId: string }).matchId).toBe(MATCH_ID);
-    expect(completeMatchInternal).toHaveBeenCalledWith(MATCH_ID, "disconnect");
+    // Caller (PLAYER_A) must be passed as forcedWinnerId so they win
+    // unconditionally, regardless of the live scoreboard.
+    expect(completeMatchInternal).toHaveBeenCalledWith(
+      MATCH_ID,
+      "disconnect",
+      PLAYER_A,
+    );
+  });
+
+  test("returns rate_limited on the second call within the same minute", async () => {
+    vi.mocked(getDisconnectedAt).mockReturnValue(Date.now() - 95_000);
+
+    const first = await claimWinAction(MATCH_ID);
+    expect(first.status).toBe("ok");
+
+    const second = await claimWinAction(MATCH_ID);
+    expect(second.status).toBe("rate_limited");
+    expect(
+      (second as { status: "rate_limited"; retryAfterSeconds: number })
+        .retryAfterSeconds,
+    ).toBeGreaterThan(0);
+    // completeMatchInternal only runs for the first call.
+    expect(completeMatchInternal).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/app/actions/claimWin.test.ts
+++ b/tests/unit/app/actions/claimWin.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/matchmaking/profile", () => ({ readLobbySession: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ getServiceRoleClient: vi.fn() }));
+vi.mock("@/app/actions/match/handleDisconnect", () => ({
+  getDisconnectedAt: vi.fn(),
+  RECONNECT_WINDOW_MS_EXPORT: 90_000,
+}));
+vi.mock("@/app/actions/match/completeMatch", () => ({
+  completeMatchInternal: vi.fn(),
+}));
+
+import { claimWinAction } from "@/app/actions/match/claimWin";
+import { completeMatchInternal } from "@/app/actions/match/completeMatch";
+import { getDisconnectedAt } from "@/app/actions/match/handleDisconnect";
+import { readLobbySession } from "@/lib/matchmaking/profile";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+
+const MATCH_ID = "00000000-0000-0000-0000-000000000001";
+const PLAYER_A = "player-a-id";
+const PLAYER_B = "player-b-id";
+
+const SESSION = {
+  token: "tok",
+  issuedAt: Date.now(),
+  player: {
+    id: PLAYER_A,
+    username: "ari",
+    displayName: "Ari",
+    avatarUrl: null,
+    status: "available" as const,
+    lastSeenAt: new Date().toISOString(),
+    eloRating: 1200,
+  },
+};
+
+type QueryResult = { data: unknown; error: { message: string } | null };
+
+function buildChain(result: QueryResult) {
+  const chain = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    maybeSingle: vi.fn(),
+  };
+  chain.select.mockReturnValue(chain);
+  chain.eq.mockReturnValue(chain);
+  chain.maybeSingle.mockResolvedValue(result);
+  return chain;
+}
+
+function buildSupabase(matchData: unknown) {
+  return {
+    from: vi.fn(() => buildChain({ data: matchData, error: null })),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(readLobbySession).mockResolvedValue(SESSION as never);
+  vi.mocked(getServiceRoleClient).mockReturnValue(
+    buildSupabase({
+      state: "in_progress",
+      player_a_id: PLAYER_A,
+      player_b_id: PLAYER_B,
+    }) as never,
+  );
+  vi.mocked(getDisconnectedAt).mockReturnValue(null);
+  vi.mocked(completeMatchInternal).mockResolvedValue({} as never);
+});
+
+describe("claimWinAction", () => {
+  test("returns unauthenticated when no session", async () => {
+    vi.mocked(readLobbySession).mockResolvedValue(null);
+
+    const result = await claimWinAction(MATCH_ID);
+
+    expect(result.status).toBe("unauthenticated");
+    expect(completeMatchInternal).not.toHaveBeenCalled();
+  });
+
+  test("returns error when matchId is not a UUID", async () => {
+    const result = await claimWinAction("not-a-uuid");
+
+    expect(result.status).toBe("error");
+    expect((result as { status: "error"; message: string }).message).toBe(
+      "Invalid matchId.",
+    );
+  });
+
+  test("returns error when match is not found", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      buildSupabase(null) as never,
+    );
+
+    const result = await claimWinAction(MATCH_ID);
+
+    expect(result.status).toBe("error");
+    expect((result as { status: "error"; message: string }).message).toBe(
+      "Match not found.",
+    );
+  });
+
+  test("returns forbidden when caller is not a participant", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      buildSupabase({
+        state: "in_progress",
+        player_a_id: "stranger-1",
+        player_b_id: "stranger-2",
+      }) as never,
+    );
+
+    const result = await claimWinAction(MATCH_ID);
+
+    expect(result.status).toBe("forbidden");
+  });
+
+  test("returns already_completed when match state is completed", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      buildSupabase({
+        state: "completed",
+        player_a_id: PLAYER_A,
+        player_b_id: PLAYER_B,
+      }) as never,
+    );
+
+    const result = await claimWinAction(MATCH_ID);
+
+    expect(result.status).toBe("already_completed");
+    expect((result as { status: "already_completed"; matchId: string }).matchId).toBe(MATCH_ID);
+  });
+
+  test("returns not_disconnected when opponent has no disconnect record", async () => {
+    vi.mocked(getDisconnectedAt).mockReturnValue(null);
+
+    const result = await claimWinAction(MATCH_ID);
+
+    expect(result.status).toBe("not_disconnected");
+  });
+
+  test("returns too_early when opponent disconnected 30s ago", async () => {
+    vi.mocked(getDisconnectedAt).mockReturnValue(Date.now() - 30_000);
+
+    const result = await claimWinAction(MATCH_ID);
+
+    expect(result.status).toBe("too_early");
+    const remaining = (result as { status: "too_early"; remainingMs: number }).remainingMs;
+    expect(remaining).toBeGreaterThan(59_000);
+    expect(remaining).toBeLessThan(61_000);
+  });
+
+  test("returns ok and calls completeMatchInternal when opponent disconnected 95s ago", async () => {
+    vi.mocked(getDisconnectedAt).mockReturnValue(Date.now() - 95_000);
+
+    const result = await claimWinAction(MATCH_ID);
+
+    expect(result.status).toBe("ok");
+    expect((result as { status: "ok"; matchId: string }).matchId).toBe(MATCH_ID);
+    expect(completeMatchInternal).toHaveBeenCalledWith(MATCH_ID, "disconnect");
+  });
+});

--- a/tests/unit/components/match/DisconnectionModal.test.tsx
+++ b/tests/unit/components/match/DisconnectionModal.test.tsx
@@ -1,0 +1,85 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { DisconnectionModal } from "@/components/match/DisconnectionModal";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const WINDOW_MS = 90_000;
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof DisconnectionModal>> = {},
+) {
+  const baseTime = Date.now();
+  return render(
+    <DisconnectionModal
+      opponentDisplayName="Birna"
+      disconnectedAt={overrides.disconnectedAt ?? baseTime}
+      windowMs={overrides.windowMs ?? WINDOW_MS}
+      onClose={overrides.onClose ?? vi.fn()}
+      onClaimWin={overrides.onClaimWin ?? vi.fn()}
+      isClaiming={overrides.isClaiming ?? false}
+    />,
+  );
+}
+
+describe("DisconnectionModal", () => {
+  test("renders opponent name + Connection lost eyebrow", () => {
+    renderModal();
+    expect(screen.getByText(/Connection lost/i)).toBeInTheDocument();
+    expect(screen.getByText(/Birna dropped out/i)).toBeInTheDocument();
+  });
+
+  test("shows countdown starting near 90 seconds", () => {
+    renderModal();
+    expect(screen.getByText(/1:30/)).toBeInTheDocument();
+  });
+
+  test("Claim win is disabled while countdown has remaining time", () => {
+    renderModal();
+    const btn = screen.getByRole("button", { name: /Claim win/i });
+    expect(btn).toBeDisabled();
+  });
+
+  test("Claim win becomes enabled after the window elapses", () => {
+    renderModal();
+    const btn = screen.getByRole("button", { name: /Claim win/i });
+    expect(btn).toBeDisabled();
+    // Advance 91 seconds to ensure the countdown hits 0.
+    act(() => {
+      vi.advanceTimersByTime(91_000);
+    });
+    expect(btn).not.toBeDisabled();
+  });
+
+  test("Claim win click invokes onClaimWin", () => {
+    const onClaimWin = vi.fn();
+    renderModal({
+      disconnectedAt: Date.now() - WINDOW_MS - 1_000, // already expired
+      onClaimWin,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Claim win/i }));
+    expect(onClaimWin).toHaveBeenCalledTimes(1);
+  });
+
+  test("Keep waiting click invokes onClose", () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    fireEvent.click(screen.getByRole("button", { name: /Keep waiting/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("Claim win button shows spinner copy while isClaiming", () => {
+    renderModal({
+      disconnectedAt: Date.now() - WINDOW_MS - 1_000,
+      isClaiming: true,
+    });
+    expect(screen.getByRole("button", { name: /Claiming/i })).toBeDisabled();
+  });
+});

--- a/tests/unit/components/match/useCountdown.test.ts
+++ b/tests/unit/components/match/useCountdown.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { useCountdown } from "@/components/match/useCountdown";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useCountdown", () => {
+  test("starts at the initial seconds", () => {
+    const { result } = renderHook(() => useCountdown(90));
+    expect(result.current.remaining).toBe(90);
+    expect(result.current.expired).toBe(false);
+  });
+
+  test("decrements every second", () => {
+    const { result } = renderHook(() => useCountdown(5));
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(result.current.remaining).toBe(3);
+  });
+
+  test("flips `expired` to true when remaining reaches 0", () => {
+    const { result } = renderHook(() => useCountdown(2));
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(result.current.remaining).toBe(0);
+    expect(result.current.expired).toBe(true);
+  });
+
+  test("resets when startSeconds changes", () => {
+    const { result, rerender } = renderHook(({ s }) => useCountdown(s), {
+      initialProps: { s: 10 },
+    });
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    expect(result.current.remaining).toBe(7);
+    rerender({ s: 90 });
+    expect(result.current.remaining).toBe(90);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the passive "Opponent disconnected" banner with a centered `DisconnectionModal` — warn-colored pulse indicator, 90s mm:ss countdown, "Keep waiting" / "Claim win" actions (Claim win disabled until the countdown expires).
- New `claimWinAction(matchId)` Server Action that awards the caller the win once the opponent has been gone for ≥90s. Rate-limited to 1/min per player via the `match:claim-win` scope; idempotent on re-call.
- Reconnect window bumped 10s → 90s in `handleDisconnect.ts`, matching the modal countdown.
- Extends `completeMatchInternal` with an optional `forcedWinnerId` so disconnect flows (both claim-win and the 90s auto-finalise) award the still-connected player regardless of live score — loss-of-connection is treated as forfeit per the Warm Editorial spec §6.

Implementation plan: `docs/superpowers/plans/2026-04-22-phase-6-disconnect-modal.md`
Design spec: `docs/superpowers/specs/2026-04-19-wottle-design-implementation.md` §6

## Commits

1. `feat(match): extend disconnect window to 90s + export getDisconnectedAt`
2. `feat(match): add claimWinAction for 90s-disconnect forfeit`
3. `feat(match): add useCountdown hook`
4. `fix(match): force caller as winner on claim-win + add rate limit`
5. `feat(match): add DisconnectionModal with 90s countdown + claim-win CTA`
6. `feat(match): mount DisconnectionModal when opponent drops`
7. `test(match): add @disconnect-modal Playwright smoke + Phase 6 plan doc`
8. `docs(claude): reflect Phase 6 disconnection modal + claim-win`

## Test plan

- [x] `pnpm test` — 146 files / 959 tests pass (2 intentionally skipped).
- [x] `pnpm lint` — zero warnings.
- [x] `pnpm typecheck` — clean.
- [x] New integration regression test proves `completeMatchInternal` uses `forcedWinnerId` over `determineMatchWinner` even when the disconnected player is leading on score (`tests/integration/match/forcedWinner.spec.ts`).
- [x] New claim-win unit tests cover: forced-winner arg passed, rate limit rejection.
- [ ] CI: `@disconnect-modal` Playwright smoke (two-session, chromium-only to match profile-modal pattern).
- [ ] Manual: two browsers, close one mid-match → modal appears on the other, Claim win disabled during countdown, Keep waiting dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)