### PR TITLE
feat(postgame): cumulative round-by-round chart with delta overlay (#173)

### DIFF
--- a/components/match/RoundByRoundChart.tsx
+++ b/components/match/RoundByRoundChart.tsx
@@ -10,11 +10,11 @@ interface RoundByRoundChartProps {
 const DEFAULT_MAX_HEIGHT = 120;
 const LABEL_MIN_BAR_PX = 14;
 
-function maxAbsDelta(rounds: ScoreboardRow[]): number {
+function maxCumulativeScore(rounds: ScoreboardRow[]): number {
   let m = 0;
   for (const r of rounds) {
-    if (Math.abs(r.playerADelta) > m) m = Math.abs(r.playerADelta);
-    if (Math.abs(r.playerBDelta) > m) m = Math.abs(r.playerBDelta);
+    if (r.playerAScore > m) m = r.playerAScore;
+    if (r.playerBScore > m) m = r.playerBScore;
   }
   return m;
 }
@@ -23,9 +23,9 @@ export function RoundByRoundChart({
   rounds,
   maxHeightPx = DEFAULT_MAX_HEIGHT,
 }: RoundByRoundChartProps) {
-  const scale = maxAbsDelta(rounds);
-  const toHeight = (delta: number): number =>
-    scale === 0 ? 0 : Math.round((Math.abs(delta) / scale) * maxHeightPx);
+  const scale = maxCumulativeScore(rounds);
+  const toHeight = (value: number): number =>
+    scale === 0 ? 0 : Math.round((Math.max(0, value) / scale) * maxHeightPx);
 
   return (
     <div
@@ -41,8 +41,10 @@ export function RoundByRoundChart({
           style={{ top: `${maxHeightPx}px` }}
         />
         {rounds.map((row) => {
-          const aH = toHeight(row.playerADelta);
-          const bH = toHeight(row.playerBDelta);
+          const aTotal = toHeight(row.playerAScore);
+          const aDelta = toHeight(row.playerADelta);
+          const bTotal = toHeight(row.playerBScore);
+          const bDelta = toHeight(row.playerBDelta);
           return (
             <div
               key={row.roundNumber}
@@ -56,13 +58,22 @@ export function RoundByRoundChart({
                 <div
                   data-testid="round-chart-bar--a"
                   data-delta={row.playerADelta}
-                  className="relative w-full rounded-t bg-p1"
-                  style={{ height: `${aH}px` }}
+                  data-score={row.playerAScore}
+                  className="relative w-full rounded-t bg-p1-deep"
+                  style={{ height: `${aTotal}px` }}
                 >
-                  {row.playerADelta > 0 && aH >= LABEL_MIN_BAR_PX ? (
-                    <span className="absolute inset-x-0 top-0.5 text-center font-mono text-[9px] leading-none text-white/90">
-                      {row.playerADelta}
-                    </span>
+                  {row.playerADelta > 0 ? (
+                    <div
+                      data-testid="round-chart-bar--a-delta"
+                      className="absolute inset-x-0 top-0 rounded-t bg-p1"
+                      style={{ height: `${aDelta}px` }}
+                    >
+                      {aDelta >= LABEL_MIN_BAR_PX ? (
+                        <span className="absolute inset-x-0 top-0.5 text-center font-mono text-[9px] leading-none text-white/90">
+                          {row.playerADelta}
+                        </span>
+                      ) : null}
+                    </div>
                   ) : null}
                 </div>
               </div>
@@ -73,13 +84,22 @@ export function RoundByRoundChart({
                 <div
                   data-testid="round-chart-bar--b"
                   data-delta={row.playerBDelta}
-                  className="relative w-full rounded-b bg-p2 opacity-70"
-                  style={{ height: `${bH}px` }}
+                  data-score={row.playerBScore}
+                  className="relative w-full rounded-b bg-p2-deep opacity-70"
+                  style={{ height: `${bTotal}px` }}
                 >
-                  {row.playerBDelta > 0 && bH >= LABEL_MIN_BAR_PX ? (
-                    <span className="absolute inset-x-0 bottom-0.5 text-center font-mono text-[9px] leading-none text-white/90">
-                      {row.playerBDelta}
-                    </span>
+                  {row.playerBDelta > 0 ? (
+                    <div
+                      data-testid="round-chart-bar--b-delta"
+                      className="absolute inset-x-0 bottom-0 rounded-b bg-p2"
+                      style={{ height: `${bDelta}px` }}
+                    >
+                      {bDelta >= LABEL_MIN_BAR_PX ? (
+                        <span className="absolute inset-x-0 bottom-0.5 text-center font-mono text-[9px] leading-none text-white/90">
+                          {row.playerBDelta}
+                        </span>
+                      ) : null}
+                    </div>
                   ) : null}
                 </div>
               </div>

--- a/tests/unit/components/match/RoundByRoundChart.test.tsx
+++ b/tests/unit/components/match/RoundByRoundChart.test.tsx
@@ -24,31 +24,53 @@ describe("RoundByRoundChart", () => {
     expect(within(cols[2]).getByText("R3")).toBeInTheDocument();
   });
 
-  test("scales bar heights relative to maxAbsDelta", () => {
+  test("bar heights encode cumulative score and grow monotonically left-to-right", () => {
     render(<RoundByRoundChart rounds={sampleRounds} maxHeightPx={100} />);
-    const bar = screen.getAllByTestId("round-chart-bar--a")[0];
-    expect(Number(bar.style.height.replace("px", ""))).toBeGreaterThan(75);
-    expect(Number(bar.style.height.replace("px", ""))).toBeLessThan(82);
+    const bars = screen.getAllByTestId("round-chart-bar--a");
+    const heights = bars.map((b) => Number(b.style.height.replace("px", "")));
+    // Scale = max cumulative score across both players = 50 (player B, round 3).
+    // Player A cumulative scores: 22, 31, 43 → heights 44, 62, 86 at maxHeightPx=100.
+    expect(heights[0]).toBe(44);
+    expect(heights[1]).toBe(62);
+    expect(heights[2]).toBe(86);
+    expect(heights[0]).toBeLessThan(heights[1]);
+    expect(heights[1]).toBeLessThan(heights[2]);
   });
 
-  test("records deltas via data attributes for inspection", () => {
+  test("stacks a delta overlay on top of each bar sized by the round delta", () => {
+    render(<RoundByRoundChart rounds={sampleRounds} maxHeightPx={100} />);
+    const deltaOverlays = screen.getAllByTestId("round-chart-bar--a-delta");
+    const heights = deltaOverlays.map((d) => Number(d.style.height.replace("px", "")));
+    // Scale = 50. Deltas 22, 9, 12 → 44, 18, 24.
+    expect(heights).toEqual([44, 18, 24]);
+  });
+
+  test("records delta and cumulative score via data attributes for inspection", () => {
     render(<RoundByRoundChart rounds={sampleRounds} />);
     const firstA = screen.getAllByTestId("round-chart-bar--a")[0];
     const firstB = screen.getAllByTestId("round-chart-bar--b")[0];
     expect(firstA.dataset.delta).toBe("22");
+    expect(firstA.dataset.score).toBe("22");
     expect(firstB.dataset.delta).toBe("15");
+    expect(firstB.dataset.score).toBe("15");
   });
 
-  test("zero-delta round renders with height 0", () => {
+  test("zero-delta round still shows the cumulative base bar without a delta overlay", () => {
     render(
       <RoundByRoundChart
         rounds={[
-          { roundNumber: 1, playerAScore: 0, playerBScore: 10, playerADelta: 0, playerBDelta: 10 },
+          { roundNumber: 1, playerAScore: 22, playerBScore: 15, playerADelta: 22, playerBDelta: 15 },
+          { roundNumber: 2, playerAScore: 22, playerBScore: 33, playerADelta: 0, playerBDelta: 18 },
         ]}
+        maxHeightPx={100}
       />,
     );
-    const a = screen.getAllByTestId("round-chart-bar--a")[0];
-    expect(a.style.height).toBe("0px");
+    const secondA = screen.getAllByTestId("round-chart-bar--a")[1];
+    // Cumulative still 22 → scale 33 → height 67.
+    expect(Number(secondA.style.height.replace("px", ""))).toBe(67);
+    const deltaOverlays = screen.queryAllByTestId("round-chart-bar--a-delta");
+    // Only round 1 has a delta overlay for player A; round 2 has playerADelta = 0.
+    expect(deltaOverlays).toHaveLength(1);
   });
 
   test("renders a zero baseline at maxHeightPx from the top of the bar area", () => {
@@ -57,23 +79,23 @@ describe("RoundByRoundChart", () => {
     expect(zero.style.top).toBe("140px");
   });
 
-  test("renders the delta as a label inside each non-zero bar", () => {
+  test("renders the delta as a label inside the shaded top overlay", () => {
     render(<RoundByRoundChart rounds={sampleRounds} />);
-    const firstA = screen.getAllByTestId("round-chart-bar--a")[0];
-    const firstB = screen.getAllByTestId("round-chart-bar--b")[0];
-    expect(within(firstA).getByText("22")).toBeInTheDocument();
-    expect(within(firstB).getByText("15")).toBeInTheDocument();
+    const firstADelta = screen.getAllByTestId("round-chart-bar--a-delta")[0];
+    const firstBDelta = screen.getAllByTestId("round-chart-bar--b-delta")[0];
+    expect(within(firstADelta).getByText("22")).toBeInTheDocument();
+    expect(within(firstBDelta).getByText("15")).toBeInTheDocument();
   });
 
-  test("omits the delta label when the delta is zero", () => {
+  test("omits the delta overlay when the delta is zero", () => {
     render(
       <RoundByRoundChart
         rounds={[
-          { roundNumber: 1, playerAScore: 0, playerBScore: 10, playerADelta: 0, playerBDelta: 10 },
+          { roundNumber: 1, playerAScore: 10, playerBScore: 10, playerADelta: 0, playerBDelta: 10 },
         ]}
       />,
     );
-    const barA = screen.getAllByTestId("round-chart-bar--a")[0];
-    expect(within(barA).queryByText("0")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("round-chart-bar--a-delta")).not.toBeInTheDocument();
+    expect(screen.getByTestId("round-chart-bar--b-delta")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Closes #173.

The post-game round-by-round bar chart now encodes **cumulative** score after each round (bars grow left-to-right), with the round's delta stacked on top as a differently-shaded overlay.

### Before
Each bar's height = that round's delta. Adjacent rounds looked flat regardless of score momentum, and the visual didn't match how players think about score progression.

### After
- **Base bar** — height = cumulative score after the round, shaded with `bg-p{1,2}-deep`.
- **Delta overlay** — anchored to the top of the bar, height = the round's delta, shaded with `bg-p{1,2}` (brighter).
- **Label** — the delta value still renders in light text inside the overlay.
- Scale is driven by max cumulative score across both players, so end-of-match columns fill the chart.
- Bars now carry both `data-delta` and `data-score` for inspection/tests.

## Test plan
- [x] `pnpm test` — 9 chart unit tests updated/added, all passing.
- [x] Typecheck + lint clean on touched files.
- [ ] Visual spot-check in `/match/[id]/summary` after merge (chart contained in `FinalSummary`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)