### PR TITLE
fix(match): suppress disconnect modal at match end + stop channel cascade

### DIFF
--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -104,6 +104,17 @@ export function MatchClient({
   const [disconnectedPlayerId, setDisconnectedPlayerId] = useState<
     string | null
   >(null);
+  /**
+   * Mirrors `disconnectedPlayerId` so the Realtime channel useEffect can read
+   * the current value without listing it in deps. Listing it caused the channel
+   * to be torn down + remounted on every flip; the teardown emits a presence
+   * "leave" to the opponent, who then fires `onOpponentLeave` and triggers
+   * a cascading round-trip flicker. See discussion under issue #161.
+   */
+  const disconnectedPlayerIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    disconnectedPlayerIdRef.current = disconnectedPlayerId;
+  }, [disconnectedPlayerId]);
   // Phase 6 — disconnection modal state. disconnectStartedAt anchors the 90s
   // countdown on the wall clock when the opponent first drops.
   const [disconnectStartedAt, setDisconnectStartedAt] = useState<number | null>(
@@ -366,7 +377,7 @@ export function MatchClient({
             snapshot.disconnectedPlayerId !== currentPlayerId,
           );
         } else if (
-          disconnectedPlayerId &&
+          disconnectedPlayerIdRef.current &&
           snapshot.disconnectedPlayerId === null
         ) {
           setIsReconnecting(false);
@@ -444,7 +455,6 @@ export function MatchClient({
     matchId,
     usePolling,
     currentPlayerId,
-    disconnectedPlayerId,
     applySnapshot,
     showRoundAnnounce,
     matchState.timers.playerA.playerId,
@@ -681,7 +691,21 @@ export function MatchClient({
   const opponentDisconnected =
     disconnectedPlayerId !== null &&
     disconnectedPlayerId === opponentTimer.playerId;
+  // Only count active play states. `pending`, `completed`, and `abandoned`
+  // must never trigger the disconnect modal — match-end navigation triggers
+  // a presence "leave" on the opponent's channel which would otherwise flash
+  // the modal during the 1-frame window before the completed snapshot
+  // commits (see follow-up to issue #161).
+  const isMatchActive =
+    matchState.state === "collecting" || matchState.state === "resolving";
   useEffect(() => {
+    if (!isMatchActive) {
+      // Drop any modal state we may have queued — once the match is past
+      // active play we never want to open the modal regardless of late
+      // disconnect signals.
+      if (disconnectStartedAt !== null) setDisconnectStartedAt(null);
+      return;
+    }
     if (opponentDisconnected && disconnectStartedAt === null) {
       setDisconnectStartedAt(Date.now());
       setShowDisconnectModal(true);
@@ -689,7 +713,7 @@ export function MatchClient({
       setDisconnectStartedAt(null);
       setShowDisconnectModal(true);
     }
-  }, [opponentDisconnected, disconnectStartedAt]);
+  }, [opponentDisconnected, disconnectStartedAt, isMatchActive]);
 
   const opponentSlot: "player_a" | "player_b" =
     playerSlot === "player_a" ? "player_b" : "player_a";
@@ -813,7 +837,7 @@ export function MatchClient({
       {opponentDisconnected &&
       showDisconnectModal &&
       disconnectStartedAt !== null &&
-      matchState.state !== "completed" ? (
+      isMatchActive ? (
         <DisconnectionModal
           opponentDisplayName={
             (opponentSlot === "player_a"

--- a/tests/unit/components/MatchClient.test.tsx
+++ b/tests/unit/components/MatchClient.test.tsx
@@ -728,6 +728,72 @@ describe("MatchClient round-recap flash (US1)", () => {
   });
 });
 
+// ─── DisconnectionModal end-of-match guard (issue #161 follow-up) ──────────
+
+describe("MatchClient disconnection modal guard", () => {
+  beforeEach(() => {
+    mockMatchCallbacks.onState = null;
+  });
+
+  test("does not render the disconnection modal when state is 'completed', even if a snapshot reports an opponent disconnect", async () => {
+    const { MatchClient } = await import("@/components/match/MatchClient");
+
+    await act(async () => {
+      render(
+        <MatchClient
+          initialState={createMatchState()}
+          currentPlayerId="player-1"
+          matchId="match-test-123"
+          playerProfiles={defaultProfiles}
+        />,
+      );
+    });
+
+    // Simulate the round-end race: a state snapshot arrives carrying both
+    // `state: "completed"` AND a non-null `disconnectedPlayerId`.
+    act(() => {
+      mockMatchCallbacks.onState!(
+        createMatchState({
+          state: "completed",
+          disconnectedPlayerId: "player-2",
+        }),
+      );
+    });
+
+    expect(
+      screen.queryByTestId("disconnection-modal"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("does not render the disconnection modal when state is 'pending'", async () => {
+    const { MatchClient } = await import("@/components/match/MatchClient");
+
+    await act(async () => {
+      render(
+        <MatchClient
+          initialState={createMatchState({ state: "pending" })}
+          currentPlayerId="player-1"
+          matchId="match-test-123"
+          playerProfiles={defaultProfiles}
+        />,
+      );
+    });
+
+    act(() => {
+      mockMatchCallbacks.onState!(
+        createMatchState({
+          state: "pending",
+          disconnectedPlayerId: "player-2",
+        }),
+      );
+    });
+
+    expect(
+      screen.queryByTestId("disconnection-modal"),
+    ).not.toBeInTheDocument();
+  });
+});
+
 // ─── MatchClient dual timeout tests (US4) ──────────────────────────────────
 
 describe("MatchClient dual timeout (US4)", () => {


### PR DESCRIPTION
## Summary
Two follow-ups to PR #163 (the #161 hotfix). After merging #163, a manual playtest revealed the disconnection modal still flashes briefly when one player makes their final move at round 10. This addresses the two mechanisms most likely responsible.

## Changes

### 1. Modal is gated on a positive `isMatchActive` check
Replace the negative `matchState.state !== "completed"` guard with the positive `state === "collecting" || state === "resolving"`. Same condition is now applied to the modal-opening effect so we never queue modal state once the match leaves active play.

This closes the end-of-match navigation race: when one client unmounts `MatchClient` first (`router.push` to summary), the cleanup calls `client.removeChannel(channel)` which emits a presence "leave" to the other subscriber. The other client's `onOpponentLeave` callback fires and sets `disconnectedPlayerId`. With the previous `!== "completed"` guard there was a 1-frame window where `opponentDisconnected === true` AND `matchState.state` had not yet committed `"completed"` — the modal rendered for ~1 paint. The positive check shuts the door on `pending`, `abandoned`, and `completed` from the opening side, not just the render side.

### 2. Stop the cascading channel re-subscribe
`disconnectedPlayerId` was previously listed in the Realtime channel useEffect deps. Every flip caused the cleanup to run `client.removeChannel(channel)` and the effect to remount a new channel. The teardown emitted a presence "leave" to the opponent's channel, who then fired `onOpponentLeave` and triggered a fresh disconnect record server-side — a round-trip ping-pong amplifying any single transient flicker.

The value is now read via a ref (`disconnectedPlayerIdRef`) inside the `onState` callback, and removed from the deps. The channel is created once per (matchId, currentPlayerId, polling-mode) tuple and survives disconnect-state changes.

## Tests
- 2 new regression tests in `tests/unit/components/MatchClient.test.tsx` confirming the modal stays hidden when a state snapshot reports an opponent disconnect alongside `state: "completed"` and `state: "pending"`.
- Full unit suite: 146 files, 969 passing, 2 skipped.
- `pnpm typecheck` clean.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:unit`
- [x] `pnpm exec eslint --max-warnings 0 components/match/MatchClient.tsx tests/unit/components/MatchClient.test.tsx`
- [ ] Manual playtest: complete a 10-round match end-to-end with two browsers; confirm the disconnection modal does not flash at round 10 final move or at end-of-match navigation.
- [ ] Manual playtest: kill one tab mid-match → opposite client still sees the modal (verifies the channel ref read still surfaces the disconnect signal).

## References
- #161 — original bug
- #163 — root-cause hotfix (removed the per-process heartbeat module); merged
- #164 — follow-up tracking the centralized-store safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)