### PR TITLE
fix(match): stop duplicate word scoring on concurrent round resolution (#177)

### DIFF
--- a/app/actions/match/publishRoundSummary.ts
+++ b/app/actions/match/publishRoundSummary.ts
@@ -405,7 +405,22 @@ async function executeScoringPipeline(
         return { wordScores: [], finalBoard: result.finalBoard };
     }
 
-    // Persist word scores to word_score_entries table
+    // Persist word scores to word_score_entries table.
+    // Delete any existing rows for this round first so retries (and any
+    // stray concurrent caller that slipped past the rounds-state CAS) stay
+    // idempotent — `word_score_entries` has no UNIQUE constraint, so a bare
+    // INSERT would stack duplicate rows and double the round delta (#177).
+    const { error: deleteError } = await supabase
+        .from("word_score_entries")
+        .delete()
+        .eq("round_id", roundId);
+
+    if (deleteError) {
+        throw new Error(
+            `Failed to clear prior word scores: ${deleteError.message}`,
+        );
+    }
+
     const entries = allBreakdowns.map((bd) => ({
         match_id: matchId,
         round_id: roundId,

--- a/lib/match/roundEngine.ts
+++ b/lib/match/roundEngine.ts
@@ -239,21 +239,32 @@ export async function advanceRound(matchId: string) {
     }
 
     // 9.5. Mark round as resolving immediately after board computation, before word scoring.
-    // This shrinks the window where both clocks appear "paused" (stateLoader sees
-    // collecting + both submissions) to < 10ms. Also acts as a write-lock against
-    // concurrent advanceRound() calls on the same round.
+    // Uses a conditional (compare-and-swap) update on `state = 'collecting'`
+    // to serialize concurrent advanceRound() callers — both players submitting
+    // near-simultaneously queue two `after()` advanceRound() hooks, and without
+    // the CAS both pass the `state === 'collecting'` check at step 3 and both
+    // run the scoring pipeline, producing duplicate word_score_entries rows
+    // (issue #177).
     // Note: board_snapshot_after is set AFTER word scoring (step 9c) to reflect
     // the word engine's final board state, which may differ from boardAfter if
     // the word engine rejects swaps that touch tiles frozen earlier in the round.
-    const { error: updateRoundError } = await supabase
+    const { data: resolvingRows, error: updateRoundError } = await supabase
         .from("rounds")
         .update({
             state: "resolving",
             resolution_started_at: new Date().toISOString(),
         })
-        .eq("id", round.id);
+        .eq("id", round.id)
+        .eq("state", "collecting")
+        .select("id");
 
     if (updateRoundError) throw new Error("Failed to update round state");
+
+    // CAS lost: another advanceRound() call already transitioned this round.
+    // Exit cleanly — the winning caller will finish scoring and advance.
+    if (!resolvingRows || resolvingRows.length === 0) {
+        return { status: "not_advancing", reason: "Round already being resolved" };
+    }
 
     // 9b. Compute word scores from the board delta
     let scoringFinalBoard = boardAfter;

--- a/tests/unit/lib/match/roundEngine.test.ts
+++ b/tests/unit/lib/match/roundEngine.test.ts
@@ -134,10 +134,26 @@ describe("roundEngine.advanceRound", () => {
 
         moveSubmissionsInsert = vi.fn().mockResolvedValue({ error: null });
 
-        const roundsUpdateEq = vi.fn().mockResolvedValue({ error: null });
+        // Rounds update supports both shapes:
+        //  - `.update(x).eq('id', X)` (awaited directly)  — steps 9c, 11
+        //  - `.update(x).eq('id', X).eq('state', 'collecting').select('id')`
+        //    — step 9.5 CAS lock (returns { data: [...], error }).
+        // The chain is both thenable (for the non-CAS path) and has `.eq`
+        // returning itself + `.select` returning a resolved CAS result.
+        const makeRoundsUpdateChain = () => {
+            const chain: Record<string, unknown> = {};
+            chain.eq = vi.fn().mockImplementation(() => chain);
+            chain.select = vi
+                .fn()
+                .mockResolvedValue({ data: [{ id: "round-1" }], error: null });
+            (chain as { then: unknown }).then = (
+                onFulfilled: (v: { error: null }) => unknown,
+            ) => Promise.resolve({ error: null }).then(onFulfilled);
+            return chain;
+        };
         const roundsUpdate = vi.fn((payload) => {
             updateCalls.push({ table: "rounds", payload });
-            return { eq: roundsUpdateEq };
+            return makeRoundsUpdateChain();
         });
 
         roundsInsert = vi.fn().mockResolvedValue({ error: null });
@@ -907,5 +923,79 @@ describe("roundEngine.advanceRound", () => {
         expect(timerUpdate.payload.player_a_timer_ms).toBe(270_000);
         // player-b took 45s → 300000 - 45000 = 255000
         expect(timerUpdate.payload.player_b_timer_ms).toBe(255_000);
+    });
+
+    // Regression for issue #177: two concurrent advanceRound() callers (e.g.
+    // both players' `after()` hooks firing in parallel) would both pass the
+    // step 3 `round.state === 'collecting'` gate and both run the scoring
+    // pipeline, producing duplicate word_score_entries rows and doubled
+    // deltas. The fix makes step 9.5 a compare-and-swap on the rounds row;
+    // the loser of the CAS must exit cleanly before scoring.
+    it("exits cleanly when another caller already transitioned the round to resolving", async () => {
+        const { advanceRound } = await import("@/lib/match/roundEngine");
+        const { computeWordScoresForRound } = await import(
+            "@/app/actions/match/publishRoundSummary"
+        );
+
+        setupSupabase([
+            {
+                id: "sub-a",
+                player_id: "player-a",
+                from_x: 0,
+                from_y: 0,
+                to_x: 0,
+                to_y: 1,
+                submitted_at: "2025-01-01T00:00:00Z",
+                status: "pending",
+            },
+            {
+                id: "sub-b",
+                player_id: "player-b",
+                from_x: 5,
+                from_y: 5,
+                to_x: 5,
+                to_y: 6,
+                submitted_at: "2025-01-01T00:00:01Z",
+                status: "pending",
+            },
+        ]);
+
+        // Override the rounds `update` to simulate the CAS losing — no row
+        // matched because a concurrent caller already flipped state away
+        // from 'collecting'.
+        const client = getServiceRoleClient();
+        const originalFrom = (client as { from: (t: string) => unknown }).from;
+        (client as { from: (t: string) => unknown }).from = vi.fn(
+            (table: string) => {
+                const base = (originalFrom as (t: string) => unknown)(table);
+                if (table !== "rounds") return base;
+                return {
+                    ...(base as object),
+                    update: vi.fn(() => {
+                        const chain: Record<string, unknown> = {};
+                        chain.eq = vi.fn().mockImplementation(() => chain);
+                        chain.select = vi
+                            .fn()
+                            .mockResolvedValue({ data: [], error: null });
+                        (chain as { then: unknown }).then = (
+                            onFulfilled: (v: { error: null }) => unknown,
+                        ) => Promise.resolve({ error: null }).then(onFulfilled);
+                        return chain;
+                    }),
+                };
+            },
+        );
+
+        const computeSpy = vi.mocked(computeWordScoresForRound);
+        computeSpy.mockClear();
+
+        const result = await advanceRound("match-1");
+
+        expect(result).toEqual({
+            status: "not_advancing",
+            reason: "Round already being resolved",
+        });
+        // Critical: scoring pipeline must NOT run when CAS is lost.
+        expect(computeSpy).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
Fixes #177 — the same word was being scored (and shown in round history) twice, with doubled round deltas.

Two independent bugs both stack duplicate rows into `word_score_entries` (which has no UNIQUE constraint):

1. **Race in `advanceRound()`.** When both players submit near-simultaneously, each `submitMove` schedules an `after()` hook that calls `advanceRound(matchId)`. Both callers pass the step 3 `round.state === 'collecting'` gate and both reach step 9.5 — the comment there claimed the unconditional `UPDATE rounds SET state = 'resolving'` was a write-lock, but it isn't; both callers run the scoring pipeline and INSERT the same rows.
   - **Fix:** step 9.5 is now a CAS (`.eq("state", "collecting").select("id")`) and the caller that gets 0 rows back exits cleanly before scoring runs.
2. **Retry non-idempotency.** `executeScoringPipeline` is wrapped in `withRetry` (up to 3 attempts). If the INSERT succeeds but `persistFrozenTilesAtomically` subsequently throws, the retry re-INSERTs the same rows.
   - **Fix:** DELETE existing `word_score_entries` for the round before INSERT, making the pipeline idempotent regardless of retry depth.

## Test plan
- [x] `pnpm test` — 147 files, 995 tests passing
- [x] New regression unit test in `roundEngine.test.ts` forces the CAS to return 0 rows and asserts `computeWordScoresForRound` is NOT called (exits cleanly).
- [ ] CI Playwright suite passes.

## Notes
No migration needed — both fixes are application-level. A follow-up to add a UNIQUE constraint on `word_score_entries(round_id, player_id, word, tiles)` would be a belt-and-braces layer but requires a text/hash key since `tiles` is JSONB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)