### PR TITLE
fix(match): heartbeat-based disconnect detection for the Disconnectio…

### DIFF
--- a/app/api/match/[matchId]/disconnect/route.ts
+++ b/app/api/match/[matchId]/disconnect/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+import { handlePlayerDisconnect } from "@/app/actions/match/handleDisconnect";
+import { readLobbySession } from "@/lib/matchmaking/profile";
+
+/**
+ * sendBeacon-friendly disconnect endpoint. Used by MatchClient on `pagehide`
+ * to reliably notify the server when the tab is being torn down — Server
+ * Actions invoked from a closing tab routinely abort mid-fetch, but
+ * `navigator.sendBeacon` queues the request on the browser's network thread
+ * and is delivered even after the page is gone.
+ *
+ * Body: ignored (we identify the player from the session cookie). The endpoint
+ * accepts POST so sendBeacon can deliver it; the body is whatever the browser
+ * sent (typically an empty Blob).
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ matchId: string }> },
+): Promise<NextResponse> {
+  const { matchId } = await params;
+  const session = await readLobbySession();
+
+  if (!session) {
+    return NextResponse.json(
+      { error: "Authentication required." },
+      { status: 401 },
+    );
+  }
+
+  try {
+    await handlePlayerDisconnect(matchId, session.player.id);
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    console.error("[api/match/disconnect] handlePlayerDisconnect failed:", error);
+    return NextResponse.json(
+      { error: "Failed to record disconnect." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/match/[matchId]/state/route.ts
+++ b/app/api/match/[matchId]/state/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import { readLobbySession } from "@/lib/matchmaking/profile";
 import { loadMatchState } from "@/lib/match/stateLoader";
+import { recordHeartbeat } from "@/lib/match/heartbeatStore";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 
 const NO_CACHE_HEADERS = {
@@ -21,6 +22,11 @@ export async function GET(
       { status: 401, headers: NO_CACHE_HEADERS },
     );
   }
+
+  // Record this poll as a heartbeat — loadMatchState uses heartbeat staleness
+  // to detect when the *other* player has disappeared without sending a
+  // graceful disconnect notification.
+  recordHeartbeat(matchId, session.player.id);
 
   const supabase = getServiceRoleClient();
   const state = await loadMatchState(supabase, matchId);

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -176,6 +176,20 @@ export function MatchClient({
     setMatchState(initialState);
   }, [initialState]);
 
+  // Sync the matchState's disconnectedPlayerId (which can be set by Realtime
+  // onState OR by polling via applySnapshot) into the dedicated state field
+  // that the modal and reconnect UI read from. The Realtime onState handler
+  // also calls setDisconnectedPlayerId directly, but polling paths don't —
+  // this effect closes the gap so the modal renders even when Realtime is
+  // unavailable.
+  useEffect(() => {
+    const fromSnapshot = matchState.disconnectedPlayerId ?? null;
+    setDisconnectedPlayerId((prev) => (prev === fromSnapshot ? prev : fromSnapshot));
+    if (fromSnapshot && fromSnapshot !== currentPlayerId) {
+      setIsReconnecting(false);
+    }
+  }, [matchState.disconnectedPlayerId, currentPlayerId]);
+
   // Trigger round-recap animation whenever a new lastSummary arrives (via onState or onSummary).
   // Using lastSummary as the source-of-truth means the animation fires reliably regardless
   // of whether the Realtime "round-summary" broadcast or the "state" broadcast arrives first.
@@ -303,6 +317,7 @@ export function MatchClient({
 
     const client = getBrowserSupabaseClient();
     const channel = subscribeToMatchChannel(client, matchId, {
+      presenceKey: currentPlayerId,
       onState: (snapshot) => {
         if (snapshot.disconnectedPlayerId) {
           setDisconnectedPlayerId(snapshot.disconnectedPlayerId);
@@ -330,6 +345,19 @@ export function MatchClient({
           scores: nextSummary.totals,
           lastSummary: nextSummary,
         }));
+      },
+      // Opponent's WebSocket dropped (tab close, crash, network drop). Supabase
+      // Realtime emits a presence "leave" to every other subscriber, so the
+      // surviving client (us) is responsible for telling the server — the
+      // disconnecting client can't be trusted to fire a fetch on its way out.
+      onOpponentLeave: ({ playerId: opponentId }) => {
+        setDisconnectedPlayerId(opponentId);
+        void handlePlayerDisconnect(matchId, opponentId).catch((error) => {
+          console.error(
+            "[MatchClient] Failed to notify server of opponent disconnect:",
+            error,
+          );
+        });
       },
       onError: (error) => {
         console.error(
@@ -363,7 +391,13 @@ export function MatchClient({
     });
 
     return () => {
-      channel.unsubscribe();
+      // Use removeChannel (not just unsubscribe) so the server-side join state
+      // for `match:${matchId}` is fully released. Plain unsubscribe leaves the
+      // channel cached on the SupabaseClient, and a re-subscribe (e.g. React
+      // StrictMode double-mount in dev) collides with the prior server-side
+      // join — the second subscribe stalls at TIMED_OUT and presence never
+      // joins, so opponent-leave events never fire.
+      void client.removeChannel(channel);
     };
   }, [
     matchId,
@@ -375,6 +409,24 @@ export function MatchClient({
     matchState.timers.playerA.playerId,
     playWordDiscovery,
   ]);
+
+  // ── pagehide → sendBeacon disconnect notification ────────────────
+  // Best-effort: tells the server "I'm leaving" before the tab dies. Note that
+  // some test runners (e.g. Playwright `BrowserContext.close()`) force-kill
+  // the page without firing pagehide, so detection ALSO falls back to the
+  // server-side heartbeat staleness check in `loadMatchState`.
+  useEffect(() => {
+    const notifyDisconnect = () => {
+      if (typeof navigator === "undefined" || !navigator.sendBeacon) {
+        return;
+      }
+      navigator.sendBeacon(`/api/match/${matchId}/disconnect`);
+    };
+    window.addEventListener("pagehide", notifyDisconnect);
+    return () => {
+      window.removeEventListener("pagehide", notifyDisconnect);
+    };
+  }, [matchId]);
 
   // ── Primary polling (only when Realtime is confirmed down) ────────
   useEffect(() => {
@@ -425,8 +477,13 @@ export function MatchClient({
       const roundAdvanced = snapshot.currentRound > current.currentRound;
       const matchCompleted =
         snapshot.state === "completed" && current.state !== "completed";
+      // Also apply when disconnect state flips — this is the only signal
+      // when Realtime broadcasts aren't reaching the surviving client.
+      const disconnectChanged =
+        (snapshot.disconnectedPlayerId ?? null) !==
+        (current.disconnectedPlayerId ?? null);
 
-      if (roundAdvanced || matchCompleted) {
+      if (roundAdvanced || matchCompleted || disconnectChanged) {
         applySnapshot(snapshot);
       }
     };

--- a/lib/match/heartbeatStore.ts
+++ b/lib/match/heartbeatStore.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+/**
+ * In-memory heartbeat tracker used to detect player disconnections without
+ * relying on the disconnecting client cooperatively notifying the server.
+ *
+ * MatchClient polls `/api/match/[matchId]/state` every few seconds; that
+ * endpoint records the caller's heartbeat here. `loadMatchState` then
+ * consults the heartbeat for the *other* player — if it's older than
+ * `STALE_THRESHOLD_MS`, the other player is considered disconnected and the
+ * snapshot's `disconnectedPlayerId` is set accordingly.
+ *
+ * This works even when the disconnecting browser is force-killed (Playwright
+ * `context.close`, browser crash, network drop), because no notification from
+ * the dying side is required — the surviving side detects staleness on its
+ * next poll.
+ *
+ * Scope note: per-process Map. In a multi-instance deployment this should
+ * graduate to Redis or a dedicated table.
+ */
+
+/** Polling cadence is ~3s; allow up to ~3 missed polls before flagging. */
+export const HEARTBEAT_STALE_THRESHOLD_MS = 10_000;
+
+const heartbeats = new Map<string, number>();
+
+function keyFor(matchId: string, playerId: string): string {
+  return `${matchId}:${playerId}`;
+}
+
+export function recordHeartbeat(matchId: string, playerId: string): void {
+  heartbeats.set(keyFor(matchId, playerId), Date.now());
+}
+
+export function getLastHeartbeat(
+  matchId: string,
+  playerId: string,
+): number | null {
+  return heartbeats.get(keyFor(matchId, playerId)) ?? null;
+}
+
+export function isHeartbeatStale(
+  matchId: string,
+  playerId: string,
+  now: number = Date.now(),
+): boolean {
+  const lastSeen = heartbeats.get(keyFor(matchId, playerId));
+  if (lastSeen === undefined) {
+    // Never seen — not stale; the player simply hasn't polled yet.
+    return false;
+  }
+  return now - lastSeen > HEARTBEAT_STALE_THRESHOLD_MS;
+}
+
+export function clearHeartbeat(matchId: string, playerId: string): void {
+  heartbeats.delete(keyFor(matchId, playerId));
+}
+
+/** @internal — test hook. */
+export function __resetHeartbeatStoreForTests(): void {
+  heartbeats.clear();
+}

--- a/lib/match/stateLoader.ts
+++ b/lib/match/stateLoader.ts
@@ -14,6 +14,8 @@ import type {
 } from "@/lib/types/match";
 import { generateBoard } from "@/scripts/supabase/generateBoard";
 import { computeElapsedMs, computeRemainingMs } from "./clockEnforcer";
+import { getDisconnectRecord } from "./disconnectStore";
+import { isHeartbeatStale } from "./heartbeatStore";
 
 type AnyClient = SupabaseClient<any, any, any>;
 
@@ -359,6 +361,30 @@ export async function loadMatchState(
     playerBStatus = "running";
   }
 
+  // Surface disconnect state in the polled snapshot. Two complementary signals:
+  //   1. `disconnectStore` — populated by `handlePlayerDisconnect` when the
+  //      disconnecting client *does* manage to notify us (sendBeacon, system
+  //      CLOSED handler).
+  //   2. Heartbeat staleness — covers the cases where the client never gets to
+  //      notify us (Playwright `context.close`, browser crash, network drop).
+  //      Each `/state` poll updates the caller's heartbeat; the surviving
+  //      side detects the other's silence here on the very next poll.
+  // Only flags the match as in-progress (completed matches don't need it).
+  const disconnectFromStore =
+    getDisconnectRecord(match.id, match.player_a_id)?.playerId ??
+    getDisconnectRecord(match.id, match.player_b_id)?.playerId ??
+    null;
+
+  let disconnectFromHeartbeat: string | null = null;
+  if (effectiveState !== "completed") {
+    if (isHeartbeatStale(match.id, match.player_a_id)) {
+      disconnectFromHeartbeat = match.player_a_id;
+    } else if (isHeartbeatStale(match.id, match.player_b_id)) {
+      disconnectFromHeartbeat = match.player_b_id;
+    }
+  }
+  const disconnectedPlayerId = disconnectFromStore ?? disconnectFromHeartbeat;
+
   return {
     matchId: match.id,
     board,
@@ -379,6 +405,7 @@ export async function loadMatchState(
     scores,
     lastSummary,
     frozenTiles: (match as any).frozen_tiles ?? {},
+    disconnectedPlayerId,
   };
 }
 

--- a/lib/realtime/matchChannel.ts
+++ b/lib/realtime/matchChannel.ts
@@ -6,19 +6,48 @@ import type {
   RoundSummary,
 } from "@/lib/types/match";
 
+export interface MatchPresencePayload {
+  playerId: string;
+}
+
 export interface MatchChannelCallbacks {
   onState?: (snapshot: MatchState) => void;
   onSummary?: (summary: RoundSummary) => void;
   onRematchEvent?: (event: RematchEvent) => void;
   onError?: (error: unknown) => void;
+  /**
+   * Fires when a *different* player's presence drops from the match channel.
+   * Supabase emits a presence "leave" event when a peer's WebSocket closes
+   * for any reason (tab close, crash, network drop). Self-leaves are filtered
+   * out so consumers only see opponent disconnects.
+   *
+   * Only invoked when `presenceKey` is set on the subscription, and only when
+   * the channel actually reaches SUBSCRIBED — which is not guaranteed in every
+   * environment, so this should be treated as a best-effort signal alongside
+   * the sendBeacon + polling fallback.
+   */
+  onOpponentLeave?: (presence: MatchPresencePayload) => void;
+}
+
+export interface MatchChannelOptions extends MatchChannelCallbacks {
+  /**
+   * If provided, the channel joins Supabase presence under this key (typically
+   * the local player's id). Required for `onOpponentLeave` to fire.
+   */
+  presenceKey?: string;
 }
 
 export function subscribeToMatchChannel(
   client: SupabaseClient,
   matchId: string,
-  callbacks: MatchChannelCallbacks
+  options: MatchChannelOptions
 ): RealtimeChannel {
-  const channel = client.channel(`match:${matchId}`);
+  const { presenceKey, ...callbacks } = options;
+  const channel = presenceKey
+    ? client.channel(`match:${matchId}`, {
+        config: { presence: { key: presenceKey } },
+      })
+    : client.channel(`match:${matchId}`);
 
   channel
     .on("broadcast", { event: "state" }, (payload) => {
@@ -29,12 +58,28 @@ export function subscribeToMatchChannel(
     })
     .on("broadcast", { event: "rematch" }, (payload) => {
       callbacks.onRematchEvent?.(payload.payload as RematchEvent);
-    })
-    .subscribe((status) => {
-      if (status === "CHANNEL_ERROR") {
-        callbacks.onError?.(new Error(`Realtime channel error (match:${matchId})`));
+    });
+
+  if (presenceKey) {
+    channel.on("presence", { event: "leave" }, ({ leftPresences }) => {
+      for (const presence of leftPresences) {
+        const playerId = (presence as { playerId?: unknown })?.playerId;
+        if (typeof playerId === "string" && playerId !== presenceKey) {
+          callbacks.onOpponentLeave?.({ playerId });
+        }
       }
     });
+  }
+
+  channel.subscribe((status) => {
+    if (status === "CHANNEL_ERROR") {
+      callbacks.onError?.(new Error(`Realtime channel error (match:${matchId})`));
+      return;
+    }
+    if (status === "SUBSCRIBED" && presenceKey) {
+      void channel.track({ playerId: presenceKey });
+    }
+  });
 
   return channel;
 }

--- a/tests/unit/components/MatchClient.test.tsx
+++ b/tests/unit/components/MatchClient.test.tsx
@@ -23,9 +23,11 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(),
 }));
 
-// Mock Supabase browser client
+// Mock Supabase browser client — removeChannel is invoked on cleanup
 vi.mock("@/lib/supabase/browser", () => ({
-  getBrowserSupabaseClient: () => ({}),
+  getBrowserSupabaseClient: () => ({
+    removeChannel: vi.fn(),
+  }),
 }));
 
 // Mock realtime channel — captures onSummary for phase machine tests
@@ -33,7 +35,12 @@ vi.mock("@/lib/realtime/matchChannel", () => ({
   subscribeToMatchChannel: (
     _client: unknown,
     _matchId: string,
-    callbacks: { onSummary: (summary: RoundSummary) => void; onState?: (state: MatchState) => void },
+    callbacks: {
+      onSummary: (summary: RoundSummary) => void;
+      onState?: (state: MatchState) => void;
+      onOpponentLeave?: (presence: { playerId: string }) => void;
+      presenceKey?: string;
+    },
   ) => {
     mockMatchCallbacks.onSummary = callbacks.onSummary;
     mockMatchCallbacks.onState = callbacks.onState ?? null;

--- a/tests/unit/lib/match/heartbeatStore.test.ts
+++ b/tests/unit/lib/match/heartbeatStore.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  HEARTBEAT_STALE_THRESHOLD_MS,
+  __resetHeartbeatStoreForTests,
+  clearHeartbeat,
+  getLastHeartbeat,
+  isHeartbeatStale,
+  recordHeartbeat,
+} from "@/lib/match/heartbeatStore";
+
+afterEach(() => {
+  __resetHeartbeatStoreForTests();
+  vi.useRealTimers();
+});
+
+describe("heartbeatStore", () => {
+  test("recordHeartbeat stores a timestamp retrievable by getLastHeartbeat", () => {
+    const before = Date.now();
+    recordHeartbeat("match-1", "player-a");
+    const after = Date.now();
+
+    const ts = getLastHeartbeat("match-1", "player-a");
+    expect(ts).not.toBeNull();
+    expect(ts!).toBeGreaterThanOrEqual(before);
+    expect(ts!).toBeLessThanOrEqual(after);
+  });
+
+  test("getLastHeartbeat returns null for an unrecorded player", () => {
+    expect(getLastHeartbeat("match-1", "player-a")).toBeNull();
+  });
+
+  test("recordHeartbeat scopes by (matchId, playerId) — different players in same match are independent", () => {
+    recordHeartbeat("match-1", "player-a");
+    expect(getLastHeartbeat("match-1", "player-b")).toBeNull();
+  });
+
+  test("recordHeartbeat scopes by matchId — same player in different matches are independent", () => {
+    recordHeartbeat("match-1", "player-a");
+    expect(getLastHeartbeat("match-2", "player-a")).toBeNull();
+  });
+
+  test("isHeartbeatStale returns false when no heartbeat exists (player has never polled)", () => {
+    expect(isHeartbeatStale("match-1", "player-a")).toBe(false);
+  });
+
+  test("isHeartbeatStale returns false immediately after recordHeartbeat", () => {
+    recordHeartbeat("match-1", "player-a");
+    expect(isHeartbeatStale("match-1", "player-a")).toBe(false);
+  });
+
+  test("isHeartbeatStale returns true when last heartbeat exceeds the threshold", () => {
+    vi.useFakeTimers();
+    const start = new Date("2026-04-22T12:00:00Z").getTime();
+    vi.setSystemTime(start);
+    recordHeartbeat("match-1", "player-a");
+
+    vi.setSystemTime(start + HEARTBEAT_STALE_THRESHOLD_MS + 1);
+    expect(isHeartbeatStale("match-1", "player-a")).toBe(true);
+  });
+
+  test("isHeartbeatStale returns false when last heartbeat is exactly at the threshold", () => {
+    vi.useFakeTimers();
+    const start = new Date("2026-04-22T12:00:00Z").getTime();
+    vi.setSystemTime(start);
+    recordHeartbeat("match-1", "player-a");
+
+    vi.setSystemTime(start + HEARTBEAT_STALE_THRESHOLD_MS);
+    expect(isHeartbeatStale("match-1", "player-a")).toBe(false);
+  });
+
+  test("recordHeartbeat refreshes a previously-stale entry", () => {
+    vi.useFakeTimers();
+    const start = new Date("2026-04-22T12:00:00Z").getTime();
+    vi.setSystemTime(start);
+    recordHeartbeat("match-1", "player-a");
+
+    vi.setSystemTime(start + HEARTBEAT_STALE_THRESHOLD_MS + 5_000);
+    expect(isHeartbeatStale("match-1", "player-a")).toBe(true);
+
+    recordHeartbeat("match-1", "player-a");
+    expect(isHeartbeatStale("match-1", "player-a")).toBe(false);
+  });
+
+  test("clearHeartbeat removes the entry — subsequent isHeartbeatStale returns false (treated as never-polled)", () => {
+    recordHeartbeat("match-1", "player-a");
+    clearHeartbeat("match-1", "player-a");
+    expect(getLastHeartbeat("match-1", "player-a")).toBeNull();
+    expect(isHeartbeatStale("match-1", "player-a")).toBe(false);
+  });
+
+  test("isHeartbeatStale accepts a custom now value for deterministic checks", () => {
+    vi.useFakeTimers();
+    const start = new Date("2026-04-22T12:00:00Z").getTime();
+    vi.setSystemTime(start);
+    recordHeartbeat("match-1", "player-a");
+
+    expect(
+      isHeartbeatStale(
+        "match-1",
+        "player-a",
+        start + HEARTBEAT_STALE_THRESHOLD_MS + 1,
+      ),
+    ).toBe(true);
+    expect(
+      isHeartbeatStale("match-1", "player-a", start + 1_000),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/lib/realtime/matchChannel.test.ts
+++ b/tests/unit/lib/realtime/matchChannel.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { subscribeToMatchChannel } from "@/lib/realtime/matchChannel";
+
+type Handler = (...args: unknown[]) => void;
+interface CapturedHandler {
+  type: string;
+  opts: Record<string, unknown>;
+  cb: Handler;
+}
+
+interface FakeChannel {
+  on: (type: string, opts: Record<string, unknown>, cb: Handler) => FakeChannel;
+  subscribe: (cb?: (status: string) => void) => FakeChannel;
+  track: (...args: unknown[]) => unknown;
+  unsubscribe: () => void;
+  presenceState: () => Record<string, unknown>;
+}
+
+function createFakeClient() {
+  const handlers: CapturedHandler[] = [];
+  let subscribeCb: ((status: string) => void) | null = null;
+  let lastTopic: string | null = null;
+  let lastOpts: Record<string, unknown> | undefined;
+
+  const trackMock = vi.fn();
+  const unsubscribeMock = vi.fn();
+
+  const channel: FakeChannel = {
+    on(type, opts, cb) {
+      handlers.push({ type, opts, cb });
+      return channel;
+    },
+    subscribe(cb) {
+      subscribeCb = cb ?? null;
+      return channel;
+    },
+    track: trackMock,
+    unsubscribe: unsubscribeMock,
+    presenceState: () => ({}),
+  };
+
+  const client = {
+    channel: vi.fn((topic: string, opts?: Record<string, unknown>) => {
+      lastTopic = topic;
+      lastOpts = opts;
+      return channel;
+    }),
+  };
+
+  return {
+    client,
+    channel,
+    handlers,
+    trackMock,
+    triggerSubscribe: (status: string) => subscribeCb?.(status),
+    getLastTopic: () => lastTopic,
+    getLastOpts: () => lastOpts,
+  };
+}
+
+describe("subscribeToMatchChannel — presence", () => {
+  test("when no presenceKey provided, channel is created without presence config", () => {
+    const fake = createFakeClient();
+
+    subscribeToMatchChannel(fake.client as never, "match-1", {});
+
+    expect(fake.getLastTopic()).toBe("match:match-1");
+    expect(fake.getLastOpts()).toBeUndefined();
+    expect(fake.trackMock).not.toHaveBeenCalled();
+  });
+
+  test("when presenceKey provided, channel is configured with presence and tracks self after SUBSCRIBED", () => {
+    const fake = createFakeClient();
+
+    subscribeToMatchChannel(fake.client as never, "match-1", {
+      presenceKey: "player-a",
+    });
+
+    expect(fake.getLastOpts()).toEqual({
+      config: { presence: { key: "player-a" } },
+    });
+
+    fake.triggerSubscribe("SUBSCRIBED");
+
+    expect(fake.trackMock).toHaveBeenCalledWith({ playerId: "player-a" });
+  });
+
+  test("track is NOT called when status is anything other than SUBSCRIBED", () => {
+    const fake = createFakeClient();
+
+    subscribeToMatchChannel(fake.client as never, "match-1", {
+      presenceKey: "player-a",
+    });
+
+    fake.triggerSubscribe("CHANNEL_ERROR");
+    expect(fake.trackMock).not.toHaveBeenCalled();
+  });
+
+  test("onOpponentLeave fires for other players' presence leave events", () => {
+    const fake = createFakeClient();
+    const onOpponentLeave = vi.fn();
+
+    subscribeToMatchChannel(fake.client as never, "match-1", {
+      presenceKey: "player-a",
+      onOpponentLeave,
+    });
+
+    const leaveHandler = fake.handlers.find(
+      (h) => h.type === "presence" && h.opts.event === "leave",
+    );
+    expect(leaveHandler).toBeDefined();
+
+    leaveHandler!.cb({ leftPresences: [{ playerId: "player-b" }] });
+
+    expect(onOpponentLeave).toHaveBeenCalledWith({ playerId: "player-b" });
+  });
+
+  test("onOpponentLeave ignores own playerId (self-leave is not opponent-leave)", () => {
+    const fake = createFakeClient();
+    const onOpponentLeave = vi.fn();
+
+    subscribeToMatchChannel(fake.client as never, "match-1", {
+      presenceKey: "player-a",
+      onOpponentLeave,
+    });
+
+    const leaveHandler = fake.handlers.find(
+      (h) => h.type === "presence" && h.opts.event === "leave",
+    );
+
+    leaveHandler!.cb({ leftPresences: [{ playerId: "player-a" }] });
+
+    expect(onOpponentLeave).not.toHaveBeenCalled();
+  });
+
+  test("onOpponentLeave handles multiple left presences and skips self-entries", () => {
+    const fake = createFakeClient();
+    const onOpponentLeave = vi.fn();
+
+    subscribeToMatchChannel(fake.client as never, "match-1", {
+      presenceKey: "player-a",
+      onOpponentLeave,
+    });
+
+    const leaveHandler = fake.handlers.find(
+      (h) => h.type === "presence" && h.opts.event === "leave",
+    );
+
+    leaveHandler!.cb({
+      leftPresences: [{ playerId: "player-a" }, { playerId: "player-b" }],
+    });
+
+    expect(onOpponentLeave).toHaveBeenCalledTimes(1);
+    expect(onOpponentLeave).toHaveBeenCalledWith({ playerId: "player-b" });
+  });
+
+  test("presence leave handler is NOT registered when presenceKey is absent", () => {
+    const fake = createFakeClient();
+
+    subscribeToMatchChannel(fake.client as never, "match-1", {});
+
+    const leaveHandler = fake.handlers.find(
+      (h) => h.type === "presence" && h.opts.event === "leave",
+    );
+    expect(leaveHandler).toBeUndefined();
+  });
+});


### PR DESCRIPTION
…nModal

The Phase 6 disconnect-modal Playwright spec was failing in CI and under `scripts/act.sh`. The original detection relied on the disconnecting client (B) firing a Server Action from the Realtime channel `system: CLOSED` handler — but Playwright's `BrowserContext.close()` force-kills the page before the in-flight fetch can complete, and the match channel's Realtime subscribe times out in this environment so the fallback broadcast path never reaches A either.

Replace the brittle path with three layered signals that work for real users *and* tests:

* `lib/match/heartbeatStore.ts` — in-memory `(matchId, playerId)` → lastSeenAt tracker with a 10s staleness threshold.
* `/api/match/[matchId]/state` records the caller's heartbeat on every poll. The MatchClient safety-net poller runs every 2s, so heartbeats refresh frequently for live players.
* `loadMatchState` surfaces the *other* player as `disconnectedPlayerId` when their heartbeat is stale (or when `disconnectStore` already has them marked via the existing handlePlayerDisconnect path).
* `MatchClient` gains a sync useEffect so `matchState.disconnectedPlayerId` drives the modal even when the Realtime onState handler doesn't fire, plus a best-effort `pagehide` → `sendBeacon` to a new `/api/match/[matchId]/disconnect` endpoint.
* `subscribeToMatchChannel` gains optional Supabase presence tracking with an `onOpponentLeave` callback as a Realtime-fast-path bonus.

Adds 11 unit tests for the heartbeat store and 7 for the matchChannel presence wiring. Both disconnect-modal Playwright tests now pass deterministically against the production build.