### PR TITLE
fix(match): write scoreboard_snapshots for round 10 so it renders

### DIFF
--- a/lib/match/recoverStuckRound.ts
+++ b/lib/match/recoverStuckRound.ts
@@ -3,7 +3,10 @@ import "server-only";
 import { boardGridSchema } from "@/lib/types/board";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 import { completeMatchInternal } from "@/app/actions/match/completeMatch";
-import { computeWordScoresForRound } from "@/app/actions/match/publishRoundSummary";
+import {
+    computeWordScoresForRound,
+    publishRoundSummary,
+} from "@/app/actions/match/publishRoundSummary";
 import { publishMatchState } from "./statePublisher";
 import { resolveConflicts } from "./conflictResolver";
 import { computeElapsedMs } from "./clockEnforcer";
@@ -75,6 +78,13 @@ export async function recoverStuckRound(matchId: string): Promise<void> {
     // Shape C — match already completed but winner not set.
     if (match.state === "completed") {
         if (!match.winner_id) {
+            // `publishRoundSummary` writes `scoreboard_snapshots` (upsert on
+            // `match_id,round_number`). When `advanceRound`'s fire-and-forget
+            // broadcast in step 15 was killed by Vercel function termination
+            // before it could run, the final round is missing from the chart.
+            // match.current_round is already one past the last played round
+            // (11 after round 10), so backfill current_round - 1.
+            await ensureScoreboardSnapshot(supabase, matchId, match.current_round - 1);
             await runCompleteMatch(matchId, "round_limit");
         }
         return;
@@ -92,6 +102,10 @@ export async function recoverStuckRound(matchId: string): Promise<void> {
     }
 
     if (roundCompleted && match.state === "in_progress") {
+        // Ensure the chart has an entry for the round that just finished —
+        // `publishRoundSummary` writes `scoreboard_snapshots` (upsert), which
+        // the summary page's round-by-round chart reads from.
+        await ensureScoreboardSnapshot(supabase, matchId, match.current_round);
         await finalizeCompletedRound(supabase, match, round);
     }
 
@@ -285,5 +299,33 @@ async function runCompleteMatch(
         await completeMatchInternal(matchId, reason);
     } catch (error) {
         console.error("[recoverStuckRound] completeMatchInternal failed:", error);
+    }
+}
+
+/**
+ * Write `scoreboard_snapshots` for a round if it's missing. `publishRoundSummary`
+ * reads `word_score_entries`, aggregates via `aggregateRoundSummary`, and
+ * upserts the snapshot; when the entry is already there we skip to avoid a
+ * duplicate Realtime broadcast.
+ */
+async function ensureScoreboardSnapshot(
+    supabase: Supabase,
+    matchId: string,
+    roundNumber: number,
+): Promise<void> {
+    if (roundNumber < 1) return;
+
+    const { data } = await supabase
+        .from("scoreboard_snapshots")
+        .select("round_number")
+        .eq("match_id", matchId)
+        .eq("round_number", roundNumber)
+        .maybeSingle();
+    if (data) return;
+
+    try {
+        await publishRoundSummary(matchId, roundNumber);
+    } catch (error) {
+        console.error("[recoverStuckRound] publishRoundSummary failed:", error);
     }
 }

--- a/lib/match/roundEngine.ts
+++ b/lib/match/roundEngine.ts
@@ -10,6 +10,8 @@ import { publishRoundSummary, computeWordScoresForRound } from "@/app/actions/ma
 import { trackRoundCompleted } from "@/lib/observability/log";
 import { isClockExpired, computeElapsedMs } from "./clockEnforcer";
 
+const PUBLISH_SUMMARY_OUTER_TIMEOUT_MS = 3_000;
+
 type MatchRow = {
     id: string;
     current_round: number;
@@ -364,30 +366,62 @@ export async function advanceRound(matchId: string) {
 
     if (updateError) throw new Error("Failed to update match");
 
-    // 15. Publish round summary and match state — fire-and-forget.
-    // Broadcast delivery is best-effort; clients have a 2s safety poll and
-    // loadMatchState self-heals on read, so the authoritative DB writes above
-    // are what matter. Awaiting here previously stalled step 16 by up to 20s
-    // whenever the Realtime channel subscribe timed out in local dev.
-    void Promise.allSettled([
-        publishRoundSummary(matchId, currentRound),
-        publishMatchState(matchId),
-    ]).then(([summaryResult, stateResult]) => {
-        if (summaryResult.status === "rejected") {
-            console.error("Failed to publish round summary:", summaryResult.reason);
-        }
-        if (stateResult.status === "rejected") {
-            console.error("[MatchState] Failed to broadcast match update:", stateResult.reason);
-        }
-    });
-
+    // 15. Publish round summary and match state.
+    // For non-terminal rounds: fire-and-forget. Broadcast delivery is
+    // best-effort; clients have a 2s safety poll and `loadMatchState`
+    // self-heals on read, so the authoritative DB writes above are what
+    // matter. Awaiting stalled step 16 by up to 20s whenever the Realtime
+    // subscribe timed out (pre-PR #151).
+    //
+    // For terminal rounds (game over): await `publishRoundSummary`. It
+    // writes `scoreboard_snapshots` via `recordScoreSnapshot` (upsert), and
+    // that row is what the summary page's round-by-round chart reads. After
+    // step 16 (`completeMatchInternal`) finishes and the function returns,
+    // Vercel can terminate the `after()` hook; a fire-and-forget
+    // `publishRoundSummary` was getting killed mid-flight, leaving round 10
+    // missing from the chart. The 2s subscribe timeout inside
+    // `publishRoundSummary` bounds the added latency.
     if (isGameOver) {
+        // Bounded await: `publishRoundSummary` has an internal 2s Realtime
+        // subscribe timeout; this outer 3s guard protects the pipeline from a
+        // pathological Supabase hang (or a pinned Promise in tests).
+        await Promise.race([
+            publishRoundSummary(matchId, currentRound).catch((error) => {
+                console.error("Failed to publish round summary:", error);
+            }),
+            new Promise<void>((resolve) =>
+                setTimeout(() => {
+                    console.error(
+                        "[RoundSummary] outer timeout 3000ms; continuing to completeMatchInternal",
+                    );
+                    resolve();
+                }, PUBLISH_SUMMARY_OUTER_TIMEOUT_MS),
+            ),
+        ]);
+        // publishMatchState stays fire-and-forget — `completeMatchInternal`
+        // calls it again on its own, so the final state broadcast is covered.
+        void publishMatchState(matchId).catch((error) => {
+            console.error("[MatchState] Failed to broadcast match update:", error);
+        });
+
         const endReason = nextRound > 10 ? "round_limit" : "timeout";
         try {
             await completeMatchInternal(matchId, endReason);
         } catch (error) {
             console.error("[MatchState] Failed to finalize match:", error);
         }
+    } else {
+        void Promise.allSettled([
+            publishRoundSummary(matchId, currentRound),
+            publishMatchState(matchId),
+        ]).then(([summaryResult, stateResult]) => {
+            if (summaryResult.status === "rejected") {
+                console.error("Failed to publish round summary:", summaryResult.reason);
+            }
+            if (stateResult.status === "rejected") {
+                console.error("[MatchState] Failed to broadcast match update:", stateResult.reason);
+            }
+        });
     }
 
     trackRoundCompleted({

--- a/tests/unit/lib/match/recoverStuckRound.test.ts
+++ b/tests/unit/lib/match/recoverStuckRound.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/app/actions/match/publishRoundSummary", () => ({
         wordScores: [],
         finalBoard: Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A")),
     }),
+    publishRoundSummary: vi.fn().mockResolvedValue({ ok: true }),
 }));
 vi.mock("@/lib/match/statePublisher", () => ({
     publishMatchState: vi.fn().mockResolvedValue(undefined),
@@ -17,7 +18,10 @@ vi.mock("@/lib/match/statePublisher", () => ({
 import { recoverStuckRound } from "@/lib/match/recoverStuckRound";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 import { completeMatchInternal } from "@/app/actions/match/completeMatch";
-import { computeWordScoresForRound } from "@/app/actions/match/publishRoundSummary";
+import {
+    computeWordScoresForRound,
+    publishRoundSummary,
+} from "@/app/actions/match/publishRoundSummary";
 import { publishMatchState } from "@/lib/match/statePublisher";
 
 const MATCH_ID = "match-stuck";
@@ -62,9 +66,18 @@ interface BuildClientOpts {
     round?: RoundRow;
     submissions?: SubmissionRow[];
     existingWordEntries?: Array<{ id: string }>;
+    /** Scoreboard snapshots already persisted for the round. `null` (default) =
+     *  missing → recovery should call publishRoundSummary. */
+    existingSnapshot?: { round_number: number } | null;
 }
 
-function buildMockClient({ match, round, submissions = [], existingWordEntries = [] }: BuildClientOpts) {
+function buildMockClient({
+    match,
+    round,
+    submissions = [],
+    existingWordEntries = [],
+    existingSnapshot = null,
+}: BuildClientOpts) {
     // Track writes for assertions
     const matchUpdates: Array<Record<string, unknown>> = [];
     const roundUpdates: Array<Record<string, unknown>> = [];
@@ -114,6 +127,14 @@ function buildMockClient({ match, round, submissions = [], existingWordEntries =
                 select: vi.fn(() => ({
                     eq: vi.fn().mockReturnThis(),
                     limit: vi.fn().mockResolvedValue({ data: existingWordEntries, error: null }),
+                })),
+            };
+        }
+        if (table === "scoreboard_snapshots") {
+            return {
+                select: vi.fn(() => ({
+                    eq: vi.fn().mockReturnThis(),
+                    maybeSingle: vi.fn().mockResolvedValue({ data: existingSnapshot, error: null }),
                 })),
             };
         }
@@ -196,6 +217,7 @@ describe("recoverStuckRound", () => {
         vi.mocked(getServiceRoleClient).mockReset();
         vi.mocked(completeMatchInternal).mockClear();
         vi.mocked(computeWordScoresForRound).mockClear();
+        vi.mocked(publishRoundSummary).mockClear();
         vi.mocked(publishMatchState).mockClear();
     });
 
@@ -219,6 +241,8 @@ describe("recoverStuckRound", () => {
             expect(roundUpdates.some((u) => u.state === "completed")).toBe(true);
             // Match advanced to completed (round 10 is terminal)
             expect(matchUpdates.some((u) => u.state === "completed" && u.current_round === 11)).toBe(true);
+            // scoreboard_snapshots written via publishRoundSummary before completeMatchInternal
+            expect(publishRoundSummary).toHaveBeenCalledWith(MATCH_ID, 10);
             // completeMatchInternal called with round_limit
             expect(completeMatchInternal).toHaveBeenCalledWith(MATCH_ID, "round_limit");
         });
@@ -235,12 +259,14 @@ describe("recoverStuckRound", () => {
             await recoverStuckRound(MATCH_ID);
 
             expect(computeWordScoresForRound).not.toHaveBeenCalled();
+            // Snapshot still missing → publishRoundSummary backfills it
+            expect(publishRoundSummary).toHaveBeenCalledWith(MATCH_ID, 10);
             expect(completeMatchInternal).toHaveBeenCalledWith(MATCH_ID, "round_limit");
         });
     });
 
     describe("shape B: round completed but match still in_progress", () => {
-        it("advances match to completed when current_round is 10, calls completeMatchInternal with round_limit", async () => {
+        it("advances match to completed when current_round is 10, calls publishRoundSummary + completeMatchInternal", async () => {
             const { client, matchUpdates } = buildMockClient({
                 match: baseMatch({ current_round: 10 }),
                 round: baseRound({ state: "completed" }),
@@ -256,6 +282,23 @@ describe("recoverStuckRound", () => {
             const updatedMatch = matchUpdates.find((u) => u.state === "completed");
             expect(updatedMatch?.player_a_timer_ms).toBe(119_000);
             expect(updatedMatch?.player_b_timer_ms).toBe(108_000);
+            // scoreboard_snapshots backfilled before the match is finalised
+            expect(publishRoundSummary).toHaveBeenCalledWith(MATCH_ID, 10);
+            expect(completeMatchInternal).toHaveBeenCalledWith(MATCH_ID, "round_limit");
+        });
+
+        it("skips publishRoundSummary when scoreboard_snapshots already exists for the round", async () => {
+            const { client } = buildMockClient({
+                match: baseMatch({ current_round: 10 }),
+                round: baseRound({ state: "completed" }),
+                submissions: baseSubmissions("accepted"),
+                existingSnapshot: { round_number: 10 },
+            });
+            vi.mocked(getServiceRoleClient).mockReturnValue(client);
+
+            await recoverStuckRound(MATCH_ID);
+
+            expect(publishRoundSummary).not.toHaveBeenCalled();
             expect(completeMatchInternal).toHaveBeenCalledWith(MATCH_ID, "round_limit");
         });
 
@@ -272,11 +315,13 @@ describe("recoverStuckRound", () => {
             expect(completeMatchInternal).not.toHaveBeenCalled();
             // Match updated to next round (current_round=6) but not completed
             expect(matchUpdates.some((u) => u.current_round === 6 && u.state !== "completed")).toBe(true);
+            // And the snapshot for round 5 gets backfilled for the chart
+            expect(publishRoundSummary).toHaveBeenCalledWith(MATCH_ID, 5);
         });
     });
 
     describe("shape C: match completed but winner_id null", () => {
-        it("calls completeMatchInternal to fill in winner_id", async () => {
+        it("backfills round-10 scoreboard_snapshots then calls completeMatchInternal", async () => {
             const { client } = buildMockClient({
                 match: baseMatch({ state: "completed", winner_id: null, current_round: 11 }),
             });
@@ -284,10 +329,26 @@ describe("recoverStuckRound", () => {
 
             await recoverStuckRound(MATCH_ID);
 
+            // match.current_round is 11 (post-game-over); the "last played"
+            // round is 10 — that's where a missing snapshot would live.
+            expect(publishRoundSummary).toHaveBeenCalledWith(MATCH_ID, 10);
             expect(completeMatchInternal).toHaveBeenCalledTimes(1);
             expect(completeMatchInternal).toHaveBeenCalledWith(MATCH_ID, "round_limit");
             // Scoring should NOT be re-run
             expect(computeWordScoresForRound).not.toHaveBeenCalled();
+        });
+
+        it("skips publishRoundSummary in shape C when scoreboard_snapshots for the last round already exists", async () => {
+            const { client } = buildMockClient({
+                match: baseMatch({ state: "completed", winner_id: null, current_round: 11 }),
+                existingSnapshot: { round_number: 10 },
+            });
+            vi.mocked(getServiceRoleClient).mockReturnValue(client);
+
+            await recoverStuckRound(MATCH_ID);
+
+            expect(publishRoundSummary).not.toHaveBeenCalled();
+            expect(completeMatchInternal).toHaveBeenCalledWith(MATCH_ID, "round_limit");
         });
 
         it("is a no-op when match is completed and winner_id is already set", async () => {
@@ -299,6 +360,7 @@ describe("recoverStuckRound", () => {
             await recoverStuckRound(MATCH_ID);
 
             expect(completeMatchInternal).not.toHaveBeenCalled();
+            expect(publishRoundSummary).not.toHaveBeenCalled();
             expect(matchUpdates).toHaveLength(0);
             expect(roundUpdates).toHaveLength(0);
         });

--- a/tests/unit/lib/match/roundEngine.test.ts
+++ b/tests/unit/lib/match/roundEngine.test.ts
@@ -16,6 +16,13 @@ vi.mock("@/app/actions/match/completeMatch", () => ({
     completeMatchInternal: vi.fn().mockResolvedValue({ matchId: "match-1" }),
 }));
 
+// publishMatchState hits `supabase.channel`/`removeChannel`, which the row-only
+// mocked client doesn't expose. Its internal 2s subscribe timeout otherwise
+// surfaces as an uncaught exception after the test exits.
+vi.mock("@/lib/match/statePublisher", () => ({
+    publishMatchState: vi.fn().mockResolvedValue(undefined),
+}));
+
 type SubmissionRow = {
     id: string;
     player_id: string;
@@ -392,11 +399,13 @@ describe("roundEngine.advanceRound", () => {
         expect(roundsInsert).not.toHaveBeenCalled();
     });
 
-    // Regression guard: step 15 broadcasts must be fire-and-forget, so
-    // completeMatchInternal runs even when publishRoundSummary hangs. This was
-    // the root cause of stuck round 10: awaiting the Realtime broadcast stalled
-    // the whole pipeline whenever the local channel subscribe timed out.
-    it("calls completeMatchInternal even when publishRoundSummary never resolves", async () => {
+    // Regression guard: for game-over, publishRoundSummary is awaited so its
+    // `scoreboard_snapshots` upsert finishes before Vercel terminates the
+    // function (that's why round 10 was missing from the chart). If it
+    // REJECTS, completeMatchInternal must still run — the match-level writes
+    // are authoritative, broadcasts are best-effort. An outer 3s timeout in
+    // `advanceRound` additionally protects against a pathological hang.
+    it("calls completeMatchInternal when publishRoundSummary rejects on game-over", async () => {
         const { publishRoundSummary } = await import(
             "@/app/actions/match/publishRoundSummary"
         );
@@ -404,9 +413,8 @@ describe("roundEngine.advanceRound", () => {
             "@/app/actions/match/completeMatch"
         );
         vi.mocked(completeMatchInternal).mockClear();
-        // Make the broadcast hang forever — the old implementation would block here.
-        vi.mocked(publishRoundSummary).mockImplementationOnce(
-            () => new Promise(() => {}),
+        vi.mocked(publishRoundSummary).mockImplementationOnce(() =>
+            Promise.reject(new Error("broadcast failed")),
         );
 
         setupSupabase(
@@ -446,7 +454,56 @@ describe("roundEngine.advanceRound", () => {
         );
         expect(completeMatchInternal).toHaveBeenCalledWith("match-1", "round_limit");
 
-        // Restore the mock so downstream tests don't see a hanging promise.
+        // Restore the mock so downstream tests see a normal resolve.
+        vi.mocked(publishRoundSummary).mockResolvedValue({ ok: true } as never);
+    });
+
+    // Regression guard: for NON-terminal rounds, step 15 stays fire-and-forget,
+    // so advanceRound completes even when publishRoundSummary hangs.
+    it("completes non-terminal round advance even when publishRoundSummary never resolves", async () => {
+        const { publishRoundSummary } = await import(
+            "@/app/actions/match/publishRoundSummary"
+        );
+        vi.mocked(publishRoundSummary).mockImplementationOnce(
+            () => new Promise(() => {}),
+        );
+
+        setupSupabase(
+            [
+                {
+                    id: "sub-a",
+                    player_id: "player-a",
+                    from_x: 0,
+                    from_y: 0,
+                    to_x: 0,
+                    to_y: 1,
+                    submitted_at: "2026-01-01T00:00:00Z",
+                    status: "pending",
+                },
+                {
+                    id: "sub-b",
+                    player_id: "player-b",
+                    from_x: 5,
+                    from_y: 5,
+                    to_x: 5,
+                    to_y: 6,
+                    submitted_at: "2026-01-01T00:00:01Z",
+                    status: "pending",
+                },
+            ],
+            { current_round: 3 },
+        );
+
+        const result = await advanceRound("match-1");
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                status: "advanced",
+                nextRound: 4,
+                isGameOver: false,
+            }),
+        );
+
         vi.mocked(publishRoundSummary).mockResolvedValue({ ok: true } as never);
     });
 


### PR DESCRIPTION
Follow-up to #153. Fixes the remaining slice of issue #149.

## Problem

#153 fixed the round-10 freeze, but round 10 is still missing from the `/summary` round-by-round chart (and the scored-tiles highlight animation doesn't fire at end of round). Users confirmed match completion works; only the scoring surface is wrong.

## Diagnosis

The chart reads from `scoreboard_snapshots`, which is only written by `publishRoundSummary` → `recordScoreSnapshot` (upsert on `match_id,round_number`). For round 10 this was getting dropped by **two** paths:

1. **`advanceRound` step 15** — fire-and-forget `publishRoundSummary`. For R1–R9 the `after()` hook stays alive long enough (next submit queues new work) for the broadcast to settle. For R10 the match completes at step 16 and Vercel terminates the function before the fire-and-forget finishes.
2. **`recoverStuckRound` (introduced in #153)** — never called `publishRoundSummary` at all. Whenever the recovery handled R10, `word_score_entries` got written but the snapshot did not.

Result: the chart omits R10 entirely (see screenshot in the issue comment), and the client's highlight animation at end of round never fires because the `"round-summary"` Realtime broadcast was also part of `publishRoundSummary`.

## Fix

- **`lib/match/roundEngine.ts` step 15** — for the game-over case, `await publishRoundSummary` before `completeMatchInternal`. Non-terminal rounds keep fire-and-forget (their snapshots have always worked, and awaiting there historically stalled the pipeline on Realtime timeouts per #151). An outer 3s `Promise.race` guards against pathological hangs; `publishRoundSummary` has an internal 2s subscribe timeout that bounds typical latency.
- **`lib/match/recoverStuckRound.ts`** — new `ensureScoreboardSnapshot(matchId, roundNumber)` helper. Called before match finalisation in all three stuck shapes. No-op when the row already exists (keeps us from double-broadcasting when the normal path completed).

`recordScoreSnapshot` is an upsert, so re-calls are safe.

## Test plan

- [x] `pnpm test:unit` — 983 passed, 2 skipped (+3 new tests, no regressions)
  - `recoverStuckRound.test.ts` now asserts `publishRoundSummary` is called in shapes A/B/C, and NOT called when the snapshot already exists or when match is a no-op no-op (winner already set)
  - `roundEngine.test.ts` regression guards split into two: game-over awaits (resilient to rejection), non-terminal stays fire-and-forget (resilient to hang)
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — succeeds
- [ ] Live repro: finish a match end-to-end and confirm R10 renders in the chart. Trigger recovery (manually mark round 10 `resolving` with stale `resolution_started_at`) and confirm R10 also renders.
- [ ] CI Playwright `match-completion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)