### PR TITLE
fix(match): show display names (not GUIDs) in in-game round history (#135)

### DIFF
--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -1115,8 +1115,8 @@ export function MatchClient({
             </div>
             <RoundHistoryPanel
               rounds={roundHistory}
-              playerAUsername={playerAId}
-              playerBUsername={playerBId}
+              playerAUsername={playerADisplayName}
+              playerBUsername={playerBDisplayName}
               scores={accumulatedScores}
               wordHistory={accumulatedWords}
               biggestSwing={biggestSwing}

--- a/tests/unit/components/MatchClient.test.tsx
+++ b/tests/unit/components/MatchClient.test.tsx
@@ -794,6 +794,57 @@ describe("MatchClient disconnection modal guard", () => {
   });
 });
 
+// ─── Round history display names (issue #135) ──────────────────────────────
+
+describe("MatchClient round history panel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockMatchCallbacks.onSummary = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("renders player display names (not GUIDs) in the round history popup (issue #135)", async () => {
+    const { MatchClient } = await import("@/components/match/MatchClient");
+
+    await act(async () => {
+      render(
+        <MatchClient
+          initialState={createMatchState()}
+          currentPlayerId="player-1"
+          matchId="match-test-123"
+          playerProfiles={defaultProfiles}
+        />,
+      );
+    });
+
+    // Populate accumulated round history via a summary broadcast.
+    act(() => {
+      mockMatchCallbacks.onSummary!(mockRoundSummary);
+    });
+
+    // Let the recap animation finish so the History button renders.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1300);
+    });
+
+    const historyButton = screen.getByTestId("hud-history-button");
+    await act(async () => {
+      fireEvent.click(historyButton);
+    });
+
+    const panel = screen.getByTestId("round-history-panel");
+    // Display names should appear; raw player GUIDs should not.
+    expect(panel.textContent).toContain("Alice");
+    expect(panel.textContent).toContain("Bob");
+    expect(panel.textContent).not.toContain("player-1");
+    expect(panel.textContent).not.toContain("player-2");
+  });
+});
+
 // ─── MatchClient dual timeout tests (US4) ──────────────────────────────────
 
 describe("MatchClient dual timeout (US4)", () => {


### PR DESCRIPTION
Closes #135.

## Problem
The round-history popup rendered via the "History (N)" button in the match HUD showed raw player UUIDs instead of display names. In `MatchClient.tsx`, `playerAId` / `playerBId` (player UUIDs from `matchState.timers`) were being passed to `RoundHistoryPanel`'s `playerAUsername` / `playerBUsername` props. The `playerADisplayName` / `playerBDisplayName` values derived from `playerProfiles` were already in scope but unused at this render site.

## Fix
Swap to `playerADisplayName` / `playerBDisplayName`. The post-game `FinalSummary` render path was already passing display names correctly — only the in-game popup had the bug.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 147 files, 994 passing, 2 skipped, includes a new regression test that opens the history popup and asserts the panel contains `"Alice"` / `"Bob"` and does **not** contain the raw `"player-1"` / `"player-2"` ids
- [x] `pnpm exec eslint --max-warnings 0 components/match/MatchClient.tsx tests/unit/components/MatchClient.test.tsx`
- [ ] **Manual**: play a few rounds, click the History button, confirm each round row shows display names and expanded word sections are grouped under display names (not GUIDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)