### PR TITLE
fix(lobby): query matches.state=in_progress, not status=active

### DIFF
--- a/app/api/lobby/stats/matches-in-progress/route.ts
+++ b/app/api/lobby/stats/matches-in-progress/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
     const { count, error } = await supabase
       .from("matches")
       .select("id", { count: "exact", head: true })
-      .eq("status", "active");
+      .eq("state", "in_progress");
 
     if (error) {
       console.error("Failed to count matches-in-progress", error);

--- a/tests/unit/api/lobby-stats.test.ts
+++ b/tests/unit/api/lobby-stats.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 const getMock = vi.fn();
+const eqMock = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({
   getServiceRoleClient: () => ({
     from: () => ({
       select: () => ({
-        eq: (..._args: unknown[]) => getMock(),
+        eq: (column: string, value: unknown) => {
+          eqMock(column, value);
+          return getMock();
+        },
       }),
     }),
   }),
@@ -14,6 +18,7 @@ vi.mock("@/lib/supabase/server", () => ({
 
 afterEach(() => {
   getMock.mockReset();
+  eqMock.mockReset();
 });
 
 describe("GET /api/lobby/stats/matches-in-progress", () => {
@@ -27,6 +32,7 @@ describe("GET /api/lobby/stats/matches-in-progress", () => {
     const body = (await res.json()) as { matchesInProgress: number };
     expect(body.matchesInProgress).toBe(7);
     expect(res.headers.get("cache-control")).toContain("no-store");
+    expect(eqMock).toHaveBeenCalledWith("state", "in_progress");
   });
 
   test("returns 0 when Supabase count is null", async () => {


### PR DESCRIPTION
## Summary

- `/api/lobby/stats/matches-in-progress` was querying `.eq("status", "active")` on the `matches` table, but the schema uses column `state` with values `pending | in_progress | completed | abandoned` — there is no `status` column or `"active"` value. The route 500-ed on every poll (~every 10s in prod), spamming runtime logs and leaving the lobby stats strip perpetually stuck at `—`.
- Switched to `.eq("state", "in_progress")` so we count matches actually in flight.
- Tightened the existing unit test mock to capture `eq(column, value)` args and added an explicit assertion — the original mock ignored args, which is why this regression slipped into prod.

## Context

Found while investigating a separate `/profile` 500 (which is caused by the pending `20260422001_matches_completed_at.sql` migration not yet being applied to the production Supabase DB — tracked separately; this PR does not address it).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm exec eslint` clean on both touched files
- [x] `pnpm test:unit` green (992 passing, 2 skipped), including the new `eqMock` assertion
- [ ] After merge + deploy, confirm runtime logs no longer show the periodic `Failed to count matches-in-progress` 500s and the lobby stats strip shows a real count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)