### PR TITLE
fix(lobby): log errors swallowed by top-players/recent-games catches

### DIFF
--- a/app/(lobby)/lobby/page.tsx
+++ b/app/(lobby)/lobby/page.tsx
@@ -25,9 +25,25 @@ export default async function LobbyPage() {
   const [initialPlayers, topPlayersResult, recentGamesResult] =
     await Promise.all([
       fetchLobbySnapshot(),
-      getTopPlayers({ limit: 6 }).catch(() => ({ players: [] })),
+      getTopPlayers({ limit: 6 }).catch((error) => {
+        console.error(
+          JSON.stringify({
+            event: "lobby.top_players.failed",
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+        return { players: [] };
+      }),
       getRecentGames({ playerId: session.player.id, limit: 6 }).catch(
-        () => ({ games: [] }),
+        (error) => {
+          console.error(
+            JSON.stringify({
+              event: "lobby.recent_games.failed",
+              error: error instanceof Error ? error.message : String(error),
+            }),
+          );
+          return { games: [] };
+        },
       ),
     ]);
 


### PR DESCRIPTION
## Summary

- Both `.catch(...)` handlers on `getTopPlayers` and `getRecentGames` in `app/(lobby)/lobby/page.tsx` silently returned empty data with no log.
- That silence is why #170 (empty Recent Games panel) went unnoticed for ~24h while `matches.completed_at` was missing from prod Supabase — the query threw on every lobby load, and zero entries appeared in runtime logs.
- Preserve the graceful-degradation shape (empty list on failure), but emit a structured `console.error` so the next time a dependency of these panels fails, it shows up in Vercel runtime logs instead of vanishing.

## Context

Followup to #169 and issue #170. The underlying data issue (pending migration `20260422001_matches_completed_at.sql`) has been pushed to prod. This PR is defense-in-depth so similar silent swallows don't hide the next incident.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm exec eslint` clean on the touched file
- [ ] After merge, provoke a transient failure (or wait for a real one) and confirm a `lobby.recent_games.failed` / `lobby.top_players.failed` event appears in Vercel runtime logs while the page still renders with empty panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)