### PR TITLE
feat(match): mirror opp HUD card so scores sit closest to centre (#171)

### DIFF
--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -827,3 +827,35 @@
   color: color-mix(in oklab, var(--warn) 80%, var(--ink));
   border-color: color-mix(in oklab, var(--warn) 50%, transparent);
 }
+
+.hud-card__avatar {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+/* ─── Symmetrical match HUD (issue #171) ─────────────────────────────
+   In the in-match top strip, mirror the opp card so the score sits
+   closest to centre and the player name + avatar to the outer edge.
+   Scoped to .match-layout__hud-strip so PostGameScoreboard (which
+   reuses .hud-card with flex-col) is unaffected. */
+.match-layout__hud-strip .hud-card--opp .hud-card__score {
+  order: 1;
+  margin-left: 0;
+}
+.match-layout__hud-strip .hud-card--opp .hud-card__clock {
+  order: 2;
+}
+.match-layout__hud-strip .hud-card--opp .hud-card__identity {
+  order: 3;
+  margin-left: auto;
+  align-items: flex-end;
+  text-align: right;
+}
+.match-layout__hud-strip .hud-card--opp .hud-card__avatar {
+  order: 4;
+}
+.match-layout__hud-strip .hud-card--opp::after {
+  left: auto;
+  right: 0;
+}

--- a/components/match/HudCard.tsx
+++ b/components/match/HudCard.tsx
@@ -35,7 +35,7 @@ export function HudCard({
 
   return (
     <div data-testid="hud-card" className={`hud-card ${slotClass}`}>
-      {avatar}
+      <div className="hud-card__avatar">{avatar}</div>
       <div className="hud-card__identity">
         <span className="hud-card__name" title={name}>
           {name}

--- a/tests/unit/components/match/HudCard.test.tsx
+++ b/tests/unit/components/match/HudCard.test.tsx
@@ -100,6 +100,23 @@ describe("HudCard", () => {
     );
   });
 
+  test("wraps the avatar in a .hud-card__avatar element so order/positioning rules can target it (issue #171)", () => {
+    render(
+      <HudCard
+        slot="opp"
+        avatar={<div data-testid="avatar-inner" />}
+        name="Opponent"
+        meta="m"
+        clock="0:00"
+        score={0}
+      />,
+    );
+    const avatarWrapper = screen
+      .getByTestId("avatar-inner")
+      .closest(".hud-card__avatar");
+    expect(avatarWrapper).not.toBeNull();
+  });
+
   test("renders children below identity block when provided", () => {
     render(
       <HudCard


### PR DESCRIPTION
Closes #171.

## Summary
The match HUD previously rendered both player cards with identical layouts (name + avatar on the left, clock + score on the right). With the opp card pushed to the right of the match-center chrome, the opp score ended up at the far-right edge of the screen — visually disconnected from the player score and harder to compare at a glance.

This PR mirrors the opp card so the visual order from left to right becomes:

```
[avatar  name | timer | spacer | score]   [center]   [score | spacer | timer | name  avatar]
└────── you card ──────────────────────┘             └────────────── opp card ──────────────┘
```

Scores now sit closest to the centre, timers next, names + avatars at the outer edges — matching the design in the issue.

## Implementation
- `components/match/HudCard.tsx`: wrap the `{avatar}` slot in a `<div className="hud-card__avatar">` so the layout has a stable selector for `order` rules.
- `app/styles/board.css`:
  - Add a `.hud-card__avatar` rule (transparent flex item).
  - Scoped under `.match-layout__hud-strip .hud-card--opp`:
    - Reorder children via `order` to score → clock → identity → avatar.
    - Move the auto-margin from `__score` to `__identity` so the gap appears between clock and identity, mirroring the player card.
    - Right-align identity text via `align-items: flex-end`.
    - Mirror the accent stripe (`::after`) to the right edge.
- `tests/unit/components/match/HudCard.test.tsx`: regression test asserting the avatar is wrapped in `.hud-card__avatar`.

Scoping under `.match-layout__hud-strip` keeps `PostGameScoreboard` (which reuses `.hud-card` with `flex-col`) untouched — those cards keep the existing left-stripe + column layout.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 147 files, 993 passing, 2 skipped
- [x] `pnpm exec eslint --max-warnings 0 components/match/HudCard.tsx`
- [x] **Manual** (requires two browser sessions): start a match, confirm the top HUD strip shows you-card on the left with score nearest centre, opp-card on the right with score nearest centre, and the player-colour accent stripes on the outer edges of each card.
- [x] **Manual** (post-game): visit `/match/[id]/summary` and confirm the post-game scoreboard is unchanged (still left-stripe, column layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)