### PR TITLE
test(match): support roundEngine CAS chain in rounds.update mocks

### DIFF
--- a/tests/integration/match/autoPass.spec.ts
+++ b/tests/integration/match/autoPass.spec.ts
@@ -112,9 +112,20 @@ describe("autoPass synthesis (T010)", () => {
       updateCalls.push({ table: "matches", payload });
       return { eq: vi.fn().mockResolvedValue({ error: null }) };
     });
+    // Rounds update has two call shapes in roundEngine (see PR #177):
+    //  - `.update(x).eq("id", X)` awaited directly (steps 9c, 11)
+    //  - `.update(x).eq("id", X).eq("state", "collecting").select("id")` — step 9.5 CAS
     const roundsUpdate = vi.fn().mockImplementation((payload: unknown) => {
       updateCalls.push({ table: "rounds", payload });
-      return { eq: vi.fn().mockResolvedValue({ error: null }) };
+      const chain: Record<string, unknown> = {};
+      chain.eq = vi.fn(() => chain);
+      chain.select = vi
+        .fn()
+        .mockResolvedValue({ data: [{ id: "round-1" }], error: null });
+      (chain as { then: unknown }).then = (
+        onFulfilled: (v: { error: null }) => unknown,
+      ) => Promise.resolve({ error: null }).then(onFulfilled);
+      return chain;
     });
 
     vi.mocked(getServiceRoleClient).mockReturnValue({

--- a/tests/integration/match/matchEndRoundLimit.spec.ts
+++ b/tests/integration/match/matchEndRoundLimit.spec.ts
@@ -173,7 +173,20 @@ function setupAdvanceRoundMocks() {
       if (table === "rounds")
         return {
           select: vi.fn(() => roundChain),
-          update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+          // Rounds update has two call shapes in roundEngine (see PR #177):
+          //  - `.update(x).eq("id", X)` awaited directly (steps 9c, 11)
+          //  - `.update(x).eq("id", X).eq("state", "collecting").select("id")` — step 9.5 CAS
+          update: vi.fn().mockImplementation(() => {
+            const chain: Record<string, unknown> = {};
+            chain.eq = vi.fn(() => chain);
+            chain.select = vi
+              .fn()
+              .mockResolvedValue({ data: [{ id: "round-10" }], error: null });
+            (chain as { then: unknown }).then = (
+              onFulfilled: (v: { error: null }) => unknown,
+            ) => Promise.resolve({ error: null }).then(onFulfilled);
+            return chain;
+          }),
           insert: vi.fn().mockResolvedValue({ error: null }),
         };
       if (table === "move_submissions")


### PR DESCRIPTION
## Summary
- `roundEngine` added a compare-and-swap step in PR #177 that calls `.update(x).eq("id", X).eq("state", "collecting").select("id")` alongside the prior `.update(x).eq("id", X)` direct-await shape.
- Both `tests/integration/match/autoPass.spec.ts` and `tests/integration/match/matchEndRoundLimit.spec.ts` mocked only the direct-await shape, leaving the CAS path resolving to `undefined`.
- Teach the `rounds.update` mock to return a chain that (a) chains `.eq()` back to itself, (b) resolves `.select()` with a row so the CAS check passes, and (c) is itself thenable resolving to `{ error: null }` for the direct-await shape.

## Test plan
- [ ] `pnpm test:integration -- tests/integration/match/autoPass.spec.ts`
- [ ] `pnpm test:integration -- tests/integration/match/matchEndRoundLimit.spec.ts`
- [ ] CI integration suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)