### PR TITLE
test(match): explicit disconnect beacon to stabilize Phase 6 Playwright

### DIFF
--- a/tests/integration/ui/disconnect-modal.spec.ts
+++ b/tests/integration/ui/disconnect-modal.spec.ts
@@ -30,6 +30,21 @@ async function waitForMatch(page: Page) {
   await expect(page.getByTestId("board-grid")).toBeVisible({ timeout: 15_000 });
 }
 
+// Playwright's `ctxB.close()` force-kills the browser context, so the
+// `pagehide` → `sendBeacon` path wired in MatchClient doesn't reliably reach
+// the server. Production users hit `/api/match/:id/disconnect` via the beacon
+// on tab teardown; we replicate that explicitly here so the test isn't racing
+// the teardown.
+async function notifyServerOfDisconnect(page: Page) {
+  const match = page.url().match(/\/match\/([0-9a-f-]+)/);
+  if (!match) return;
+  const [, matchId] = match;
+  await page.evaluate(
+    (id) => fetch(`/api/match/${id}/disconnect`, { method: "POST", keepalive: true }),
+    matchId,
+  );
+}
+
 test.describe("@disconnect-modal Phase 6", () => {
   test("opponent disconnect shows modal with Claim win disabled during countdown", async ({
     browser,
@@ -49,6 +64,7 @@ test.describe("@disconnect-modal Phase 6", () => {
 
       // Player B disconnects — closing the context tears down the Realtime
       // channel, which the server observes and broadcasts.
+      await notifyServerOfDisconnect(b.page);
       await ctxB.close();
 
       // Modal should render on A within a few seconds.
@@ -80,6 +96,7 @@ test.describe("@disconnect-modal Phase 6", () => {
       });
       await Promise.all([waitForMatch(a.page), waitForMatch(b.page)]);
 
+      await notifyServerOfDisconnect(b.page);
       await ctxB.close();
 
       const modal = a.page.getByTestId("disconnection-modal");


### PR DESCRIPTION
## Summary
- `ctxB.close()` in Playwright force-kills the context before `pagehide` → `sendBeacon` lands, so with the heartbeat fallback removed in #161 A's disconnect modal never opens in CI (20s timeout).
- Call `/api/match/:id/disconnect` directly from B's page before closing the context — the same request `pagehide` would fire in production, just decoupled from teardown timing.

## Test plan
- [ ] CI Playwright `@disconnect-modal` tests pass (previously failing on `main`)
- [ ] Both tests still validate the existing intent: opponent drops → modal appears on survivor, Claim win disabled during countdown / Keep waiting dismisses

## Follow-up
- Shared-store heartbeat (Supabase row or KV) is still the proper fix for the network-drop safety net — tracked as the #161 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)