### PR TITLE
fix(match): pull HUD timer next to the score on both cards (#171)

### DIFF
--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -788,7 +788,6 @@
 }
 
 .hud-card__score {
-  margin-left: auto;
   font-family: var(--font-fraunces), serif;
   font-style: italic;
   font-weight: 500;
@@ -798,6 +797,9 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* `margin-left: auto` lives on the clock so clock + score stay grouped at
+   the inner edge of the card (closest to centre). Originally on __score,
+   which left clock bunched with the name on the outer edge. See #171. */
 .hud-card__clock {
   font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
   font-size: 15px;
@@ -808,6 +810,7 @@
   background: var(--paper-2);
   border: 1px solid var(--hair);
   font-variant-numeric: tabular-nums;
+  margin-left: auto;
 }
 
 .hud-card__clock--active {
@@ -841,10 +844,13 @@
    reuses .hud-card with flex-col) is unaffected. */
 .match-layout__hud-strip .hud-card--opp .hud-card__score {
   order: 1;
-  margin-left: 0;
 }
+/* Clock's default `margin-left: auto` is wrong for opp — it would push
+   clock away from score and split the inner cluster. Reset to 0 so
+   score + clock stay glued together at the inner edge. */
 .match-layout__hud-strip .hud-card--opp .hud-card__clock {
   order: 2;
+  margin-left: 0;
 }
 .match-layout__hud-strip .hud-card--opp .hud-card__identity {
   order: 3;


### PR DESCRIPTION
Follow-up to PR #172. The first pass mirrored the opp card and pushed each card's score toward the centre, but left the timer bunched with the avatar + name on the outer edge — splitting the score and timer to opposite sides of the card. Per the user feedback on issue #171, the timer should sit immediately next to the score.

## Change
Move `margin-left: auto` from `.hud-card__score` to `.hud-card__clock`. The auto margin now lives on the leftmost element of the inner cluster (clock), so the free space lands between identity and clock — clock + score stay glued together at the inner (centre-side) edge.

For the mirrored opp layout, override clock back to `margin-left: 0` since the default auto margin would otherwise split the inner cluster apart; identity already carries the auto margin to push name + avatar to the outer edge.

## Result
```
[avatar  name |......| timer  score]   [center]   [score  timer |......| name  avatar]
└──────── you card ────────────────┘              └──────────── opp card ─────────────┘
```

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 147 files, 993 passing, 2 skipped
- [ ] **Manual** (two browser sessions): start a match, confirm both HUD cards show timer immediately next to score, with name + avatar at the outer edge and a single gap in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)