### PR TITLE
fix(match): seed next-round board from word engine's finalBoard (#130)

### DIFF
--- a/lib/match/roundEngine.ts
+++ b/lib/match/roundEngine.ts
@@ -340,7 +340,16 @@ export async function advanceRound(matchId: string) {
     const bothTimersExhausted = newPlayerATimerMs === 0 && newPlayerBTimerMs === 0;
     const isGameOver = nextRound > 10 || bothTimersExhausted;
 
-    // 13. Create next round if not game over
+    // 13. Create next round if not game over.
+    //
+    // Use the word engine's `scoringFinalBoard` as the next round's starting
+    // snapshot — NOT the raw `boardAfter`. They diverge whenever a same-round
+    // move is rejected mid-pipeline because an earlier player's word froze
+    // tiles the later move would have touched. `boardAfter` applies every
+    // accepted swap blindly; `scoringFinalBoard` reflects the word engine's
+    // freeze-aware final state, which is also what we persist to round N's
+    // `board_snapshot_after`. Using `boardAfter` here would leave round N+1
+    // showing letters from a swap that "didn't actually happen" — see #130.
     if (!isGameOver) {
         const { error: nextRoundError } = await supabase
             .from("rounds")
@@ -348,7 +357,7 @@ export async function advanceRound(matchId: string) {
                 match_id: matchId,
                 round_number: nextRound,
                 state: "collecting",
-                board_snapshot_before: boardAfter,
+                board_snapshot_before: scoringFinalBoard,
                 started_at: new Date().toISOString(),
             });
 

--- a/tests/unit/lib/match/roundEngine.test.ts
+++ b/tests/unit/lib/match/roundEngine.test.ts
@@ -266,6 +266,59 @@ describe("roundEngine.advanceRound", () => {
         );
     });
 
+    it("seeds the next round with the word engine's finalBoard, not the raw post-swap board (issue #130)", async () => {
+        // Regression test for #130: when a same-round move is rejected by the
+        // word engine because an earlier move's word froze tiles it would have
+        // touched, the next round's `board_snapshot_before` must reflect the
+        // freeze-aware finalBoard — NOT the raw `boardAfter` produced by
+        // sequentially applying every accepted move. Using `boardAfter` would
+        // leave the next round showing letters from a swap that was effectively
+        // dropped, producing the visual "I scored ÝÚP" confusion.
+        const { computeWordScoresForRound } = await import(
+            "@/app/actions/match/publishRoundSummary"
+        );
+        // A distinctive marker board the test can recognise — every cell "Z".
+        const markerFinalBoard = Array.from({ length: 10 }, () =>
+            Array.from({ length: 10 }, () => "Z"),
+        );
+        vi.mocked(computeWordScoresForRound).mockResolvedValueOnce({
+            wordScores: [],
+            finalBoard: markerFinalBoard,
+        });
+
+        setupSupabase([
+            {
+                id: "sub-a",
+                player_id: "player-a",
+                from_x: 0,
+                from_y: 0,
+                to_x: 0,
+                to_y: 1,
+                submitted_at: "2025-01-01T00:00:00Z",
+                status: "pending",
+            },
+            {
+                id: "sub-b",
+                player_id: "player-b",
+                from_x: 5,
+                from_y: 5,
+                to_x: 5,
+                to_y: 6,
+                submitted_at: "2025-01-01T00:00:01Z",
+                status: "pending",
+            },
+        ]);
+
+        await advanceRound("match-1");
+
+        expect(roundsInsert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                round_number: 2,
+                board_snapshot_before: markerFinalBoard,
+            }),
+        );
+    });
+
     it("marks conflicting submissions as rejected_invalid", async () => {
         const sharedMove = {
             from_x: 0,


### PR DESCRIPTION
Closes #130.

## Bug
When two same-round moves both touch a region where the first scoring move freezes tiles, the word engine correctly rejects the later swap and reports a freeze-aware \`finalBoard\`. \`roundEngine.ts\` uses that board to write round N's \`board_snapshot_after\` ✓ — but writes round N+1's \`board_snapshot_before\` from a *different* value (\`boardAfter\`), the raw sequential \`applySwap\` of every accepted move that does **not** know about mid-round freezes.

When those values diverge, round N+1 starts on a board that contradicts what round N's scoring was based on.

## Repro (user-reported)
- Player A swaps to form **SÚP**, locks tiles \`(0,0)/(1,0)/(2,0)\`.
- Player B's swap target is \`(0,0)\` → word engine drops it → \`scoringFinalBoard\` reads **SÚP** ✓.
- But round N+1 is seeded from \`boardAfter\` = **ÝÚP** (B's "applied" swap) → next round shows **ÝÚP** where the user just scored SÚP → user concludes "I scored an invalid word."

Frozen-tile metadata also drifts: \`(0,0)\` is frozen as 'S' but the rendered letter is 'Ý'.

## Fix
One line in \`lib/match/roundEngine.ts\`:

\`\`\`diff
-                board_snapshot_before: boardAfter,
+                board_snapshot_before: scoringFinalBoard,
\`\`\`

\`scoringFinalBoard\` is already the word engine's authoritative final state — the same value persisted as round N's \`board_snapshot_after\` in step 9c. Using it for round N+1's snapshot keeps the two consistent.

## Tests
- Adds a regression test in \`tests/unit/lib/match/roundEngine.test.ts\` that mocks \`computeWordScoresForRound\` to return a distinctive marker \`finalBoard\` and asserts \`rounds.insert\` is called with \`board_snapshot_before\` equal to that marker.
- Full unit suite: 147 files, 996 passing, 2 skipped.
- \`pnpm typecheck\` clean. \`pnpm exec eslint --max-warnings 0\` clean.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test:unit\`
- [x] \`pnpm exec eslint --max-warnings 0 lib/match/roundEngine.ts tests/unit/lib/match/roundEngine.test.ts\`
- [x] **Manual** (two browsers): reproduce the scenario — both players submit non-conflicting swaps where the second swap's destination would have landed on a tile frozen by the first player's word. Confirm the next round's board reflects the freeze (no "ghost" overwrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)