### PR TITLE
fix(match): make warning + error banners legible on light theme

### DIFF
--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -827,7 +827,7 @@ export function MatchClient({
     <MatchShell matchId={matchId}>
       {isReconnecting && disconnectedPlayerId === currentPlayerId && (
         <div
-          className="mt-4 rounded-2xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200"
+          className="mt-4 rounded-2xl border border-warn/50 bg-warn/20 p-4 text-sm text-[color-mix(in_oklab,var(--warn)_80%,var(--ink))]"
           data-testid="reconnect-banner"
         >
           Reconnecting... Please wait.
@@ -855,7 +855,7 @@ export function MatchClient({
 
       {usePolling && !isReconnecting && (
         <div
-          className="mt-4 rounded-2xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200"
+          className="mt-4 rounded-2xl border border-warn/50 bg-warn/20 p-4 text-sm text-[color-mix(in_oklab,var(--warn)_80%,var(--ink))]"
           data-testid="polling-fallback-banner"
         >
           Realtime connection lost. Falling back to polling updates.
@@ -864,7 +864,7 @@ export function MatchClient({
 
       {dualTimeoutDetected && matchState.state !== "completed" && (
         <div
-          className="mt-4 rounded-2xl border border-red-500/40 bg-red-500/10 p-4 text-center text-sm font-semibold text-red-200"
+          className="mt-4 rounded-2xl border border-bad/50 bg-bad/10 p-4 text-center text-sm font-semibold text-bad"
           data-testid="dual-timeout-overlay"
         >
           Both players timed out
@@ -873,7 +873,7 @@ export function MatchClient({
 
       {(pollError || swapError) && (
         <div
-          className="mt-2 rounded-xl border border-red-500/50 bg-red-500/10 px-4 py-2 text-sm text-red-200"
+          className="mt-2 rounded-xl border border-bad/50 bg-bad/10 px-4 py-2 text-sm text-bad"
           data-testid="round-alert"
         >
           {swapError ?? pollError}


### PR DESCRIPTION
## Summary
- Round-top banners (reconnect, polling fallback, dual timeout, round alert) were rendering pale amber-200 / red-200 text on pale amber/red tints — unreadable after the light-mode theme flip.
- Swapped to the Warm Editorial semantic tokens (\`warn\` / \`bad\`) already used by \`Toast\` and \`Badge\`, so contrast matches the rest of the app.

Closes #165

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm exec eslint components/match/MatchClient.tsx --max-warnings 0\`
- [x] \`pnpm test:unit\` (147 files, 996 passed)
- [ ] Manual: trigger \`usePolling\` fallback in dev, confirm the banner text is readable on the light paper background
- [ ] Manual: trigger a round-alert / dual-timeout state, confirm red banner text is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)