### PR TITLE
feat(profile): Warm Editorial refresh of /profile and /profile/[handle]

### DIFF
--- a/app/actions/player/getPlayerProfile.ts
+++ b/app/actions/player/getPlayerProfile.ts
@@ -41,7 +41,7 @@ export async function getPlayerProfile(
   const { data: player, error: playerError } = await supabase
     .from("players")
     .select(
-      "id, username, display_name, avatar_url, status, last_seen_at, elo_rating, games_played, wins, losses, draws",
+      "id, username, display_name, avatar_url, status, last_seen_at, created_at, elo_rating, games_played, wins, losses, draws",
     )
     .eq("id", parsed.data.playerId)
     .single();
@@ -121,6 +121,7 @@ export async function getPlayerProfile(
     avatarUrl: player.avatar_url as string | null,
     status: player.status as PlayerIdentity["status"],
     lastSeenAt: player.last_seen_at as string,
+    createdAt: (player.created_at as string | null) ?? undefined,
     eloRating: player.elo_rating as number,
   };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Fraunces, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import "./styles/board.css";
 import "./styles/lobby.css";
+import "./styles/profile.css";
 import { ToastProvider } from "@/components/ui/ToastProvider";
 import { TopBar } from "@/components/ui/TopBar";
 

--- a/app/profile/[handle]/page.tsx
+++ b/app/profile/[handle]/page.tsx
@@ -2,6 +2,7 @@ import { getRecentGames } from "@/app/actions/match/getRecentGames";
 import { getBestWords } from "@/app/actions/player/getBestWords";
 import { getPlayerProfileByHandle } from "@/app/actions/player/getPlayerProfileByHandle";
 import { ProfilePage } from "@/components/profile/ProfilePage";
+import { readLobbySession } from "@/lib/matchmaking/profile";
 
 interface Params {
   handle: string;
@@ -37,19 +38,23 @@ export default async function PublicProfilePage({
     );
   }
 
-  const [bestWordsResult, recentGamesResult] = await Promise.all([
+  const [bestWordsResult, recentGamesResult, session] = await Promise.all([
     getBestWords(profileResult.profile.identity.id, 12),
     getRecentGames({
       playerId: profileResult.profile.identity.id,
       limit: 10,
     }),
+    readLobbySession(),
   ]);
+
+  const isSelf = session?.player.id === profileResult.profile.identity.id;
 
   return (
     <ProfilePage
       profile={profileResult.profile}
       words={bestWordsResult.words ?? []}
       matches={recentGamesResult.games ?? []}
+      isSelf={isSelf}
     />
   );
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -34,6 +34,7 @@ export default async function OwnProfilePage() {
       profile={profileResult.profile}
       words={bestWordsResult.words ?? []}
       matches={recentGamesResult.games ?? []}
+      isSelf
     />
   );
 }

--- a/app/styles/profile.css
+++ b/app/styles/profile.css
@@ -1,0 +1,79 @@
+/* Warm Editorial profile utilities — shared by /profile and /profile/[handle]. */
+
+.profile-card {
+  background: var(--paper);
+  border: 1px solid var(--hair);
+  border-radius: 14px;
+  padding: 20px 22px;
+  box-shadow: var(--shadow-sm);
+}
+
+.profile-card__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.profile-card__head h3 {
+  font-family: var(--font-fraunces, "Fraunces"), serif;
+  font-style: italic;
+  font-weight: 500;
+  font-size: 18px;
+  color: var(--ink);
+  margin: 0;
+}
+
+.profile-card__head-meta {
+  font-family: var(--font-jetbrains-mono, "JetBrains Mono"), ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--ink-soft);
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.profile-stats-frame {
+  border: 1px solid var(--hair);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--paper);
+}
+
+.profile-stats-frame > * {
+  padding: 16px 18px;
+}
+
+.profile-stats-frame > * + * {
+  border-left: 1px solid var(--hair);
+}
+
+@media (max-width: 640px) {
+  .profile-stats-frame > * + * {
+    border-left: none;
+    border-top: 1px solid var(--hair);
+  }
+  .profile-stats-frame > *:nth-child(even) {
+    border-left: 1px solid var(--hair);
+  }
+  .profile-stats-frame > *:nth-child(3),
+  .profile-stats-frame > *:nth-child(4) {
+    border-top: 1px solid var(--hair);
+  }
+}
+
+.profile-eyebrow {
+  font-family: var(--font-jetbrains-mono, "JetBrains Mono"), ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--ink-soft);
+}
+
+.profile-rating-card {
+  background: var(--paper-2);
+  border: 1px solid var(--hair);
+  border-radius: 10px;
+  padding: 14px;
+}

--- a/components/profile/ProfileMatchHistoryList.tsx
+++ b/components/profile/ProfileMatchHistoryList.tsx
@@ -32,7 +32,7 @@ export function ProfileMatchHistoryList({ matches }: ProfileMatchHistoryListProp
     return (
       <div
         data-testid="profile-match-history"
-        className="rounded-xl border border-hair bg-paper-2 px-4 py-6 text-center text-sm text-ink-soft"
+        className="px-2 py-4 text-center text-sm text-ink-soft"
       >
         No recent matches.
       </div>
@@ -41,13 +41,13 @@ export function ProfileMatchHistoryList({ matches }: ProfileMatchHistoryListProp
   return (
     <ul
       data-testid="profile-match-history"
-      className="flex flex-col divide-y divide-hair rounded-xl border border-hair bg-paper"
+      className="flex flex-col divide-y divide-hair"
     >
       {matches.map((m) => (
         <li
           key={m.matchId}
           data-testid="match-history-row"
-          className="flex items-center gap-4 px-4 py-3"
+          className="flex flex-wrap items-center gap-x-4 gap-y-1 py-3 first:pt-0 last:pb-0"
         >
           <span
             data-testid={`match-history-chip-${m.matchId}`}
@@ -55,17 +55,26 @@ export function ProfileMatchHistoryList({ matches }: ProfileMatchHistoryListProp
           >
             {CHIP_LABEL[m.result]}
           </span>
-          <span className="min-w-0 flex-1 truncate font-mono text-sm text-ink">
-            @{m.opponentUsername}
+          <span className="min-w-0 flex-1 truncate text-sm text-ink">
+            vs <b className="font-semibold">@{m.opponentUsername}</b>
           </span>
           <span className="font-mono text-sm text-ink">
-            {m.yourScore} – {m.opponentScore}
+            {m.yourScore}–{m.opponentScore}
+          </span>
+          <span
+            data-testid={`match-history-words-${m.matchId}`}
+            className="font-mono text-[11px] text-ink-soft"
+          >
+            {m.wordsFound} words
           </span>
           <span className="font-mono text-[11px] text-ink-soft">
             {relativeTime(m.completedAt)}
           </span>
-          <span className="font-mono text-[11px] text-ink-soft/60">
-            Replay → (soon)
+          <span
+            aria-disabled="true"
+            className="ml-auto font-mono text-[11px] text-ink-soft/60"
+          >
+            Replay →
           </span>
         </li>
       ))}

--- a/components/profile/ProfilePage.tsx
+++ b/components/profile/ProfilePage.tsx
@@ -1,7 +1,12 @@
 import type { RecentGameRow } from "@/lib/types/lobby";
+import {
+  deriveRecentRatingDelta,
+  sliceRatingHistoryWindow,
+} from "@/components/profile/deriveProfileChartData";
 import { ProfileMatchHistoryList } from "@/components/profile/ProfileMatchHistoryList";
 import { ProfileRatingChart } from "@/components/profile/ProfileRatingChart";
 import { ProfileSidebar } from "@/components/profile/ProfileSidebar";
+import { ProfileStat } from "@/components/profile/ProfileStat";
 import { ProfileWordCloud } from "@/components/profile/ProfileWordCloud";
 import type { BestWord, PlayerProfile } from "@/lib/types/match";
 
@@ -9,63 +14,85 @@ interface ProfilePageProps {
   profile: PlayerProfile;
   words: BestWord[];
   matches: RecentGameRow[];
+  isSelf: boolean;
 }
 
-function StatTile({ label, value }: { label: string; value: string | number }) {
+function formatWinRate(winRate: number | null): string {
+  return winRate !== null ? `${Math.round(winRate * 100)}%` : "—";
+}
+
+function formatWeeklyDelta(delta: number): string {
+  if (delta === 0) return "± 0 this week";
+  return `${delta > 0 ? "+" : ""}${delta} this week`;
+}
+
+function StatsFrame({ profile }: { profile: PlayerProfile }) {
+  const { stats, peakRating } = profile;
+  const record = `${stats.wins}–${stats.losses}–${stats.draws}`;
   return (
-    <div className="rounded-xl border border-hair bg-paper-2 p-3">
-      <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-soft">
-        {label}
-      </p>
-      <p className="mt-1 font-display text-2xl font-semibold text-ink">{value}</p>
-    </div>
+    <section aria-label="At-a-glance stats">
+      <p className="profile-eyebrow">At a glance</p>
+      <div className="profile-stats-frame mt-2.5 grid grid-cols-2 sm:grid-cols-4">
+        <ProfileStat label="Matches" value={stats.gamesPlayed} />
+        <ProfileStat label="W · L · D" value={record} />
+        <ProfileStat label="Win rate" value={formatWinRate(stats.winRate)} />
+        <ProfileStat label="Peak rating" value={peakRating} />
+      </div>
+    </section>
   );
 }
 
-export function ProfilePage({ profile, words, matches }: ProfilePageProps) {
-  const { stats, peakRating, ratingHistory } = profile;
-  const winRatePct =
-    stats.winRate !== null ? `${Math.round(stats.winRate * 100)}%` : "—";
+function PanelCard({
+  title,
+  meta,
+  children,
+  testId,
+}: {
+  title: string;
+  meta: string;
+  children: React.ReactNode;
+  testId: string;
+}) {
+  return (
+    <section className="profile-card" data-testid={testId}>
+      <header className="profile-card__head">
+        <h3>{title}</h3>
+        <span className="profile-card__head-meta">{meta}</span>
+      </header>
+      {children}
+    </section>
+  );
+}
+
+export function ProfilePage({ profile, words, matches, isSelf }: ProfilePageProps) {
+  const thirtyDay = sliceRatingHistoryWindow(profile.ratingHistory, 30);
+  const weeklyDelta = deriveRecentRatingDelta(profile.ratingHistory, 7);
 
   return (
     <main
       data-testid="profile-page"
-      className="mx-auto grid w-full max-w-5xl gap-10 px-5 py-8 sm:grid-cols-[200px_1fr] sm:px-8 sm:py-12"
+      className="mx-auto grid w-full max-w-[1200px] gap-10 px-5 py-8 sm:grid-cols-[280px_1fr] sm:px-14 sm:py-14"
     >
-      <ProfileSidebar profile={profile} />
+      <ProfileSidebar profile={profile} isSelf={isSelf} />
 
-      <div className="flex flex-col gap-8">
-        <section
-          aria-label="At-a-glance stats"
-          className="grid grid-cols-2 gap-3 sm:grid-cols-5"
+      <div className="flex flex-col gap-7">
+        <StatsFrame profile={profile} />
+
+        <PanelCard
+          title="Rating · last 30 days"
+          meta={formatWeeklyDelta(weeklyDelta)}
+          testId="panel-rating"
         >
-          <StatTile label="Matches" value={stats.gamesPlayed} />
-          <StatTile label="Wins" value={stats.wins} />
-          <StatTile label="Losses" value={stats.losses} />
-          <StatTile label="Win rate" value={winRatePct} />
-          <StatTile label="Peak" value={peakRating} />
-        </section>
+          <ProfileRatingChart history={thirtyDay} />
+        </PanelCard>
 
-        <section aria-label="Rating history">
-          <h2 className="mb-3 font-display text-xl font-semibold text-ink">
-            Rating
-          </h2>
-          <ProfileRatingChart history={ratingHistory} />
-        </section>
-
-        <section aria-label="Best words">
-          <h2 className="mb-3 font-display text-xl font-semibold text-ink">
-            Best words
-          </h2>
+        <PanelCard title="Best words" meta="All-time" testId="panel-words">
           <ProfileWordCloud words={words} />
-        </section>
+        </PanelCard>
 
-        <section aria-label="Recent matches">
-          <h2 className="mb-3 font-display text-xl font-semibold text-ink">
-            Recent matches
-          </h2>
+        <PanelCard title="Recent matches" meta="Last 7 days" testId="panel-history">
           <ProfileMatchHistoryList matches={matches} />
-        </section>
+        </PanelCard>
       </div>
     </main>
   );

--- a/components/profile/ProfileRatingChart.tsx
+++ b/components/profile/ProfileRatingChart.tsx
@@ -5,18 +5,18 @@ interface ProfileRatingChartProps {
 }
 
 const VIEWBOX_W = 600;
-const VIEWBOX_H = 220;
+const VIEWBOX_H = 180;
 const PAD_X = 24;
-const PAD_Y = 16;
+const PAD_Y = 14;
 
 export function ProfileRatingChart({ history }: ProfileRatingChartProps) {
   if (history.length === 0) {
     return (
       <div
         data-testid="profile-rating-chart"
-        className="flex h-[220px] w-full items-center justify-center rounded-xl border border-hair bg-paper-2 text-sm text-ink-soft"
+        className="flex h-[180px] w-full items-center justify-center text-sm text-ink-soft"
       >
-        No rated matches yet.
+        No rated matches in the last 30 days.
       </div>
     );
   }
@@ -30,7 +30,7 @@ export function ProfileRatingChart({ history }: ProfileRatingChartProps) {
     history.length > 1 ? (VIEWBOX_W - PAD_X * 2) / (history.length - 1) : 0;
 
   const points = history.map((h, i) => {
-    const x = PAD_X + i * xStep;
+    const x = history.length > 1 ? PAD_X + i * xStep : VIEWBOX_W / 2;
     const y =
       VIEWBOX_H - PAD_Y - ((h.rating - min) / range) * (VIEWBOX_H - PAD_Y * 2);
     return { x, y, rating: h.rating };
@@ -55,14 +55,9 @@ export function ProfileRatingChart({ history }: ProfileRatingChartProps) {
       role="img"
       aria-label="Rating history chart"
       viewBox={`0 0 ${VIEWBOX_W} ${VIEWBOX_H}`}
-      className="h-[220px] w-full rounded-xl border border-hair bg-paper-2"
+      preserveAspectRatio="none"
+      className="block h-[180px] w-full"
     >
-      <defs>
-        <linearGradient id="rating-chart-grad" x1="0" x2="0" y1="0" y2="1">
-          <stop offset="0%" stopColor="var(--ochre-deep)" stopOpacity="0.3" />
-          <stop offset="100%" stopColor="var(--ochre-deep)" stopOpacity="0" />
-        </linearGradient>
-      </defs>
       {gridYs.map((y) => (
         <line
           key={y}
@@ -70,11 +65,12 @@ export function ProfileRatingChart({ history }: ProfileRatingChartProps) {
           x2={VIEWBOX_W - PAD_X}
           y1={y}
           y2={y}
-          stroke="var(--hair)"
-          strokeDasharray="3 4"
+          stroke="currentColor"
+          strokeOpacity={0.08}
+          strokeDasharray="2 4"
         />
       ))}
-      <path d={areaD} fill="url(#rating-chart-grad)" />
+      <path d={areaD} fill="var(--ochre-tint)" opacity={0.7} />
       <path
         d={lineD}
         fill="none"
@@ -83,7 +79,14 @@ export function ProfileRatingChart({ history }: ProfileRatingChartProps) {
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <circle cx={endpoint.x} cy={endpoint.y} r={5} fill="var(--ochre-deep)" />
+      <circle
+        cx={endpoint.x}
+        cy={endpoint.y}
+        r={5}
+        fill="var(--ochre-deep)"
+        stroke="var(--paper)"
+        strokeWidth={2}
+      />
     </svg>
   );
 }

--- a/components/profile/ProfileSidebar.tsx
+++ b/components/profile/ProfileSidebar.tsx
@@ -119,7 +119,10 @@ export function ProfileSidebar({ profile, isSelf }: ProfileSidebarProps) {
           <h1 className="mt-1 font-display text-[42px] font-normal italic leading-[1.05] text-ink">
             {profile.identity.displayName}
           </h1>
-          <p className="mt-1 font-mono text-[12px] text-ink-soft">
+          <p
+            data-testid="profile-handle"
+            className="mt-1 font-mono text-[12px] text-ink-soft"
+          >
             @{profile.identity.username}
             {memberSince ? ` · member since ${memberSince}` : null}
           </p>

--- a/components/profile/ProfileSidebar.tsx
+++ b/components/profile/ProfileSidebar.tsx
@@ -1,43 +1,134 @@
+import Link from "next/link";
+
+import { deriveTodayRatingDelta } from "@/components/profile/deriveProfileChartData";
 import { Avatar } from "@/components/ui/Avatar";
 import type { PlayerProfile } from "@/lib/types/match";
 
 interface ProfileSidebarProps {
   profile: PlayerProfile;
+  isSelf: boolean;
 }
 
-export function ProfileSidebar({ profile }: ProfileSidebarProps) {
-  const year = new Date(profile.identity.lastSeenAt).getUTCFullYear();
+const MEMBER_SINCE_FMT = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "short",
+});
+
+function formatMemberSince(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return MEMBER_SINCE_FMT.format(d);
+}
+
+function TodayDelta({ delta }: { delta: number }) {
+  if (delta === 0) return null;
+  const positive = delta > 0;
+  const glyph = positive ? "▲" : "▼";
+  const color = positive ? "text-good" : "text-bad";
+  return (
+    <p
+      data-testid="today-delta"
+      className={`mt-1 font-mono text-[11px] tracking-[0.08em] ${color}`}
+    >
+      {glyph} {positive ? "+" : "−"}
+      {Math.abs(delta)} TODAY
+    </p>
+  );
+}
+
+function RatingCard({
+  rating,
+  todayDelta,
+}: {
+  rating: number;
+  todayDelta: number;
+}) {
+  return (
+    <div className="profile-rating-card" data-testid="rating-card">
+      <p className="profile-eyebrow">Rating</p>
+      <p className="mt-1 font-display text-[46px] italic leading-none text-ochre-deep">
+        {rating.toLocaleString("en-US")}
+      </p>
+      <TodayDelta delta={todayDelta} />
+    </div>
+  );
+}
+
+function SidebarActions({
+  isSelf,
+  handle,
+}: {
+  isSelf: boolean;
+  handle: string;
+}) {
+  if (isSelf) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Link
+          href="/matchmaking?mode=ranked"
+          data-testid="play-now-cta"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-ochre-deep px-4 py-2 text-sm font-semibold text-paper transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+        >
+          ◆ Play now
+        </Link>
+        <button
+          type="button"
+          disabled
+          title="Coming soon"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-hair bg-transparent px-4 py-2 text-sm font-medium text-ink-soft disabled:cursor-not-allowed"
+        >
+          Edit profile
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      <Link
+        href="/lobby"
+        data-testid="challenge-cta"
+        className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-ochre-deep px-4 py-2 text-sm font-semibold text-paper transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+      >
+        Challenge @{handle} →
+      </Link>
+    </div>
+  );
+}
+
+export function ProfileSidebar({ profile, isSelf }: ProfileSidebarProps) {
+  const memberSince = formatMemberSince(profile.identity.createdAt);
+  const todayDelta = deriveTodayRatingDelta(profile.ratingHistory);
+
   return (
     <aside
       data-testid="profile-sidebar"
-      className="flex w-full flex-col gap-6 sm:w-[180px]"
+      className="flex w-full flex-col gap-6 sm:sticky sm:top-20 sm:w-[280px]"
     >
-      <div className="flex flex-col items-start gap-3">
+      <div className="flex flex-col items-start gap-4">
         <Avatar
           playerId={profile.identity.id}
           displayName={profile.identity.displayName}
           avatarUrl={profile.identity.avatarUrl}
-          size="lg"
+          size="xl"
         />
-        <h1 className="font-display text-3xl font-semibold italic text-ink">
-          {profile.identity.displayName}
-        </h1>
-        <p className="font-mono text-[11px] text-ink-soft">
-          @{profile.identity.username} · joined {year}
-        </p>
+        <div>
+          <p className="profile-eyebrow">
+            {isSelf ? "Your profile" : "Player profile"}
+          </p>
+          <h1 className="mt-1 font-display text-[42px] font-normal italic leading-[1.05] text-ink">
+            {profile.identity.displayName}
+          </h1>
+          <p className="mt-1 font-mono text-[12px] text-ink-soft">
+            @{profile.identity.username}
+            {memberSince ? ` · member since ${memberSince}` : null}
+          </p>
+        </div>
       </div>
 
-      <div>
-        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-ink-soft">
-          Rating
-        </p>
-        <p className="mt-1 font-display text-5xl font-semibold italic text-ochre-deep">
-          {profile.stats.eloRating}
-        </p>
-        <p className="mt-1 font-mono text-[11px] text-ink-soft">
-          peak {profile.peakRating}
-        </p>
-      </div>
+      <RatingCard rating={profile.stats.eloRating} todayDelta={todayDelta} />
+
+      <SidebarActions isSelf={isSelf} handle={profile.identity.username} />
     </aside>
   );
 }

--- a/components/profile/ProfileStat.tsx
+++ b/components/profile/ProfileStat.tsx
@@ -1,0 +1,17 @@
+interface ProfileStatProps {
+  label: string;
+  value: string | number;
+}
+
+export function ProfileStat({ label, value }: ProfileStatProps) {
+  return (
+    <div data-testid="profile-stat">
+      <p className="font-display text-[26px] italic leading-none text-ink">
+        {value}
+      </p>
+      <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.2em] text-ink-soft">
+        {label}
+      </p>
+    </div>
+  );
+}

--- a/components/profile/ProfileWordCloud.tsx
+++ b/components/profile/ProfileWordCloud.tsx
@@ -14,7 +14,7 @@ export function ProfileWordCloud({ words }: ProfileWordCloudProps) {
     return (
       <div
         data-testid="profile-word-cloud"
-        className="rounded-xl border border-hair bg-paper-2 px-4 py-6 text-center text-sm text-ink-soft"
+        className="px-2 py-4 text-center text-sm text-ink-soft"
       >
         No scored words yet.
       </div>
@@ -24,7 +24,7 @@ export function ProfileWordCloud({ words }: ProfileWordCloudProps) {
   return (
     <div
       data-testid="profile-word-cloud"
-      className="flex flex-wrap items-baseline gap-x-3 gap-y-2"
+      className="flex flex-wrap items-baseline gap-x-3.5 gap-y-2"
     >
       {words.map((w, i) => {
         const isTopThree = i < 3;
@@ -33,10 +33,13 @@ export function ProfileWordCloud({ words }: ProfileWordCloudProps) {
           <span
             key={`${w.word}-${i}`}
             data-testid="word-cloud-item"
-            className={`font-display font-semibold ${colorClass}`}
+            className={`font-display font-semibold italic ${colorClass}`}
             style={{ fontSize: `${fontSizeFor(w.points)}px` }}
           >
             {w.word}
+            <sub className="ml-[3px] font-mono text-[10px] not-italic text-ink-soft">
+              +{w.points}
+            </sub>
           </span>
         );
       })}

--- a/components/profile/deriveProfileChartData.ts
+++ b/components/profile/deriveProfileChartData.ts
@@ -1,0 +1,65 @@
+import type { RatingHistoryEntry } from "@/lib/types/match";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function dayKey(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function windowStartMs(now: Date, days: number): number {
+  return now.getTime() - days * MS_PER_DAY;
+}
+
+export function sliceRatingHistoryWindow(
+  history: RatingHistoryEntry[],
+  days: number,
+  now: Date = new Date(),
+): RatingHistoryEntry[] {
+  const threshold = windowStartMs(now, days);
+  return history.filter((e) => new Date(e.recordedAt).getTime() >= threshold);
+}
+
+export function deriveTodayRatingDelta(
+  history: RatingHistoryEntry[],
+  now: Date = new Date(),
+): number {
+  if (history.length === 0) return 0;
+  const today = now.toISOString().slice(0, 10);
+  const lastTodayIdx = findLastIndex(history, (e) => dayKey(e.recordedAt) === today);
+  if (lastTodayIdx === -1) return 0;
+  const lastBeforeIdx = findLastIndex(
+    history,
+    (e) => dayKey(e.recordedAt) < today,
+  );
+  if (lastBeforeIdx === -1) return 0;
+  return history[lastTodayIdx].rating - history[lastBeforeIdx].rating;
+}
+
+export function deriveRecentRatingDelta(
+  history: RatingHistoryEntry[],
+  days: number,
+  now: Date = new Date(),
+): number {
+  if (history.length === 0) return 0;
+  const threshold = windowStartMs(now, days);
+  const current = history[history.length - 1];
+  const beforeIdx = findLastIndex(
+    history,
+    (e) => new Date(e.recordedAt).getTime() < threshold,
+  );
+  if (beforeIdx !== -1) {
+    return current.rating - history[beforeIdx].rating;
+  }
+  const firstInWindow = history.find(
+    (e) => new Date(e.recordedAt).getTime() >= threshold,
+  );
+  if (!firstInWindow || firstInWindow === current) return 0;
+  return current.rating - firstInWindow.rating;
+}
+
+function findLastIndex<T>(arr: T[], pred: (item: T) => boolean): number {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    if (pred(arr[i])) return i;
+  }
+  return -1;
+}

--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react";
 
 import { generateAvatar } from "@/lib/ui/avatarGradient";
 
-export type AvatarSize = "sm" | "md" | "lg";
+export type AvatarSize = "sm" | "md" | "lg" | "xl";
 
 interface AvatarProps {
   playerId: string;
@@ -16,6 +16,7 @@ const SIZE_STYLES: Record<AvatarSize, string> = {
   sm: "h-8 w-8 text-xs",
   md: "h-12 w-12 text-sm",
   lg: "h-16 w-16 text-base",
+  xl: "h-[180px] w-[180px] text-[72px] font-display italic",
 };
 
 export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(

--- a/lib/types/match.ts
+++ b/lib/types/match.ts
@@ -13,6 +13,9 @@ export interface PlayerIdentity {
   status: LobbyStatus;
   lastSeenAt: string;
   eloRating?: number | null;
+  /** ISO timestamp — when the player row was first created. Optional so
+   *  existing lobby/presence loaders that don't fetch it stay compatible. */
+  createdAt?: string;
 }
 
 export type TimerStatus = "running" | "paused" | "expired";

--- a/tests/integration/ui/profile-page.spec.ts
+++ b/tests/integration/ui/profile-page.spec.ts
@@ -57,7 +57,12 @@ test.describe("@profile-page Phase 5b profile pages", () => {
     await expect(viewerPage.getByTestId("profile-page")).toBeVisible({
       timeout: 10_000,
     });
-    await expect(viewerPage.getByText(`@${seedUsername}`)).toBeVisible();
+    // Handle appears inside the sidebar identity line.
+    await expect(viewerPage.getByTestId("profile-handle")).toContainText(
+      `@${seedUsername}`,
+    );
+    // And since the viewer is not the seed, the Challenge CTA is rendered.
+    await expect(viewerPage.getByTestId("challenge-cta")).toBeVisible();
   });
 
   test("/profile/ghost renders 'No such player' for unknown handle", async () => {

--- a/tests/unit/app/actions/getPlayerProfile.test.ts
+++ b/tests/unit/app/actions/getPlayerProfile.test.ts
@@ -34,6 +34,7 @@ const PLAYER_ROW = {
   avatar_url: null,
   status: "available",
   last_seen_at: "2026-04-22T10:00:00Z",
+  created_at: "2025-03-10T08:00:00Z",
   elo_rating: 1234,
   games_played: 7,
   wins: 4,

--- a/tests/unit/components/profile/ProfileMatchHistoryList.test.tsx
+++ b/tests/unit/components/profile/ProfileMatchHistoryList.test.tsx
@@ -54,4 +54,23 @@ describe("ProfileMatchHistoryList", () => {
     render(<ProfileMatchHistoryList matches={[]} />);
     expect(screen.getByText(/No recent matches/i)).toBeInTheDocument();
   });
+
+  test("renders words-found count per row", () => {
+    render(<ProfileMatchHistoryList matches={ROWS} />);
+    expect(screen.getByTestId("match-history-words-m1")).toHaveTextContent(
+      "7 words",
+    );
+    expect(screen.getByTestId("match-history-words-m2")).toHaveTextContent(
+      "2 words",
+    );
+  });
+
+  test("renders a Replay link (placeholder) per row", () => {
+    render(<ProfileMatchHistoryList matches={ROWS} />);
+    const replayLinks = screen.getAllByText(/Replay →/);
+    expect(replayLinks).toHaveLength(2);
+    replayLinks.forEach((el) =>
+      expect(el).toHaveAttribute("aria-disabled", "true"),
+    );
+  });
 });

--- a/tests/unit/components/profile/ProfilePage.test.tsx
+++ b/tests/unit/components/profile/ProfilePage.test.tsx
@@ -43,20 +43,28 @@ const PROFILE = {
 } as PlayerProfile;
 
 describe("ProfilePage", () => {
-  test("mounts sidebar + chart + cloud + matches", () => {
-    render(<ProfilePage profile={PROFILE} words={[]} matches={[]} />);
+  test("mounts sidebar + chart + cloud + matches inside panel cards", () => {
+    render(<ProfilePage profile={PROFILE} words={[]} matches={[]} isSelf />);
     expect(screen.getByTestId("profile-page")).toBeInTheDocument();
     expect(screen.getByTestId("stub-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-rating")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-words")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-history")).toBeInTheDocument();
     expect(screen.getByTestId("stub-chart")).toBeInTheDocument();
     expect(screen.getByTestId("stub-cloud")).toBeInTheDocument();
     expect(screen.getByTestId("stub-matches")).toBeInTheDocument();
   });
 
-  test("renders at-a-glance stats grid with win-rate percentage", () => {
-    render(<ProfilePage profile={PROFILE} words={[]} matches={[]} />);
-    expect(screen.getByText(/63%|62%/)).toBeInTheDocument(); // 5/8 = 62.5% rounds to 63
+  test("renders at-a-glance stats grid with combined W·L·D record", () => {
+    render(<ProfilePage profile={PROFILE} words={[]} matches={[]} isSelf />);
     expect(screen.getByText("9")).toBeInTheDocument(); // games played
-    expect(screen.getByText("5")).toBeInTheDocument(); // wins
+    expect(screen.getByText("5–3–1")).toBeInTheDocument(); // W·L·D
+    expect(screen.getByText(/63%|62%/)).toBeInTheDocument(); // 5/8 → 63%
     expect(screen.getByText("1250")).toBeInTheDocument(); // peak rating
+  });
+
+  test("renders 'At a glance' eyebrow label", () => {
+    render(<ProfilePage profile={PROFILE} words={[]} matches={[]} isSelf />);
+    expect(screen.getByText("At a glance")).toBeInTheDocument();
   });
 });

--- a/tests/unit/components/profile/ProfileSidebar.test.tsx
+++ b/tests/unit/components/profile/ProfileSidebar.test.tsx
@@ -4,14 +4,15 @@ import { describe, expect, test } from "vitest";
 import { ProfileSidebar } from "@/components/profile/ProfileSidebar";
 import type { PlayerProfile } from "@/lib/types/match";
 
-const SAMPLE: PlayerProfile = {
+const BASE: PlayerProfile = {
   identity: {
     id: "p1",
     username: "ari",
     displayName: "Ari",
     avatarUrl: null,
     status: "available",
-    lastSeenAt: "2025-09-01T00:00:00Z",
+    lastSeenAt: "2026-04-22T00:00:00Z",
+    createdAt: "2025-03-10T08:00:00Z",
     eloRating: 1234,
   },
   stats: {
@@ -29,22 +30,64 @@ const SAMPLE: PlayerProfile = {
   ratingHistory: [],
 };
 
-describe("ProfileSidebar", () => {
-  test("renders avatar, name, handle, and rating", () => {
-    render(<ProfileSidebar profile={SAMPLE} />);
+describe("ProfileSidebar (self)", () => {
+  test("renders avatar, eyebrow, display name, handle", () => {
+    render(<ProfileSidebar profile={BASE} isSelf />);
     expect(screen.getByTestId("profile-sidebar")).toBeInTheDocument();
+    expect(screen.getByText("Your profile")).toBeInTheDocument();
     expect(screen.getByText("Ari")).toBeInTheDocument();
+    expect(screen.getByText(/@ari · member since Mar 2025/)).toBeInTheDocument();
+  });
+
+  test("renders rating card with ELO", () => {
+    render(<ProfileSidebar profile={BASE} isSelf />);
+    expect(screen.getByTestId("rating-card")).toHaveTextContent("1,234");
+  });
+
+  test("omits `member since` when createdAt is missing", () => {
+    const profile: PlayerProfile = {
+      ...BASE,
+      identity: { ...BASE.identity, createdAt: undefined },
+    };
+    render(<ProfileSidebar profile={profile} isSelf />);
+    expect(screen.queryByText(/member since/i)).not.toBeInTheDocument();
     expect(screen.getByText(/@ari/)).toBeInTheDocument();
-    expect(screen.getByText("1234")).toBeInTheDocument();
   });
 
-  test("renders peak rating badge", () => {
-    render(<ProfileSidebar profile={SAMPLE} />);
-    expect(screen.getByText(/peak\s+1250/i)).toBeInTheDocument();
+  test("shows today's rating delta when history includes today", () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const profile: PlayerProfile = {
+      ...BASE,
+      ratingHistory: [
+        { recordedAt: "2026-04-10T12:00:00Z", rating: 1210 },
+        { recordedAt: `${today}T09:00:00Z`, rating: 1234 },
+      ],
+    };
+    render(<ProfileSidebar profile={profile} isSelf />);
+    expect(screen.getByTestId("today-delta")).toHaveTextContent("+24 TODAY");
   });
 
-  test("renders joined year from lastSeenAt", () => {
-    render(<ProfileSidebar profile={SAMPLE} />);
-    expect(screen.getByText(/joined\s+2025/i)).toBeInTheDocument();
+  test("hides today delta when no entries fall on today", () => {
+    render(<ProfileSidebar profile={BASE} isSelf />);
+    expect(screen.queryByTestId("today-delta")).not.toBeInTheDocument();
+  });
+
+  test("renders Play now + Edit profile CTAs", () => {
+    render(<ProfileSidebar profile={BASE} isSelf />);
+    const playNow = screen.getByTestId("play-now-cta");
+    expect(playNow).toHaveAttribute("href", "/matchmaking?mode=ranked");
+    expect(screen.getByRole("button", { name: /edit profile/i })).toBeDisabled();
+  });
+});
+
+describe("ProfileSidebar (other)", () => {
+  test("renders Player profile eyebrow and Challenge CTA", () => {
+    render(<ProfileSidebar profile={BASE} isSelf={false} />);
+    expect(screen.getByText("Player profile")).toBeInTheDocument();
+    const challenge = screen.getByTestId("challenge-cta");
+    expect(challenge).toHaveTextContent("Challenge @ari");
+    expect(challenge).toHaveAttribute("href", "/lobby");
+    expect(screen.queryByRole("button", { name: /edit profile/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("play-now-cta")).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/components/profile/ProfileWordCloud.test.tsx
+++ b/tests/unit/components/profile/ProfileWordCloud.test.tsx
@@ -44,4 +44,11 @@ describe("ProfileWordCloud", () => {
     expect(screen.getByText(/No scored words/i)).toBeInTheDocument();
     expect(screen.queryAllByTestId("word-cloud-item")).toHaveLength(0);
   });
+
+  test("renders a mono point-value subscript beside each word", () => {
+    render(<ProfileWordCloud words={[{ word: "KAFFI", points: 42 }]} />);
+    const item = screen.getByTestId("word-cloud-item");
+    expect(item.textContent).toContain("+42");
+    expect(item.querySelector("sub")).not.toBeNull();
+  });
 });

--- a/tests/unit/components/profile/deriveProfileChartData.test.ts
+++ b/tests/unit/components/profile/deriveProfileChartData.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveRecentRatingDelta,
+  deriveTodayRatingDelta,
+  sliceRatingHistoryWindow,
+} from "@/components/profile/deriveProfileChartData";
+import type { RatingHistoryEntry } from "@/lib/types/match";
+
+const NOW = new Date("2026-04-23T15:30:00Z");
+
+function entry(recordedAt: string, rating: number): RatingHistoryEntry {
+  return { recordedAt, rating };
+}
+
+describe("sliceRatingHistoryWindow", () => {
+  it("returns empty array when history is empty", () => {
+    expect(sliceRatingHistoryWindow([], 30, NOW)).toEqual([]);
+  });
+
+  it("keeps entries within the window", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-20T10:00:00Z", 1700),
+      entry("2026-04-22T12:00:00Z", 1710),
+      entry("2026-04-23T09:00:00Z", 1720),
+    ];
+    expect(sliceRatingHistoryWindow(history, 30, NOW)).toHaveLength(3);
+  });
+
+  it("filters out entries older than the window", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-03-01T10:00:00Z", 1600),
+      entry("2026-04-22T12:00:00Z", 1710),
+      entry("2026-04-23T09:00:00Z", 1720),
+    ];
+    expect(sliceRatingHistoryWindow(history, 30, NOW)).toHaveLength(2);
+  });
+
+  it("handles a 7-day window", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-10T10:00:00Z", 1600),
+      entry("2026-04-18T12:00:00Z", 1700),
+      entry("2026-04-23T09:00:00Z", 1720),
+    ];
+    expect(sliceRatingHistoryWindow(history, 7, NOW)).toHaveLength(2);
+  });
+});
+
+describe("deriveTodayRatingDelta", () => {
+  it("returns 0 for empty history", () => {
+    expect(deriveTodayRatingDelta([], NOW)).toBe(0);
+  });
+
+  it("returns 0 when no entries fall on today", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-21T12:00:00Z", 1700),
+      entry("2026-04-22T12:00:00Z", 1710),
+    ];
+    expect(deriveTodayRatingDelta(history, NOW)).toBe(0);
+  });
+
+  it("returns last-today minus last-before-today", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-22T12:00:00Z", 1700),
+      entry("2026-04-23T09:00:00Z", 1712),
+      entry("2026-04-23T14:00:00Z", 1724),
+    ];
+    expect(deriveTodayRatingDelta(history, NOW)).toBe(24);
+  });
+
+  it("returns a negative delta when rating dropped today", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-22T12:00:00Z", 1720),
+      entry("2026-04-23T09:00:00Z", 1700),
+    ];
+    expect(deriveTodayRatingDelta(history, NOW)).toBe(-20);
+  });
+
+  it("returns 0 when today's entry is the first ever rating", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-23T09:00:00Z", 1500),
+    ];
+    expect(deriveTodayRatingDelta(history, NOW)).toBe(0);
+  });
+
+  it("aggregates multiple entries on the same day", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-22T23:00:00Z", 1700),
+      entry("2026-04-23T01:00:00Z", 1705),
+      entry("2026-04-23T10:00:00Z", 1715),
+      entry("2026-04-23T14:00:00Z", 1720),
+    ];
+    expect(deriveTodayRatingDelta(history, NOW)).toBe(20);
+  });
+});
+
+describe("deriveRecentRatingDelta", () => {
+  it("returns 0 for empty history", () => {
+    expect(deriveRecentRatingDelta([], 7, NOW)).toBe(0);
+  });
+
+  it("returns 0 for a single entry with no prior baseline", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-23T09:00:00Z", 1500),
+    ];
+    expect(deriveRecentRatingDelta(history, 7, NOW)).toBe(0);
+  });
+
+  it("uses the last entry before the window as baseline", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-10T12:00:00Z", 1700),
+      entry("2026-04-18T12:00:00Z", 1710),
+      entry("2026-04-22T12:00:00Z", 1720),
+      entry("2026-04-23T09:00:00Z", 1724),
+    ];
+    // Window starts 7 days before NOW (2026-04-16T15:30Z). Baseline is the
+    // last entry before that boundary (index 0, rating 1700). Current is 1724.
+    expect(deriveRecentRatingDelta(history, 7, NOW)).toBe(24);
+  });
+
+  it("falls back to earliest in-window entry if no prior baseline exists", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-20T12:00:00Z", 1700),
+      entry("2026-04-23T09:00:00Z", 1724),
+    ];
+    expect(deriveRecentRatingDelta(history, 7, NOW)).toBe(24);
+  });
+
+  it("returns a negative delta when rating dropped", () => {
+    const history: RatingHistoryEntry[] = [
+      entry("2026-04-10T12:00:00Z", 1800),
+      entry("2026-04-23T09:00:00Z", 1770),
+    ];
+    expect(deriveRecentRatingDelta(history, 7, NOW)).toBe(-30);
+  });
+});


### PR DESCRIPTION
## Summary

Aligns `/profile` and `/profile/[handle]` with the Warm Editorial design prototype at `docs/design_documentation/260422-wottle-game-design/`. Visual refresh + minor data plumbing; no gameplay or server changes.

- **Sidebar** — 280px sticky column, XL avatar (180px), 42px Fraunces-italic display name, `member since {MMM YYYY}`, bordered rating card with today's ▲/▼ delta, and `◆ Play now` / `Edit profile` CTAs (self) or `Challenge @handle →` (other) driven by a new `isSelf` prop threaded from the two page entries.
- **Stats** — collapsed five separate tiles into a single bordered 4-cell frame with a combined W·L·D record (`ProfileStat` leaf + `.profile-stats-frame` utility).
- **Rating chart** — windowed to last 30 days, ochre-tint area fill, endpoint dot with paper stroke, wrapped in a panel card with a `+N this week` meta.
- **Best words** — wrapped in a panel card, adds mono `+{points}` subscript beside each word.
- **Recent matches** — wrapped in a panel card, adds `{wordsFound} words` column.
- **Data**: pure utilities `sliceRatingHistoryWindow`, `deriveTodayRatingDelta`, `deriveRecentRatingDelta` with full TDD coverage (14 new unit tests). `PlayerIdentity` gains optional `createdAt` sourced from `players.created_at`. `Avatar` gains an `xl` size. New `app/styles/profile.css` with `.profile-card`, `.profile-card__head`, `.profile-stats-frame`, `.profile-eyebrow`, `.profile-rating-card` utilities.

### Deliberately deferred (out of scope)
- Dark mode — whole-app theme flip, deserves its own spec.
- Real Edit profile — needs product decisions (editable fields, avatar upload). Ships as a disabled placeholder.
- Real Replay link — needs a match replay route. Ships as a visible `aria-disabled` affordance.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — zero warnings
- [x] `pnpm test:unit` — 1001 passing / 2 skipped (adds 14 new tests)
- [x] `pnpm exec playwright test profile-page.spec.ts` — 4/4 passing
- [x] `pnpm exec playwright test profile-modal.spec.ts` — 3/3 passing (Phase 5a untouched)
- [x] Visual spot-check against `docs/design_documentation/260422-wottle-game-design/project/Wottle Prototype.html` — confirmed by author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)