### PR TITLE
fix(match): auto-complete match when both clocks expire (#175)

### DIFF
--- a/lib/match/stateLoader.ts
+++ b/lib/match/stateLoader.ts
@@ -13,7 +13,7 @@ import type {
   WordScore,
 } from "@/lib/types/match";
 import { generateBoard } from "@/scripts/supabase/generateBoard";
-import { computeElapsedMs, computeRemainingMs } from "./clockEnforcer";
+import { computeElapsedMs, computeRemainingMs, isClockExpired } from "./clockEnforcer";
 import { getDisconnectRecord } from "./disconnectStore";
 
 type AnyClient = SupabaseClient<any, any, any>;
@@ -432,6 +432,20 @@ export async function loadMatchState(
     // the race where submitMove's `after()` hook drops the advancement.
     const nonTimeoutSubs = typedSubs.filter((s) => s.status !== "timeout");
     if (nonTimeoutSubs.length >= 2) {
+      triggerAdvanceInBackground(matchId);
+    }
+
+    // Self-heal for issue #175: when both clocks have expired and fewer than
+    // two real submissions exist, no client input will ever call advanceRound
+    // (the submitMove path rejects flagged players; the current-round
+    // triggerTimeoutCheck only fires on the client's own countdown, which
+    // stops ticking once both reach zero). The 2s safety poll on every
+    // active client lands here, so we trigger advanceRound ourselves — its
+    // both-flagged branch will then complete the match.
+    const bothClocksExpired =
+      isClockExpired(roundStartedAt, storedA) &&
+      isClockExpired(roundStartedAt, storedB);
+    if (bothClocksExpired && nonTimeoutSubs.length < 2) {
       triggerAdvanceInBackground(matchId);
     }
 

--- a/tests/unit/lib/match/stateLoader.test.ts
+++ b/tests/unit/lib/match/stateLoader.test.ts
@@ -384,6 +384,114 @@ describe("stateLoader self-heal (stuck collecting round)", () => {
         expect(advanceRound).not.toHaveBeenCalled();
     });
 
+    // Regression for issue #175: when both players' clocks have expired but
+    // neither submitted, no client input fires advanceRound and the match
+    // sits on the board forever. The polled state endpoint must self-heal
+    // by triggering advanceRound so the both-flagged branch can complete
+    // the match.
+    it("triggers advanceRound when both players' clocks are expired with no submissions", async () => {
+        // Round started 10s ago; stored timers 1s each → both server-expired.
+        const roundStartedAt = new Date(Date.now() - 10_000);
+        const mockClient = makeMockClient(
+            {
+                id: MATCH_ID,
+                state: "in_progress",
+                current_round: 10,
+                board_seed: "seed-1",
+                player_a_id: PLAYER_A,
+                player_b_id: PLAYER_B,
+                player_a_timer_ms: 1_000,
+                player_b_timer_ms: 1_000,
+                frozen_tiles: {},
+            },
+            {
+                id: "round-10",
+                state: "collecting",
+                board_snapshot_before: Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A")),
+                board_snapshot_after: null,
+                started_at: roundStartedAt.toISOString(),
+            },
+            [],
+        );
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        await loadMatchState(mockClient as never, MATCH_ID);
+        await new Promise((r) => setImmediate(r));
+
+        expect(advanceRound).toHaveBeenCalledTimes(1);
+        expect(advanceRound).toHaveBeenCalledWith(MATCH_ID);
+    });
+
+    it("triggers advanceRound when both clocks are expired with one pending submission", async () => {
+        // One player submitted before flagging, the other never did and their
+        // clock ran out. advanceRound's both-flagged branch must still resolve.
+        const roundStartedAt = new Date(Date.now() - 10_000);
+        const mockClient = makeMockClient(
+            {
+                id: MATCH_ID,
+                state: "in_progress",
+                current_round: 10,
+                board_seed: "seed-1",
+                player_a_id: PLAYER_A,
+                player_b_id: PLAYER_B,
+                player_a_timer_ms: 1_000,
+                player_b_timer_ms: 1_000,
+                frozen_tiles: {},
+            },
+            {
+                id: "round-10",
+                state: "collecting",
+                board_snapshot_before: Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A")),
+                board_snapshot_after: null,
+                started_at: roundStartedAt.toISOString(),
+            },
+            [
+                { player_id: PLAYER_A, submitted_at: roundStartedAt.toISOString(), status: "pending" },
+            ],
+        );
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        await loadMatchState(mockClient as never, MATCH_ID);
+        await new Promise((r) => setImmediate(r));
+
+        expect(advanceRound).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT trigger advanceRound when only one player's clock has expired", async () => {
+        // Player A flagged (1s timer, 10s elapsed); Player B still has time.
+        // The normal timeout-pass synthesis inside advanceRound handles this
+        // path when the surviving player submits — the idle safety net must
+        // not fire prematurely and cancel the round on the live player.
+        const roundStartedAt = new Date(Date.now() - 10_000);
+        const mockClient = makeMockClient(
+            {
+                id: MATCH_ID,
+                state: "in_progress",
+                current_round: 10,
+                board_seed: "seed-1",
+                player_a_id: PLAYER_A,
+                player_b_id: PLAYER_B,
+                player_a_timer_ms: 1_000,
+                player_b_timer_ms: 120_000,
+                frozen_tiles: {},
+            },
+            {
+                id: "round-10",
+                state: "collecting",
+                board_snapshot_before: Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A")),
+                board_snapshot_after: null,
+                started_at: roundStartedAt.toISOString(),
+            },
+            [],
+        );
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        await loadMatchState(mockClient as never, MATCH_ID);
+        await new Promise((r) => setImmediate(r));
+
+        expect(advanceRound).not.toHaveBeenCalled();
+    });
+
     it("dedupes concurrent stuck-state polls so advanceRound is called at most once in flight", async () => {
         // Make advanceRound slow so the dedup window stays open across both calls.
         let resolveAdvance: () => void = () => {};


### PR DESCRIPTION
## Summary
Closes #175.

When both players' clocks hit zero without either submitting, the match sat on the board forever. \`advanceRound\`'s \"both flagged\" branch was correct (calls \`completeMatchInternal(matchId, 'timeout')\`), but **nothing was calling \`advanceRound\` in the idle scenario**:
- \`submitMove\`'s \`after()\` hook only fires on successful submission, and \`submitMove\` rejects flagged players up-front.
- The client's \`triggerTimeoutCheck\` effect is ref-gated (fires once) and silently swallows failures.
- The 2s safety-net poll only read state; it never triggered advancement.

## Fix
Extend the existing stateLoader self-heal path (same one that recovers \"both submitted but round stuck\"): when the 2s poll observes both clocks server-expired and fewer than two real submissions, fire \`advanceRound(matchId)\` in the background. The both-flagged branch completes the match, the next snapshot carries \`state: \"completed\"\`, and \`MatchClient\`'s existing navigate-on-completed effect takes the players to the summary.

- Server-authoritative (reuses \`isClockExpired\` — same helper the round engine uses).
- No client changes.
- Reuses \`pendingSelfHeals\` dedup, so concurrent polls only fire one background advance per match.

## Test plan
- [x] 3 new unit tests covering: both-expired no submissions; both-expired with 1 pending sub; only one clock expired (must not fire).
- [x] \`pnpm test\` — 1001 passing / 2 skipped.
- [x] Typecheck + lint clean.
- [ ] Manual: let a match sit with both clocks at zero; verify auto-navigation to summary within ~2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)