### PR TITLE
fix(lobby): lighten Ready-to-play CTA + player cards to match Warm Editorial prototype

### DIFF
--- a/app/styles/lobby.css
+++ b/app/styles/lobby.css
@@ -117,28 +117,40 @@
   cursor: not-allowed;
 }
 
-/* ---- CTA card elevation ---- */
+/* ---- CTA card — Warm Editorial paper surface ----
+ * Mirrors the prototype's `.card` treatment (background: var(--paper),
+ * hair border, soft drop shadow) but lifts elevation for the primary
+ * action and threads a thin ochre hairline border to tie the card to
+ * the CTA gradient and the hero eyebrow. Letterpress inset highlight
+ * on the top edge matches `.lobby-hero-tile` for visual continuity. */
 .lobby-cta-card {
-  background: linear-gradient(160deg, rgba(28, 38, 64, 0.9) 0%, rgba(20, 28, 46, 0.95) 100%);
-  border: 1px solid rgba(242, 234, 211, 0.08);
+  background: linear-gradient(
+    180deg,
+    var(--paper) 0%,
+    color-mix(in oklab, var(--paper-2) 92%, var(--paper)) 100%
+  );
+  border: 1px solid color-mix(in oklab, var(--ochre-deep) 22%, transparent);
   box-shadow:
-    0 20px 60px -20px rgba(0, 0, 0, 0.6),
-    inset 0 1px 0 rgba(242, 234, 211, 0.06);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+    inset 0 1px 0 color-mix(in oklab, #fff 80%, transparent),
+    inset 0 0 0 1px color-mix(in oklab, var(--ink) 4%, transparent),
+    var(--shadow-md);
 }
 
-/* ---- Player directory card ---- */
+/* ---- Player directory card ----
+ * Prototype parity: `.player-card { background: var(--paper); border: 1px
+ * solid var(--hair); border-radius: 12px; }` with a hover lift that
+ * firms the border (→ ink-3) and adds `shadow-md`. */
 .lobby-player-card {
-  background: linear-gradient(160deg, rgba(28, 38, 64, 0.75) 0%, rgba(20, 28, 46, 0.85) 100%);
-  border: 1px solid rgba(242, 234, 211, 0.06);
+  background: var(--paper);
+  border: 1px solid var(--hair);
+  box-shadow: var(--shadow-sm);
   transition: border-color 200ms ease-out, transform 200ms ease-out, box-shadow 200ms ease-out;
 }
 
 .lobby-player-card:hover {
-  border-color: rgba(232, 182, 76, 0.3);
+  border-color: var(--ink-3);
   transform: translateY(-1px);
-  box-shadow: 0 12px 28px -12px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-md);
 }
 
 /* ---- Skeleton shimmer (T020) ---- */
@@ -156,9 +168,9 @@
   overflow: hidden;
   background-image: linear-gradient(
     90deg,
-    rgba(28, 38, 64, 0.4) 0%,
-    rgba(37, 49, 86, 0.75) 50%,
-    rgba(28, 38, 64, 0.4) 100%
+    var(--paper-2) 0%,
+    var(--paper-3) 50%,
+    var(--paper-2) 100%
   );
   background-size: 200% 100%;
   animation: skeleton-shimmer 1.2s ease-in-out infinite;

--- a/components/lobby/LobbyCard.tsx
+++ b/components/lobby/LobbyCard.tsx
@@ -81,7 +81,7 @@ export const LobbyCard = forwardRef<HTMLDivElement, LobbyCardProps>(
           <div className="min-w-0 flex-1">
             <button
               type="button"
-              className="min-h-[44px] truncate text-left text-sm font-semibold text-text-inverse transition hover:text-ochre focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-focus sm:min-h-0"
+              className="min-h-[44px] truncate text-left text-sm font-semibold text-text-primary transition hover:text-ochre-deep focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-focus sm:min-h-0"
               onClick={(e) => {
                 e.stopPropagation();
                 onUsernameClick?.(player.id);
@@ -90,14 +90,14 @@ export const LobbyCard = forwardRef<HTMLDivElement, LobbyCardProps>(
             >
               {player.displayName ?? player.username}
             </button>
-            <p className="truncate text-xs text-text-inverse/50">
+            <p className="truncate text-xs text-text-muted">
               @{player.username}
             </p>
           </div>
           <div className="flex flex-col items-end gap-1">
             <span
               data-testid="lobby-elo-rating"
-              className="font-mono text-xs font-medium text-text-inverse"
+              className="font-mono text-xs font-medium text-text-primary"
             >
               {displayRating}
             </span>
@@ -154,9 +154,9 @@ function EloDiffBadge({
   const label = diff > 0 ? `+${diff}` : diff < 0 ? `${diff}` : "±0";
   const color =
     diff > 0
-      ? "text-emerald-400"
+      ? "text-good"
       : diff < 0
-        ? "text-rose-400"
+        ? "text-bad"
         : "text-text-muted";
   return (
     <span data-testid="lobby-elo-diff" className={`font-mono text-xs ${color}`}>

--- a/components/lobby/PlayNowCard.tsx
+++ b/components/lobby/PlayNowCard.tsx
@@ -50,14 +50,14 @@ export function PlayNowCard({ currentPlayer }: PlayNowCardProps) {
     <Card elevation={0} className="lobby-cta-card space-y-5 p-6 sm:p-8">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="font-display text-2xl font-semibold text-text-inverse sm:text-3xl">
+          <p className="font-display text-2xl font-semibold text-text-primary sm:text-3xl">
             Ready to play?
           </p>
-          <p className="text-sm text-text-inverse/70">
+          <p className="text-sm text-text-secondary">
             Drop into a ranked match against someone near your rating.
           </p>
         </div>
-        <span className="hidden font-display text-xs uppercase tracking-[0.3em] text-accent-focus/70 sm:inline">
+        <span className="hidden font-display text-xs uppercase tracking-[0.3em] text-ochre-deep sm:inline">
           {currentPlayer.eloRating ?? 1200} Elo
         </span>
       </div>

--- a/tests/unit/components/lobby/LobbyCard.spec.tsx
+++ b/tests/unit/components/lobby/LobbyCard.spec.tsx
@@ -52,7 +52,7 @@ describe("LobbyCard Elo display", () => {
     );
     const diff = screen.getByTestId("lobby-elo-diff");
     expect(diff).toHaveTextContent("+170");
-    expect(diff.className).toContain("text-emerald");
+    expect(diff.className).toContain("text-good");
   });
 
   it("should render negative Elo difference in red", () => {
@@ -64,7 +64,7 @@ describe("LobbyCard Elo display", () => {
     );
     const diff = screen.getByTestId("lobby-elo-diff");
     expect(diff).toHaveTextContent("-170");
-    expect(diff.className).toContain("text-rose");
+    expect(diff.className).toContain("text-bad");
   });
 
   it("should render zero Elo difference as neutral", () => {


### PR DESCRIPTION
## Summary
- The **Ready-to-play** CTA and **Players online** cards were rendering on dark navy gradients (`rgba(28, 38, 64, 0.9→0.95)`) that fought the rest of the Warm Editorial surface.
- Swapped both to the paper-on-paper treatment defined in the prototype (`docs/design_documentation/260422-wottle-game-design/project/prototype/styles.css`): `var(--paper)` + hair border + `var(--shadow-sm)`, with a subtle ochre hairline on the CTA card to tie it to the primary gradient + hero eyebrow.
- Retuned the skeleton shimmer from navy rgba to paper tones (`--paper-2` → `--paper-3`) so loading states read against the new light cards.
- Flipped `LobbyCard` and `PlayNowCard` text tokens from `text-text-inverse` (cream) to `text-text-primary` / `-secondary` / `-muted` (ink). Elo diff colors moved from hard-coded `text-emerald-400` / `text-rose-400` to the palette's `text-good` / `text-bad` tokens.

## Test plan
- [x] `pnpm lint` — zero warnings
- [x] `pnpm typecheck` — clean (after clearing stale `.next` cache)
- [x] `pnpm test` — 968 passed, 2 skipped
- [x] Visual sanity check at `/lobby` in light mode
- [x] Visual sanity check of the hover raise on a `.lobby-player-card`
- [x] Reduced-motion check: skeletons + player-card hover both still disable animation/transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)