### PR TITLE
fix(match): self-heal stuck rounds + don't block round-advance on Realtime

### DIFF
--- a/app/actions/match/publishRoundSummary.ts
+++ b/app/actions/match/publishRoundSummary.ts
@@ -10,6 +10,9 @@ import type { RoundSummary, RoundMove, WordScore, ScoreTotals, FrozenTileMap } f
 import type { Coordinate } from "@/lib/types/board";
 import type { BoardGrid } from "@/lib/types/board";
 
+/** Matches statePublisher.ts — see that file for rationale. */
+const BROADCAST_SUBSCRIBE_TIMEOUT_MS = 2_000;
+
 /**
  * Publish round summary after a round is completed.
  * This assembles word scores, calculates totals, persists snapshots, and broadcasts via Realtime.
@@ -122,10 +125,24 @@ export async function publishRoundSummary(
         // Continue anyway - we'll still publish the summary
     }
 
-    // 8. Publish via Realtime broadcast (subscribe before send — required by Supabase Cloud)
+    // 8. Publish via Realtime broadcast (subscribe before send — required by Supabase Cloud).
+    // Bounded by BROADCAST_SUBSCRIBE_TIMEOUT_MS — see statePublisher.ts for the rationale.
     const channel = supabase.channel(`match:${matchId}`);
+    let settled = false;
     await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            console.error(
+                `[RoundSummary] Channel subscribe timed out after ${BROADCAST_SUBSCRIBE_TIMEOUT_MS}ms; giving up on broadcast`,
+            );
+            supabase.removeChannel(channel);
+            resolve();
+        }, BROADCAST_SUBSCRIBE_TIMEOUT_MS);
+
         channel.subscribe((status) => {
+            if (settled) return;
+
             if (status === "SUBSCRIBED") {
                 channel
                     .send({
@@ -134,14 +151,21 @@ export async function publishRoundSummary(
                         payload: summary,
                     })
                     .then((result) => {
+                        if (settled) return;
+                        settled = true;
+                        clearTimeout(timer);
                         if (result === "error") {
                             console.error("Failed to broadcast round summary");
                         }
                         supabase.removeChannel(channel);
                         resolve();
                     });
+                return;
             }
+
             if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
+                settled = true;
+                clearTimeout(timer);
                 console.error(`[RoundSummary] Channel subscription failed: ${status}`);
                 supabase.removeChannel(channel);
                 resolve();

--- a/lib/match/roundEngine.ts
+++ b/lib/match/roundEngine.ts
@@ -364,18 +364,22 @@ export async function advanceRound(matchId: string) {
 
     if (updateError) throw new Error("Failed to update match");
 
-    // 15. Publish round summary and match state in parallel
-    const [summaryResult, stateResult] = await Promise.allSettled([
+    // 15. Publish round summary and match state — fire-and-forget.
+    // Broadcast delivery is best-effort; clients have a 2s safety poll and
+    // loadMatchState self-heals on read, so the authoritative DB writes above
+    // are what matter. Awaiting here previously stalled step 16 by up to 20s
+    // whenever the Realtime channel subscribe timed out in local dev.
+    void Promise.allSettled([
         publishRoundSummary(matchId, currentRound),
         publishMatchState(matchId),
-    ]);
-
-    if (summaryResult.status === "rejected") {
-        console.error("Failed to publish round summary:", summaryResult.reason);
-    }
-    if (stateResult.status === "rejected") {
-        console.error("[MatchState] Failed to broadcast match update:", stateResult.reason);
-    }
+    ]).then(([summaryResult, stateResult]) => {
+        if (summaryResult.status === "rejected") {
+            console.error("Failed to publish round summary:", summaryResult.reason);
+        }
+        if (stateResult.status === "rejected") {
+            console.error("[MatchState] Failed to broadcast match update:", stateResult.reason);
+        }
+    });
 
     if (isGameOver) {
         const endReason = nextRound > 10 ? "round_limit" : "timeout";

--- a/lib/match/stateLoader.ts
+++ b/lib/match/stateLoader.ts
@@ -17,6 +17,44 @@ import { computeElapsedMs, computeRemainingMs } from "./clockEnforcer";
 
 type AnyClient = SupabaseClient<any, any, any>;
 
+/**
+ * Matches currently being self-healed via background `advanceRound` trigger.
+ * Gate against concurrent polls all firing advanceRound for the same stuck
+ * round — the first one wins; the rest skip until it finishes (or fails).
+ */
+const pendingSelfHeals = new Set<string>();
+
+/**
+ * Stuck-round self-heal: when a client polls /state and we detect the round
+ * is still in `collecting` despite both players having submitted, fire
+ * `advanceRound(matchId)` in the background. `advanceRound` itself re-checks
+ * round state at its top and exits early if resolution is already in flight,
+ * so this is safe to call liberally.
+ *
+ * This is the primary backstop against the "stuck round 10" bug: if the
+ * post-submit `after()` hook drops the advancement for any reason, the
+ * client's next 2s safety poll will re-trigger it via this path.
+ */
+function triggerAdvanceInBackground(matchId: string): void {
+  if (pendingSelfHeals.has(matchId)) return;
+  pendingSelfHeals.add(matchId);
+  void (async () => {
+    try {
+      const { advanceRound } = await import("./roundEngine");
+      await advanceRound(matchId);
+    } catch (error) {
+      console.error("[stateLoader] self-heal advanceRound failed:", error);
+    } finally {
+      pendingSelfHeals.delete(matchId);
+    }
+  })();
+}
+
+/** @internal — test hook to reset the dedup set between runs. */
+export function __resetSelfHealTrackerForTests(): void {
+  pendingSelfHeals.clear();
+}
+
 function mapState(roundState: string | null | undefined, matchState: string): MatchPhase {
   // Match-level terminal states take precedence — a timeout or abandon can end the
   // match while the current round is still in "collecting" state (never advanced).
@@ -324,14 +362,25 @@ export async function loadMatchState(
   } else if (effectiveState === "collecting" && roundStartedAt && round?.id) {
     const { data: submissions } = await client
       .from("move_submissions")
-      .select("player_id, submitted_at")
+      .select("player_id, submitted_at, status")
       .eq("round_id", round.id);
 
+    const typedSubs = (submissions ?? []) as Array<{
+      player_id: string;
+      submitted_at: string;
+      status: string;
+    }>;
+
+    // Self-heal: if both players have real (non-timeout) submissions but the
+    // round hasn't advanced, fire advanceRound in the background. This closes
+    // the race where submitMove's `after()` hook drops the advancement.
+    const nonTimeoutSubs = typedSubs.filter((s) => s.status !== "timeout");
+    if (nonTimeoutSubs.length >= 2) {
+      triggerAdvanceInBackground(matchId);
+    }
+
     const subByPlayer = new Map<string, Date>(
-      (submissions ?? []).map((s: { player_id: string; submitted_at: string }) => [
-        s.player_id,
-        new Date(s.submitted_at),
-      ]),
+      typedSubs.map((s) => [s.player_id, new Date(s.submitted_at)]),
     );
     const submittedAtA = subByPlayer.get(match.player_a_id);
     const submittedAtB = subByPlayer.get(match.player_b_id);

--- a/lib/match/statePublisher.ts
+++ b/lib/match/statePublisher.ts
@@ -2,6 +2,15 @@ import { getServiceRoleClient } from "@/lib/supabase/server";
 
 import { loadMatchState } from "./stateLoader";
 
+/**
+ * Max time we'll wait for channel.subscribe() to reach SUBSCRIBED before
+ * giving up and resolving. Supabase's internal default is ~10s, which in
+ * local dev (and occasionally in prod) stalls the round-advancement pipeline
+ * because roundEngine awaits this broadcast. Callers should treat broadcast
+ * delivery as best-effort — clients recover via the 2s safety poll.
+ */
+const BROADCAST_SUBSCRIBE_TIMEOUT_MS = 2_000;
+
 export async function publishMatchState(matchId: string) {
   const supabase = getServiceRoleClient();
   const state = await loadMatchState(supabase, matchId);
@@ -10,9 +19,22 @@ export async function publishMatchState(matchId: string) {
   }
 
   const channel = supabase.channel(`match:${matchId}`);
+  let settled = false;
 
   await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      console.error(
+        `[MatchState] Channel subscribe timed out after ${BROADCAST_SUBSCRIBE_TIMEOUT_MS}ms; giving up on broadcast`,
+      );
+      supabase.removeChannel(channel);
+      resolve();
+    }, BROADCAST_SUBSCRIBE_TIMEOUT_MS);
+
     channel.subscribe((status) => {
+      if (settled) return;
+
       if (status === "SUBSCRIBED") {
         channel
           .send({
@@ -21,6 +43,9 @@ export async function publishMatchState(matchId: string) {
             payload: state,
           })
           .then((result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
             if (result === "error") {
               console.error(
                 "[MatchState] Failed to broadcast match snapshot",
@@ -29,8 +54,12 @@ export async function publishMatchState(matchId: string) {
             supabase.removeChannel(channel);
             resolve();
           });
+        return;
       }
+
       if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
+        settled = true;
+        clearTimeout(timer);
         console.error(
           `[MatchState] Channel subscription failed: ${status}`,
         );
@@ -40,4 +69,3 @@ export async function publishMatchState(matchId: string) {
     });
   });
 }
-

--- a/tests/unit/lib/match/roundEngine.test.ts
+++ b/tests/unit/lib/match/roundEngine.test.ts
@@ -392,6 +392,64 @@ describe("roundEngine.advanceRound", () => {
         expect(roundsInsert).not.toHaveBeenCalled();
     });
 
+    // Regression guard: step 15 broadcasts must be fire-and-forget, so
+    // completeMatchInternal runs even when publishRoundSummary hangs. This was
+    // the root cause of stuck round 10: awaiting the Realtime broadcast stalled
+    // the whole pipeline whenever the local channel subscribe timed out.
+    it("calls completeMatchInternal even when publishRoundSummary never resolves", async () => {
+        const { publishRoundSummary } = await import(
+            "@/app/actions/match/publishRoundSummary"
+        );
+        const { completeMatchInternal } = await import(
+            "@/app/actions/match/completeMatch"
+        );
+        vi.mocked(completeMatchInternal).mockClear();
+        // Make the broadcast hang forever — the old implementation would block here.
+        vi.mocked(publishRoundSummary).mockImplementationOnce(
+            () => new Promise(() => {}),
+        );
+
+        setupSupabase(
+            [
+                {
+                    id: "sub-a",
+                    player_id: "player-a",
+                    from_x: 0,
+                    from_y: 0,
+                    to_x: 0,
+                    to_y: 1,
+                    submitted_at: "2026-01-01T00:00:00Z",
+                    status: "pending",
+                },
+                {
+                    id: "sub-b",
+                    player_id: "player-b",
+                    from_x: 5,
+                    from_y: 5,
+                    to_x: 5,
+                    to_y: 6,
+                    submitted_at: "2026-01-01T00:00:01Z",
+                    status: "pending",
+                },
+            ],
+            { current_round: 10 },
+        );
+
+        const result = await advanceRound("match-1");
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                status: "advanced",
+                nextRound: 11,
+                isGameOver: true,
+            }),
+        );
+        expect(completeMatchInternal).toHaveBeenCalledWith("match-1", "round_limit");
+
+        // Restore the mock so downstream tests don't see a hanging promise.
+        vi.mocked(publishRoundSummary).mockResolvedValue({ ok: true } as never);
+    });
+
     // T013: createNextRound sets started_at
     it("T013: creates next round with started_at set to current server timestamp", async () => {
         setupSupabase([

--- a/tests/unit/lib/match/stateLoader.test.ts
+++ b/tests/unit/lib/match/stateLoader.test.ts
@@ -7,18 +7,32 @@ vi.mock("@/scripts/supabase/generateBoard", () => ({
     Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A")),
   ),
 }));
+// Mocked so the self-heal background trigger doesn't hit the real engine.
+vi.mock("@/lib/match/roundEngine", () => ({
+  advanceRound: vi.fn().mockResolvedValue({ status: "waiting", received: 2 }),
+}));
 
-import { loadMatchState } from "@/lib/match/stateLoader";
+import {
+  loadMatchState,
+  __resetSelfHealTrackerForTests,
+} from "@/lib/match/stateLoader";
 import { getServiceRoleClient } from "@/lib/supabase/server";
+import { advanceRound } from "@/lib/match/roundEngine";
 
 const PLAYER_A = "player-a";
 const PLAYER_B = "player-b";
 const MATCH_ID = "match-timer-test";
 
+type SubmissionFixture = {
+    player_id: string;
+    submitted_at: string;
+    status?: string;
+};
+
 function makeMockClient(
     matchData: Record<string, unknown>,
     roundData: Record<string, unknown> | null,
-    submissionsData: { player_id: string; submitted_at: string }[] | null = null,
+    submissionsData: SubmissionFixture[] | null = null,
 ) {
     const matchChain = {
         eq: vi.fn().mockReturnThis(),
@@ -242,5 +256,144 @@ describe("stateLoader.loadMatchState", () => {
         expect(state!.timers.playerB.status).toBe("running");
         expect(state!.timers.playerB.remainingMs).toBeGreaterThan(148_000);
         expect(state!.timers.playerB.remainingMs).toBeLessThanOrEqual(150_000);
+    });
+});
+
+describe("stateLoader self-heal (stuck collecting round)", () => {
+    beforeEach(() => {
+        vi.mocked(advanceRound).mockClear();
+        __resetSelfHealTrackerForTests();
+    });
+
+    function makeStuckClient() {
+        const roundStartedAt = new Date(Date.now() - 5_000);
+        return makeMockClient(
+            {
+                id: MATCH_ID,
+                state: "in_progress",
+                current_round: 10,
+                board_seed: "seed-1",
+                player_a_id: PLAYER_A,
+                player_b_id: PLAYER_B,
+                player_a_timer_ms: 120_000,
+                player_b_timer_ms: 110_000,
+                frozen_tiles: {},
+            },
+            {
+                id: "round-10",
+                state: "collecting",
+                board_snapshot_before: Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A")),
+                board_snapshot_after: null,
+                started_at: roundStartedAt.toISOString(),
+            },
+            [
+                { player_id: PLAYER_A, submitted_at: new Date(roundStartedAt.getTime() + 1_000).toISOString(), status: "pending" },
+                { player_id: PLAYER_B, submitted_at: new Date(roundStartedAt.getTime() + 2_000).toISOString(), status: "pending" },
+            ],
+        );
+    }
+
+    it("triggers advanceRound when the collecting round has 2 non-timeout submissions", async () => {
+        const mockClient = makeStuckClient();
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        await loadMatchState(mockClient as never, MATCH_ID);
+
+        // Self-heal is fire-and-forget. Yield to the microtask queue so the
+        // async IIFE that wraps `await import(...).advanceRound()` can run.
+        await new Promise((r) => setImmediate(r));
+
+        expect(advanceRound).toHaveBeenCalledTimes(1);
+        expect(advanceRound).toHaveBeenCalledWith(MATCH_ID);
+    });
+
+    it("does NOT trigger advanceRound when only one player has submitted", async () => {
+        const roundStartedAt = new Date(Date.now() - 5_000);
+        const mockClient = makeMockClient(
+            {
+                id: MATCH_ID,
+                state: "in_progress",
+                current_round: 10,
+                board_seed: "seed-1",
+                player_a_id: PLAYER_A,
+                player_b_id: PLAYER_B,
+                player_a_timer_ms: 120_000,
+                player_b_timer_ms: 110_000,
+                frozen_tiles: {},
+            },
+            {
+                id: "round-10",
+                state: "collecting",
+                board_snapshot_before: Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A")),
+                board_snapshot_after: null,
+                started_at: roundStartedAt.toISOString(),
+            },
+            [
+                { player_id: PLAYER_A, submitted_at: roundStartedAt.toISOString(), status: "pending" },
+            ],
+        );
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        await loadMatchState(mockClient as never, MATCH_ID);
+        await new Promise((r) => setImmediate(r));
+
+        expect(advanceRound).not.toHaveBeenCalled();
+    });
+
+    it("does NOT trigger advanceRound when the one real submission is paired with a synthetic timeout", async () => {
+        // timeout submissions shouldn't count as a real second submission —
+        // the round engine will re-synthesize if needed.
+        const roundStartedAt = new Date(Date.now() - 5_000);
+        const mockClient = makeMockClient(
+            {
+                id: MATCH_ID,
+                state: "in_progress",
+                current_round: 10,
+                board_seed: "seed-1",
+                player_a_id: PLAYER_A,
+                player_b_id: PLAYER_B,
+                player_a_timer_ms: 120_000,
+                player_b_timer_ms: 110_000,
+                frozen_tiles: {},
+            },
+            {
+                id: "round-10",
+                state: "collecting",
+                board_snapshot_before: Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A")),
+                board_snapshot_after: null,
+                started_at: roundStartedAt.toISOString(),
+            },
+            [
+                { player_id: PLAYER_A, submitted_at: roundStartedAt.toISOString(), status: "pending" },
+                { player_id: PLAYER_B, submitted_at: roundStartedAt.toISOString(), status: "timeout" },
+            ],
+        );
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        await loadMatchState(mockClient as never, MATCH_ID);
+        await new Promise((r) => setImmediate(r));
+
+        expect(advanceRound).not.toHaveBeenCalled();
+    });
+
+    it("dedupes concurrent stuck-state polls so advanceRound is called at most once in flight", async () => {
+        // Make advanceRound slow so the dedup window stays open across both calls.
+        let resolveAdvance: () => void = () => {};
+        vi.mocked(advanceRound).mockImplementationOnce(
+            () => new Promise((r) => { resolveAdvance = () => r({ status: "advanced", nextRound: 11, isGameOver: true, acceptedMoves: 0, rejectedMoves: 0 } as never); }),
+        );
+
+        const mockClient = makeStuckClient();
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        await Promise.all([
+            loadMatchState(mockClient as never, MATCH_ID),
+            loadMatchState(mockClient as never, MATCH_ID),
+            loadMatchState(mockClient as never, MATCH_ID),
+        ]);
+        await new Promise((r) => setImmediate(r));
+
+        expect(advanceRound).toHaveBeenCalledTimes(1);
+        resolveAdvance();
     });
 });

--- a/tests/unit/lib/match/statePublisher.test.ts
+++ b/tests/unit/lib/match/statePublisher.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({ getServiceRoleClient: vi.fn() }));
+vi.mock("@/lib/match/stateLoader", () => ({
+  loadMatchState: vi.fn().mockResolvedValue({
+    matchId: "m1",
+    board: Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A")),
+    currentRound: 10,
+    state: "completed",
+    timers: {
+      playerA: { playerId: "a", remainingMs: 120_000, status: "expired" },
+      playerB: { playerId: "b", remainingMs: 110_000, status: "expired" },
+    },
+    scores: { playerA: 91, playerB: 124 },
+    lastSummary: null,
+    frozenTiles: {},
+  }),
+}));
+
+import { publishMatchState } from "@/lib/match/statePublisher";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+
+type SubscribeCb = (status: string) => void;
+interface MockChannel {
+  subscribe: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+}
+
+function makeMockClient(opts: {
+  /** Invoked with the subscribe callback — caller decides whether/when to fire it. */
+  onSubscribe: (cb: SubscribeCb) => void;
+  onSend?: () => Promise<"ok" | "error">;
+}) {
+  const removeChannel = vi.fn();
+  const channel: MockChannel = {
+    subscribe: vi.fn(),
+    send: vi.fn().mockImplementation(opts.onSend ?? (async () => "ok")),
+  };
+  channel.subscribe.mockImplementation((cb: SubscribeCb) => {
+    opts.onSubscribe(cb);
+    return channel;
+  });
+  return {
+    channel: vi.fn().mockReturnValue(channel),
+    removeChannel,
+  };
+}
+
+describe("statePublisher.publishMatchState", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("resolves within ~2s when channel.subscribe never reports SUBSCRIBED (hung channel)", async () => {
+    vi.useFakeTimers();
+    const mockClient = makeMockClient({
+      onSubscribe: () => {
+        // Intentionally do nothing — simulates a hung subscribe.
+      },
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const pending = publishMatchState("m1");
+
+    // Advance past the 2s timeout
+    await vi.advanceTimersByTimeAsync(2_100);
+    await pending;
+
+    expect(mockClient.removeChannel).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Channel subscribe timed out"),
+    );
+
+    errorSpy.mockRestore();
+  });
+
+  it("resolves immediately on CHANNEL_ERROR", async () => {
+    const mockClient = makeMockClient({
+      onSubscribe: (cb) => cb("CHANNEL_ERROR"),
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await publishMatchState("m1");
+
+    expect(mockClient.removeChannel).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Channel subscription failed: CHANNEL_ERROR"),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("sends the broadcast when subscribe reaches SUBSCRIBED", async () => {
+    const mockClient = makeMockClient({
+      onSubscribe: (cb) => cb("SUBSCRIBED"),
+      onSend: async () => "ok",
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+    await publishMatchState("m1");
+
+    const ch = mockClient.channel.mock.results[0].value as { send: ReturnType<typeof vi.fn> };
+    expect(ch.send).toHaveBeenCalledWith({
+      type: "broadcast",
+      event: "state",
+      payload: expect.objectContaining({ matchId: "m1", state: "completed" }),
+    });
+    expect(mockClient.removeChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not double-resolve if SUBSCRIBED fires after the timeout (late callback is a no-op)", async () => {
+    vi.useFakeTimers();
+    let storedCb: SubscribeCb | null = null;
+    const mockClient = makeMockClient({
+      onSubscribe: (cb) => {
+        storedCb = cb;
+      },
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const pending = publishMatchState("m1");
+    await vi.advanceTimersByTimeAsync(2_100); // trigger timeout
+    await pending;
+
+    // Fire the (late) SUBSCRIBED — should not re-enter send or double-remove
+    (storedCb as SubscribeCb | null)?.("SUBSCRIBED");
+
+    const ch = mockClient.channel.mock.results[0].value as { send: ReturnType<typeof vi.fn> };
+    expect(ch.send).not.toHaveBeenCalled();
+    expect(mockClient.removeChannel).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes #149

## Summary

Fixes a bug where matches freeze on round 10 after both players submit — the page stays on "WAITING FOR OPPONENT" forever instead of navigating to the summary. Two coupled fragilities:

- `roundEngine` step 15 `await`-ed the Realtime broadcasts, so a ~10 s `channel.subscribe` timeout stalled `completeMatchInternal` and often left the match at `state=completed, winner_id=null`.
- Nothing retried a dropped `advanceRound`. If `submitMove`'s `after()` hook missed firing once on round 10, the match was stuck for good (rounds 1-9 are self-retrying via the next submit; round 10 is terminal).

### Fix shape

1. **`statePublisher.ts` / `publishRoundSummary.ts`** — internal 2 s subscribe timeout with a `settled` guard so late callbacks can't double-resolve.
2. **`roundEngine.ts` step 15** — broadcasts are now fire-and-forget. The authoritative DB writes in step 14 are what matter; clients recover via the 2 s safety poll.
3. **`stateLoader.ts`** — self-heal on read: when `loadMatchState` sees a `collecting` round with 2+ non-timeout submissions, it fires `advanceRound(matchId)` in the background. Module-scoped `pendingSelfHeals` Set dedupes concurrent triggers.

This turns the client's existing 2 s `/state` safety poll into an advance retry — so every stuck round (not just round 10) now heals automatically.

### Live verification

Recreated the exact stuck DB state from the reported screenshot:

```
[0] DB: {state: in_progress, current_round: 10, winner_id: null}
[1] first /state poll → state=collecting, currentRound=10
[2] t=+1s  state=completed  currentRound=11  winner=Y  completed_at=SET  ✓
[3] second /state poll → state=completed, currentRound=11  ✓ client navigates
```

Worst case ~5 s from stuck-submit to summary instead of forever.

## Test plan

- [x] `pnpm test:unit` — 948 passed, 2 skipped
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] Live repro against local Supabase: match self-heals to `completed` + `winner_id` set on next poll
- [ ] CI Playwright `match-completion @two-player-playtest` continues to pass (no behavioural change to the happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)