### PR TITLE
fix(match): unbreak Vercel build — move sync helpers out of use-server file

### DIFF
--- a/app/actions/match/claimWin.ts
+++ b/app/actions/match/claimWin.ts
@@ -5,9 +5,9 @@ import { z } from "zod";
 
 import { completeMatchInternal } from "@/app/actions/match/completeMatch";
 import {
-  RECONNECT_WINDOW_MS_EXPORT,
+  RECONNECT_WINDOW_MS,
   getDisconnectedAt,
-} from "@/app/actions/match/handleDisconnect";
+} from "@/lib/match/disconnectStore";
 import { readLobbySession } from "@/lib/matchmaking/profile";
 import {
   assertWithinRateLimit,
@@ -88,10 +88,10 @@ export async function claimWinAction(
     }
 
     const elapsed = Date.now() - disconnectedAt;
-    if (elapsed < RECONNECT_WINDOW_MS_EXPORT) {
+    if (elapsed < RECONNECT_WINDOW_MS) {
       return {
         status: "too_early",
-        remainingMs: RECONNECT_WINDOW_MS_EXPORT - elapsed,
+        remainingMs: RECONNECT_WINDOW_MS - elapsed,
       };
     }
 

--- a/app/actions/match/handleDisconnect.ts
+++ b/app/actions/match/handleDisconnect.ts
@@ -5,17 +5,12 @@ import "server-only";
 import { readLobbySession } from "@/lib/matchmaking/profile";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 import { writeMatchLog } from "@/lib/match/logWriter";
-
-const RECONNECT_WINDOW_MS = 90_000; // 90 seconds per Phase 6 disconnect-modal spec
-
-interface DisconnectRecord {
-  matchId: string;
-  playerId: string;
-  disconnectedAt: string;
-}
-
-// In-memory store for tracking disconnects (in production, use Redis or database)
-const disconnectStore = new Map<string, DisconnectRecord>();
+import {
+  RECONNECT_WINDOW_MS,
+  clearDisconnect,
+  getDisconnectRecord,
+  recordDisconnect,
+} from "@/lib/match/disconnectStore";
 
 export async function handlePlayerDisconnect(matchId: string, playerId: string): Promise<void> {
   const session = await readLobbySession();
@@ -47,23 +42,15 @@ export async function handlePlayerDisconnect(matchId: string, playerId: string):
     return;
   }
 
-  // Record disconnect time
-  const disconnectKey = `${matchId}:${playerId}`;
-  disconnectStore.set(disconnectKey, {
-    matchId,
-    playerId,
-    disconnectedAt: new Date().toISOString(),
-  });
+  recordDisconnect(matchId, playerId);
 
   // Broadcast disconnect state to all clients
   await publishMatchStateWithDisconnect(matchId, playerId);
 
   // Schedule timeout check (in production, use a proper job queue)
   setTimeout(async () => {
-    const record = disconnectStore.get(disconnectKey);
-    if (record) {
-      // Player did not reconnect within 90 seconds
-      disconnectStore.delete(disconnectKey);
+    if (clearDisconnect(matchId, playerId)) {
+      // Player did not reconnect within the window → finalize the match.
       await finalizeMatchOnDisconnectTimeout(supabase, matchId, playerId);
     }
   }, RECONNECT_WINDOW_MS);
@@ -107,33 +94,31 @@ export async function handlePlayerReconnect(matchId: string, playerId: string): 
     return;
   }
 
-  // Check if player was disconnected
-  const disconnectKey = `${matchId}:${playerId}`;
-  const record = disconnectStore.get(disconnectKey);
+  const record = getDisconnectRecord(matchId, playerId);
+  if (!record) {
+    return;
+  }
 
-  if (record) {
-    const disconnectTime = new Date(record.disconnectedAt).getTime();
-    const now = Date.now();
-    const elapsed = now - disconnectTime;
+  const disconnectTime = new Date(record.disconnectedAt).getTime();
+  const elapsed = Date.now() - disconnectTime;
 
-    if (elapsed < RECONNECT_WINDOW_MS) {
-      // Player reconnected within window - clear disconnect state
-      disconnectStore.delete(disconnectKey);
-      await publishMatchStateWithDisconnect(matchId, null); // Clear disconnect state
+  if (elapsed < RECONNECT_WINDOW_MS) {
+    // Reconnected inside the window — clear state and broadcast.
+    clearDisconnect(matchId, playerId);
+    await publishMatchStateWithDisconnect(matchId, null);
 
-      await writeMatchLog(supabase, {
-        matchId,
-        eventType: "reconnect",
-        metadata: {
-          playerId,
-          reconnectedAt: new Date().toISOString(),
-          elapsedMs: elapsed,
-        },
-      });
-    } else {
-      // Too late - match already finalized
-      disconnectStore.delete(disconnectKey);
-    }
+    await writeMatchLog(supabase, {
+      matchId,
+      eventType: "reconnect",
+      metadata: {
+        playerId,
+        reconnectedAt: new Date().toISOString(),
+        elapsedMs: elapsed,
+      },
+    });
+  } else {
+    // Too late — the timeout already fired; clear to keep the store tidy.
+    clearDisconnect(matchId, playerId);
   }
 }
 
@@ -178,24 +163,6 @@ async function loadMatchStateWithDisconnect(
     disconnectedPlayerId: null,
   };
 }
-
-/**
- * Returns the timestamp (ms since epoch) when the player first lost their
- * connection for this match, or null if they are currently connected.
- *
- * Used by claimWinAction to check whether the 90s window has elapsed.
- */
-export function getDisconnectedAt(
-  matchId: string,
-  playerId: string,
-): number | null {
-  const key = `${matchId}:${playerId}`;
-  const record = disconnectStore.get(key);
-  if (!record) return null;
-  return new Date(record.disconnectedAt).getTime();
-}
-
-export const RECONNECT_WINDOW_MS_EXPORT = RECONNECT_WINDOW_MS;
 
 async function finalizeMatchOnDisconnectTimeout(
   supabase: ReturnType<typeof getServiceRoleClient>,

--- a/lib/match/disconnectStore.ts
+++ b/lib/match/disconnectStore.ts
@@ -1,0 +1,76 @@
+import "server-only";
+
+/**
+ * In-memory disconnect tracker, shared between `handlePlayerDisconnect`
+ * (Server Action) and `claimWinAction` (Server Action).
+ *
+ * Lives outside any `"use server"` file so we can export synchronous
+ * helpers like `getDisconnectedAt` and the `RECONNECT_WINDOW_MS` constant —
+ * Next.js requires every export of a `"use server"` module to be an async
+ * Server Action, which this file deliberately is not.
+ *
+ * Scope note: the store is per-process. In a multi-instance production
+ * deployment this should graduate to Redis or a database row; for the
+ * current playtest scale a single serverless instance is fine.
+ */
+
+/** How long (in ms) an opponent may be disconnected before `claimWin` is allowed. */
+export const RECONNECT_WINDOW_MS = 90_000;
+
+interface DisconnectRecord {
+  matchId: string;
+  playerId: string;
+  disconnectedAt: string;
+}
+
+const disconnectStore = new Map<string, DisconnectRecord>();
+
+function keyFor(matchId: string, playerId: string): string {
+  return `${matchId}:${playerId}`;
+}
+
+/** Record a fresh disconnect. Overwrites any prior entry for the same player+match. */
+export function recordDisconnect(matchId: string, playerId: string): void {
+  disconnectStore.set(keyFor(matchId, playerId), {
+    matchId,
+    playerId,
+    disconnectedAt: new Date().toISOString(),
+  });
+}
+
+/**
+ * Returns the current disconnect record if one exists, else `null`.
+ * Kept as a separate helper from {@link getDisconnectedAt} because
+ * `handlePlayerReconnect` needs to know if there IS a record (to decide
+ * whether to clear it + broadcast), not just the timestamp.
+ */
+export function getDisconnectRecord(
+  matchId: string,
+  playerId: string,
+): { matchId: string; playerId: string; disconnectedAt: string } | null {
+  return disconnectStore.get(keyFor(matchId, playerId)) ?? null;
+}
+
+/**
+ * Returns the timestamp (ms since epoch) when the player first lost their
+ * connection for this match, or `null` if they are currently connected.
+ * Used by `claimWinAction` to check whether the 90s window has elapsed.
+ */
+export function getDisconnectedAt(
+  matchId: string,
+  playerId: string,
+): number | null {
+  const record = disconnectStore.get(keyFor(matchId, playerId));
+  if (!record) return null;
+  return new Date(record.disconnectedAt).getTime();
+}
+
+/** Clear the record. Returns true if a record existed, false otherwise. */
+export function clearDisconnect(matchId: string, playerId: string): boolean {
+  return disconnectStore.delete(keyFor(matchId, playerId));
+}
+
+/** @internal — test hook. Leaks nothing in prod since this is server-only. */
+export function __resetDisconnectStoreForTests(): void {
+  disconnectStore.clear();
+}

--- a/tests/unit/app/actions/claimWin.test.ts
+++ b/tests/unit/app/actions/claimWin.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("@/lib/matchmaking/profile", () => ({ readLobbySession: vi.fn() }));
 vi.mock("@/lib/supabase/server", () => ({ getServiceRoleClient: vi.fn() }));
-vi.mock("@/app/actions/match/handleDisconnect", () => ({
+vi.mock("@/lib/match/disconnectStore", () => ({
   getDisconnectedAt: vi.fn(),
-  RECONNECT_WINDOW_MS_EXPORT: 90_000,
+  RECONNECT_WINDOW_MS: 90_000,
 }));
 vi.mock("@/app/actions/match/completeMatch", () => ({
   completeMatchInternal: vi.fn(),
@@ -12,7 +12,7 @@ vi.mock("@/app/actions/match/completeMatch", () => ({
 
 import { claimWinAction } from "@/app/actions/match/claimWin";
 import { completeMatchInternal } from "@/app/actions/match/completeMatch";
-import { getDisconnectedAt } from "@/app/actions/match/handleDisconnect";
+import { getDisconnectedAt } from "@/lib/match/disconnectStore";
 import { readLobbySession } from "@/lib/matchmaking/profile";
 import { resetRateLimitStoreForTests } from "@/lib/rate-limiting/middleware";
 import { getServiceRoleClient } from "@/lib/supabase/server";


### PR DESCRIPTION
## Summary

Hotfix for the Vercel build failure on `main`:

```
./app/actions/match/handleDisconnect.ts:188:17
Server Actions must be async functions.
> 188 | export function getDisconnectedAt(
```

Next.js 16 Turbopack enforces that every export of a `"use server"` module is an async Server Action. Phase 6 (#150) added two exports that violate the rule:

- `getDisconnectedAt` — a synchronous helper reading an in-memory Map, used by `claimWinAction` to check the 90 s window.
- `RECONNECT_WINDOW_MS_EXPORT` — a plain `const number`.

Both are illegal from a `"use server"` file.

### Fix

Extract the in-memory disconnect store, the constant, and the synchronous accessors into a new `lib/match/disconnectStore.ts` module (marked `import "server-only"` so it still can't leak into client bundles). `handleDisconnect.ts` keeps only the async Server Actions and calls into the new module via `recordDisconnect` / `clearDisconnect` / `getDisconnectRecord`.

`claimWinAction` and its test now import `getDisconnectedAt` and `RECONNECT_WINDOW_MS` (renamed from `RECONNECT_WINDOW_MS_EXPORT` — the alias was only there to dodge the same Server Action rule, no longer needed) from the new location.

No behavioural change — same Map, same TTL, same call sites.

### Why Phase 6 passed review but broke on deploy

The Turbopack enforcement fires at _production build time_ only. `pnpm dev`, `pnpm test:unit`, `pnpm typecheck`, and `pnpm lint` all pass with the broken exports. Worth considering adding `pnpm build` to CI if it isn't there already.

## Test plan

- [x] `pnpm build` — succeeds (was failing)
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 968 passed, 2 skipped
- [ ] Vercel preview deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)