### PR TITLE
feat: pg_cron sweep finalises orphaned in_progress matches (#180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,30 @@ The project follows a spec-driven development workflow using GitHub Spec-kit.
 | `NEXT_PUBLIC_ENABLE_PLAYTEST_MATCH` | Set to `true` to surface match summary preview UI                  | _unset_ (false)                      |
 | `PLAYTEST_SESSION_SECURE`           | Force secure cookies (`true`/`false`); override for local Playwright | auto (`true` in production)          |
 | `RATE_LIMIT_DISABLED_SCOPES`        | Comma-separated list of scopes to bypass (e.g., `auth:login`)      | _unset_                              |
+| `CRON_SECRET`                       | Shared secret for `/api/cron/*` routes; must match Postgres `app.cron_secret` setting | _unset_ (required in prod)           |
 
 Tweak the playtest-related values when simulating heavier loads; e.g., increase `PLAYTEST_MAX_CONCURRENT_MATCHES` when running soak tests on a beefier Supabase instance, or lower `PLAYTEST_INVITE_EXPIRY_SECONDS` to keep the lobby tidy during short feedback sessions.
+
+### pg_cron sweep (production / Supabase Cloud)
+
+Migration `20260423001_sweep_stale_matches.sql` registers a 30-second pg_cron job that POSTs `/api/cron/sweep-stale-matches` to auto-finalise matches stuck `in_progress` with no live presence on either side (issue #180). After deploying:
+
+1. Set `CRON_SECRET` in the Vercel project env (any random value).
+2. In the Supabase SQL editor, configure the matching Postgres settings:
+   ```sql
+   alter database postgres set app.app_url = 'https://wottle.example.com';
+   alter database postgres set app.cron_secret = 'same-value-as-CRON_SECRET';
+   ```
+3. Verify the job is firing:
+   ```sql
+   select start_time, status, return_message
+   from cron.job_run_details
+   where jobname = 'sweep-stale-matches'
+   order by start_time desc
+   limit 5;
+   ```
+
+The local Supabase Docker image keeps pg_cron loaded, but the schedule body uses `current_setting(..., true)` so missing `app.app_url` / `app.cron_secret` resolve to NULL and `net.http_post` no-ops harmlessly. The `find_orphaned_matches()` SQL function is portable and is safe to invoke directly for ad-hoc cleanup.
 
 ## Scripts
 

--- a/app/actions/match/completeMatch.ts
+++ b/app/actions/match/completeMatch.ts
@@ -105,12 +105,16 @@ export async function completeMatchInternal(
   const supabase = getServiceRoleClient();
   const match = await fetchMatch(supabase, matchId);
 
-  if (match.state === "completed" && match.winner_id) {
+  if (match.state === "completed") {
+    const existingWinner = match.winner_id;
     return {
       matchId,
-      winnerId: match.winner_id,
-      loserId:
-        match.winner_id === match.player_a_id ? match.player_b_id : match.player_a_id,
+      winnerId: existingWinner,
+      loserId: existingWinner
+        ? existingWinner === match.player_a_id
+          ? match.player_b_id
+          : match.player_a_id
+        : null,
       isDraw: false,
       scores: await fetchLatestScores(supabase, matchId),
       endedReason: (match.ended_reason as MatchEndedReason) ?? reason,
@@ -123,22 +127,26 @@ export async function completeMatchInternal(
   );
   // Disconnect flows award the still-connected / claiming player regardless of
   // score: loss of connection is treated as forfeit per Phase 6 spec §6.
+  // Abandoned matches (sweep-finalised with no live presence on either side)
+  // record no winner — there is no reliable signal for who "should" have won.
   const result =
-    forcedWinnerId !== undefined
-      ? {
-          winnerId: forcedWinnerId,
-          loserId:
-            forcedWinnerId === match.player_a_id
-              ? match.player_b_id
-              : match.player_a_id,
-          isDraw: false,
-        }
-      : determineMatchWinner(
-          scores,
-          match.player_a_id,
-          match.player_b_id,
-          frozenCounts,
-        );
+    reason === "abandoned"
+      ? { winnerId: null, loserId: null, isDraw: false }
+      : forcedWinnerId !== undefined
+        ? {
+            winnerId: forcedWinnerId,
+            loserId:
+              forcedWinnerId === match.player_a_id
+                ? match.player_b_id
+                : match.player_a_id,
+            isDraw: false,
+          }
+        : determineMatchWinner(
+            scores,
+            match.player_a_id,
+            match.player_b_id,
+            frozenCounts,
+          );
 
   await supabase
     .from("matches")
@@ -150,24 +158,27 @@ export async function completeMatchInternal(
     })
     .eq("id", matchId);
 
-  // Calculate and persist Elo rating changes
+  // Calculate and persist Elo rating changes — skip for abandoned matches
+  // since no winner means no meaningful rating delta.
   let ratingChanges: RatingChange | undefined;
-  try {
-    ratingChanges = await applyRatingChanges(
-      supabase,
-      matchId,
-      match.player_a_id,
-      match.player_b_id,
-      result,
-    );
-  } catch (err) {
-    console.error(
-      JSON.stringify({
-        event: "rating.update.error",
+  if (reason !== "abandoned") {
+    try {
+      ratingChanges = await applyRatingChanges(
+        supabase,
         matchId,
-        error: err instanceof Error ? err.message : String(err),
-      }),
-    );
+        match.player_a_id,
+        match.player_b_id,
+        result,
+      );
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          event: "rating.update.error",
+          matchId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
   }
 
   await resetPlayerStatuses(supabase, [match.player_a_id, match.player_b_id]);

--- a/app/api/cron/sweep-stale-matches/route.ts
+++ b/app/api/cron/sweep-stale-matches/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+
+import { completeMatchInternal } from "@/app/actions/match/completeMatch";
+import { findOrphanedMatches } from "@/lib/match/findOrphanedMatches";
+
+const NO_CACHE_HEADERS = { "Cache-Control": "no-store" } as const;
+
+export async function POST(request: Request): Promise<Response> {
+  const expectedSecret = process.env.CRON_SECRET;
+  if (!expectedSecret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET is not configured." },
+      { status: 500, headers: NO_CACHE_HEADERS },
+    );
+  }
+
+  const auth = request.headers.get("authorization");
+  if (auth !== `Bearer ${expectedSecret}`) {
+    return NextResponse.json(
+      { error: "Unauthorized." },
+      { status: 401, headers: NO_CACHE_HEADERS },
+    );
+  }
+
+  const startedAt = Date.now();
+  let matchIds: string[];
+  try {
+    matchIds = await findOrphanedMatches();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown error";
+    console.error(
+      JSON.stringify({
+        event: "sweep_stale_matches.find_failed",
+        error: message,
+      }),
+    );
+    return NextResponse.json(
+      { error: message },
+      { status: 500, headers: NO_CACHE_HEADERS },
+    );
+  }
+
+  const settled = await Promise.allSettled(
+    matchIds.map((id) => completeMatchInternal(id, "abandoned")),
+  );
+
+  const swept: string[] = [];
+  const failed: Array<{ matchId: string; error: string }> = [];
+  settled.forEach((outcome, index) => {
+    const matchId = matchIds[index];
+    if (outcome.status === "fulfilled") {
+      swept.push(matchId);
+    } else {
+      const reason = outcome.reason;
+      failed.push({
+        matchId,
+        error: reason instanceof Error ? reason.message : String(reason),
+      });
+    }
+  });
+
+  console.log(
+    JSON.stringify({
+      event: "sweep_stale_matches",
+      swept_count: swept.length,
+      failed_count: failed.length,
+      duration_ms: Date.now() - startedAt,
+    }),
+  );
+
+  return NextResponse.json(
+    { swept, failed },
+    { status: 200, headers: NO_CACHE_HEADERS },
+  );
+}

--- a/docs/superpowers/plans/2026-04-23-stale-in-match-cleanup.md
+++ b/docs/superpowers/plans/2026-04-23-stale-in-match-cleanup.md
@@ -1,0 +1,1061 @@
+# Stale "In Match" Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-abort orphaned matches (`state='in_progress'` with no live presence for either player) via a pg_cron-driven sweep that reuses `completeMatchInternal`.
+
+**Architecture:** A new SQL function `find_orphaned_matches()` returns affected match ids. A POST route `/api/cron/sweep-stale-matches` (gated by `CRON_SECRET`) calls the function and runs `completeMatchInternal(id, 'abandoned')` for each match, awaiting `Promise.allSettled` so one failure doesn't block the rest. Supabase pg_cron schedules the route every 30s via `net.http_post`. Phase 6 live-disconnect flow stays untouched.
+
+**Tech Stack:** Next.js 16 App Router (route handler), Supabase JS v2 (`getServiceRoleClient`, `.rpc()`), Vitest (unit + integration), Postgres 17 + pg_cron + pg_net (Supabase Cloud).
+
+**Reference:** [Design spec](../specs/2026-04-23-stale-in-match-cleanup-design.md), GitHub issue [#180](https://github.com/minniai/wottle/issues/180).
+
+---
+
+## File Structure
+
+| File | Purpose |
+|---|---|
+| `lib/types/match.ts` | Add `'abandoned'` to `MatchEndedReason` union. |
+| `app/actions/match/completeMatch.ts` | Strengthen idempotency guard so abandoned matches (null winner) short-circuit on re-entry. |
+| `supabase/migrations/20260423001_sweep_stale_matches.sql` | Extend CHECK constraint, create `find_orphaned_matches()` SQL fn, enable pg_cron/pg_net (guarded), schedule sweep. |
+| `lib/match/findOrphanedMatches.ts` | TS helper wrapping `supabase.rpc('find_orphaned_matches')`. |
+| `app/api/cron/sweep-stale-matches/route.ts` | POST handler with `CRON_SECRET` auth, runs the sweep. |
+| `tests/unit/lib/match/findOrphanedMatches.test.ts` | Unit test for RPC helper. |
+| `tests/unit/app/api/sweepStaleMatches.test.ts` | Unit test for route auth + per-match failure resilience. |
+| `tests/unit/app/actions/completeMatchAbandoned.test.ts` | Unit test for `completeMatchInternal('abandoned', undefined)` behavior. |
+| `tests/integration/api/sweepStaleMatches.spec.ts` | Integration test against real Supabase: seed orphan, run sweep, assert finalisation. |
+| `README.md` | Document `CRON_SECRET` env var and Supabase Cloud `app.cron_secret`/`app.app_url` settings. |
+
+---
+
+## Task 1: Add `'abandoned'` to `MatchEndedReason` type
+
+**Files:**
+- Modify: `lib/types/match.ts:36-41`
+- Test: `tests/unit/lib/types/matchEndedReason.test.ts` (new)
+
+- [ ] **Step 1.1: Write the failing test**
+
+Create `tests/unit/lib/types/matchEndedReason.test.ts`:
+
+```typescript
+import { describe, it, expectTypeOf } from "vitest";
+import type { MatchEndedReason } from "@/lib/types/match";
+
+describe("MatchEndedReason", () => {
+  it("includes 'abandoned' as a valid reason", () => {
+    const reason: MatchEndedReason = "abandoned";
+    expectTypeOf(reason).toEqualTypeOf<MatchEndedReason>();
+  });
+});
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+```bash
+pnpm test:unit -- tests/unit/lib/types/matchEndedReason.test.ts
+```
+
+Expected: type error `Type '"abandoned"' is not assignable to type 'MatchEndedReason'`.
+
+- [ ] **Step 1.3: Add `'abandoned'` to the union**
+
+Edit `lib/types/match.ts` lines 36-41 — change:
+
+```typescript
+export type MatchEndedReason =
+  | "round_limit"
+  | "timeout"
+  | "disconnect"
+  | "forfeit"
+  | "error";
+```
+
+to:
+
+```typescript
+export type MatchEndedReason =
+  | "round_limit"
+  | "timeout"
+  | "disconnect"
+  | "forfeit"
+  | "abandoned"
+  | "error";
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+```bash
+pnpm test:unit -- tests/unit/lib/types/matchEndedReason.test.ts
+pnpm typecheck
+```
+
+Both expected: PASS.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add lib/types/match.ts tests/unit/lib/types/matchEndedReason.test.ts
+git commit -m "feat(types): add 'abandoned' to MatchEndedReason union (#180)"
+```
+
+---
+
+## Task 2: Strengthen `completeMatchInternal` idempotency guard
+
+The existing guard at `app/actions/match/completeMatch.ts:108-118` only short-circuits when `match.state === "completed" && match.winner_id`. Abandoned matches have `winner_id = NULL`, so a second call would re-execute. Tighten the guard to short-circuit on any `state !== "in_progress"`.
+
+**Files:**
+- Modify: `app/actions/match/completeMatch.ts:108-118`
+- Test: `tests/unit/app/actions/completeMatchAbandoned.test.ts` (new)
+
+- [ ] **Step 2.1: Write the failing test**
+
+Create `tests/unit/app/actions/completeMatchAbandoned.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+vi.mock("@/lib/match/statePublisher", () => ({
+  publishMatchState: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { getServiceRoleClient } from "@/lib/supabase/server";
+import { completeMatchInternal } from "@/app/actions/match/completeMatch";
+
+function buildClientForCompletedMatch(state: string, winnerId: string | null) {
+  const matchRow = {
+    id: "match-1",
+    state,
+    winner_id: winnerId,
+    player_a_id: "player-a",
+    player_b_id: "player-b",
+    ended_reason: "abandoned",
+  };
+  const matchSelect = {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: matchRow, error: null }),
+      }),
+    }),
+  };
+  const wordScoresSelect = {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }),
+  };
+  return {
+    from: vi.fn((table: string) => {
+      if (table === "matches") return matchSelect;
+      if (table === "word_scores") return wordScoresSelect;
+      return { select: vi.fn() };
+    }),
+  } as unknown;
+}
+
+describe("completeMatchInternal idempotency for abandoned matches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("short-circuits when match is already completed with no winner (abandoned)", async () => {
+    const client = buildClientForCompletedMatch("completed", null);
+    vi.mocked(getServiceRoleClient).mockReturnValue(client as never);
+
+    const result = await completeMatchInternal("match-1", "abandoned");
+
+    expect(result.matchId).toBe("match-1");
+    expect(result.winnerId).toBeNull();
+    expect(result.endedReason).toBe("abandoned");
+  });
+});
+```
+
+- [ ] **Step 2.2: Run the test to verify it fails**
+
+```bash
+pnpm test:unit -- tests/unit/app/actions/completeMatchAbandoned.test.ts
+```
+
+Expected: FAIL — current guard at `completeMatch.ts:108` requires `match.winner_id` to be truthy, so the test path falls through and tries to load scores/players from the mock that doesn't fully support that path.
+
+- [ ] **Step 2.3: Update the guard**
+
+Edit `app/actions/match/completeMatch.ts:108-118` — change:
+
+```typescript
+if (match.state === "completed" && match.winner_id) {
+  return {
+    matchId,
+    winnerId: match.winner_id,
+    loserId:
+      match.winner_id === match.player_a_id ? match.player_b_id : match.player_a_id,
+    isDraw: false,
+    scores: await fetchLatestScores(supabase, matchId),
+    endedReason: (match.ended_reason as MatchEndedReason) ?? reason,
+  };
+}
+```
+
+to:
+
+```typescript
+if (match.state === "completed") {
+  const winnerId = match.winner_id ?? null;
+  return {
+    matchId,
+    winnerId,
+    loserId: winnerId
+      ? winnerId === match.player_a_id
+        ? match.player_b_id
+        : match.player_a_id
+      : null,
+    isDraw: winnerId === null,
+    scores: await fetchLatestScores(supabase, matchId),
+    endedReason: (match.ended_reason as MatchEndedReason) ?? reason,
+  };
+}
+```
+
+Note: this assumes `CompleteMatchResult.winnerId` and `loserId` accept `null`. Verify `app/actions/match/completeMatch.ts` for the type. If they're `string` (not nullable), update the type in the same file to `string | null`.
+
+- [ ] **Step 2.4: Verify type compatibility**
+
+```bash
+pnpm typecheck
+```
+
+If errors mention `CompleteMatchResult.winnerId` not accepting `null`, find the type declaration in `app/actions/match/completeMatch.ts` (search for `interface CompleteMatchResult` or `type CompleteMatchResult`) and change the `winnerId` and `loserId` fields to `string | null`. Also check call sites — `winnerId` consumers may need null-handling. Run typecheck again.
+
+- [ ] **Step 2.5: Run all completeMatch tests**
+
+```bash
+pnpm test:unit -- tests/unit/app/actions/completeMatch
+```
+
+Expected: all pass, including the new abandoned-idempotency test. If existing tests break because of the new `null` widening, narrow the change minimally — add only what's needed for abandoned matches.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add app/actions/match/completeMatch.ts tests/unit/app/actions/completeMatchAbandoned.test.ts
+git commit -m "fix(match): make completeMatchInternal idempotent for abandoned matches (#180)"
+```
+
+---
+
+## Task 3: Migration — extend CHECK constraint, add SQL function, schedule cron
+
+**Files:**
+- Create: `supabase/migrations/20260423001_sweep_stale_matches.sql`
+
+- [ ] **Step 3.1: Write the migration**
+
+Create `supabase/migrations/20260423001_sweep_stale_matches.sql`:
+
+```sql
+-- Stale "in match" cleanup (issue #180).
+-- Adds 'abandoned' to matches.ended_reason, ships the SQL fn used by
+-- the /api/cron/sweep-stale-matches route, and (where pg_cron is
+-- available) schedules the sweep every 30 seconds via pg_net.
+-- pg_cron + pg_net are Supabase Cloud features; the schedule block is
+-- guarded so local Supabase (no pg_cron) does not break migrations.
+
+-- 1. Extend matches.ended_reason CHECK to allow 'abandoned'.
+alter table public.matches
+  drop constraint if exists matches_ended_reason_check;
+
+alter table public.matches
+  add constraint matches_ended_reason_check
+  check (
+    ended_reason is null
+    or ended_reason in (
+      'round_limit',
+      'timeout',
+      'disconnect',
+      'forfeit',
+      'draw',
+      'abandoned'
+    )
+  );
+
+-- 2. find_orphaned_matches() — returns ids of in_progress matches where
+--    neither player has a live lobby_presence row.
+create or replace function public.find_orphaned_matches()
+returns setof uuid
+language sql
+stable
+as $$
+  select m.id
+  from public.matches m
+  where m.state = 'in_progress'
+    and not exists (
+      select 1
+      from public.lobby_presence lp
+      where lp.player_id in (m.player_a_id, m.player_b_id)
+        and lp.expires_at > now()
+    );
+$$;
+
+comment on function public.find_orphaned_matches() is
+  'Issue #180: matches stuck in_progress with no live presence for either player. Consumed by /api/cron/sweep-stale-matches.';
+
+-- 3. Schedule the sweep — guarded so local environments without
+--    pg_cron/pg_net do not fail. Production Supabase Cloud has both.
+do $$
+begin
+  create extension if not exists pg_cron;
+  create extension if not exists pg_net;
+
+  -- Unschedule any prior version (idempotent re-runs).
+  perform cron.unschedule(jobid)
+    from cron.job
+    where jobname = 'sweep-stale-matches';
+
+  perform cron.schedule(
+    'sweep-stale-matches',
+    '*/30 * * * * *',
+    $cron$
+      select net.http_post(
+        url := current_setting('app.app_url', true) || '/api/cron/sweep-stale-matches',
+        headers := jsonb_build_object(
+          'Authorization', 'Bearer ' || current_setting('app.cron_secret', true),
+          'Content-Type', 'application/json'
+        ),
+        body := '{}'::jsonb
+      );
+    $cron$
+  );
+exception
+  when undefined_file then
+    raise notice 'pg_cron/pg_net unavailable in this environment; skipping schedule. Function find_orphaned_matches() is still available for direct invocation.';
+  when others then
+    raise notice 'pg_cron schedule skipped: %', sqlerrm;
+end;
+$$;
+```
+
+- [ ] **Step 3.2: Apply the migration locally**
+
+```bash
+pnpm supabase:migrate
+```
+
+Expected: migration applies cleanly. The `do` block emits a `notice` about pg_cron being unavailable on the local image (that's fine — `find_orphaned_matches()` is still created).
+
+- [ ] **Step 3.3: Verify the SQL function exists and runs**
+
+```bash
+psql "$DATABASE_URL" -c "SELECT * FROM public.find_orphaned_matches();"
+```
+
+(If `DATABASE_URL` isn't set in your shell, use the local Supabase URL: `postgresql://postgres:postgres@127.0.0.1:54322/postgres`.)
+
+Expected: returns 0 rows on a clean local DB.
+
+- [ ] **Step 3.4: Verify the CHECK constraint accepts 'abandoned'**
+
+```bash
+psql "$DATABASE_URL" -c "SELECT conname, pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'matches_ended_reason_check';"
+```
+
+Expected: definition includes `'abandoned'`.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add supabase/migrations/20260423001_sweep_stale_matches.sql
+git commit -m "feat(db): add find_orphaned_matches() + 'abandoned' reason + pg_cron sweep (#180)"
+```
+
+---
+
+## Task 4: TS helper `findOrphanedMatches()`
+
+**Files:**
+- Create: `lib/match/findOrphanedMatches.ts`
+- Test: `tests/unit/lib/match/findOrphanedMatches.test.ts`
+
+- [ ] **Step 4.1: Write the failing test**
+
+Create `tests/unit/lib/match/findOrphanedMatches.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+import { getServiceRoleClient } from "@/lib/supabase/server";
+import { findOrphanedMatches } from "@/lib/match/findOrphanedMatches";
+
+describe("findOrphanedMatches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns ids returned by the SQL function", async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: [{ id: "match-1" }, { id: "match-2" }],
+      error: null,
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue({ rpc } as never);
+
+    const result = await findOrphanedMatches();
+
+    expect(rpc).toHaveBeenCalledWith("find_orphaned_matches");
+    expect(result).toEqual(["match-1", "match-2"]);
+  });
+
+  it("returns empty array when no orphans exist", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+    vi.mocked(getServiceRoleClient).mockReturnValue({ rpc } as never);
+
+    const result = await findOrphanedMatches();
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when RPC returns null data", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+    vi.mocked(getServiceRoleClient).mockReturnValue({ rpc } as never);
+
+    const result = await findOrphanedMatches();
+
+    expect(result).toEqual([]);
+  });
+
+  it("throws when the RPC errors", async () => {
+    const rpc = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: "boom" } });
+    vi.mocked(getServiceRoleClient).mockReturnValue({ rpc } as never);
+
+    await expect(findOrphanedMatches()).rejects.toThrow(/boom/);
+  });
+});
+```
+
+- [ ] **Step 4.2: Run the test to verify it fails**
+
+```bash
+pnpm test:unit -- tests/unit/lib/match/findOrphanedMatches.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 4.3: Implement the helper**
+
+Create `lib/match/findOrphanedMatches.ts`:
+
+```typescript
+import { getServiceRoleClient } from "@/lib/supabase/server";
+
+type OrphanRow = { id: string };
+
+export async function findOrphanedMatches(): Promise<string[]> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase.rpc("find_orphaned_matches");
+
+  if (error) {
+    throw new Error(`find_orphaned_matches failed: ${error.message}`);
+  }
+
+  if (!data) return [];
+
+  return (data as OrphanRow[]).map((row) => row.id);
+}
+```
+
+- [ ] **Step 4.4: Run the test to verify it passes**
+
+```bash
+pnpm test:unit -- tests/unit/lib/match/findOrphanedMatches.test.ts
+pnpm typecheck
+```
+
+Both expected: PASS.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add lib/match/findOrphanedMatches.ts tests/unit/lib/match/findOrphanedMatches.test.ts
+git commit -m "feat(match): add findOrphanedMatches RPC helper (#180)"
+```
+
+---
+
+## Task 5: Sweep route — `/api/cron/sweep-stale-matches`
+
+**Files:**
+- Create: `app/api/cron/sweep-stale-matches/route.ts`
+- Test: `tests/unit/app/api/sweepStaleMatches.test.ts`
+
+- [ ] **Step 5.1: Write the failing test**
+
+Create `tests/unit/app/api/sweepStaleMatches.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/match/findOrphanedMatches", () => ({
+  findOrphanedMatches: vi.fn(),
+}));
+
+vi.mock("@/app/actions/match/completeMatch", () => ({
+  completeMatchInternal: vi.fn(),
+}));
+
+import { findOrphanedMatches } from "@/lib/match/findOrphanedMatches";
+import { completeMatchInternal } from "@/app/actions/match/completeMatch";
+import { POST } from "@/app/api/cron/sweep-stale-matches/route";
+
+const ORIGINAL_SECRET = process.env.CRON_SECRET;
+
+function buildRequest(authHeader?: string): Request {
+  const headers = new Headers();
+  if (authHeader !== undefined) {
+    headers.set("authorization", authHeader);
+  }
+  return new Request("http://localhost/api/cron/sweep-stale-matches", {
+    method: "POST",
+    headers,
+    body: "{}",
+  });
+}
+
+describe("POST /api/cron/sweep-stale-matches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = "test-secret";
+  });
+
+  afterEach(() => {
+    process.env.CRON_SECRET = ORIGINAL_SECRET;
+  });
+
+  it("returns 401 when authorization header is missing", async () => {
+    const res = await POST(buildRequest());
+    expect(res.status).toBe(401);
+    expect(findOrphanedMatches).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when bearer token mismatches", async () => {
+    const res = await POST(buildRequest("Bearer wrong"));
+    expect(res.status).toBe(401);
+    expect(findOrphanedMatches).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with empty result when there are no orphans", async () => {
+    vi.mocked(findOrphanedMatches).mockResolvedValue([]);
+
+    const res = await POST(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ swept: [], failed: [] });
+    expect(completeMatchInternal).not.toHaveBeenCalled();
+  });
+
+  it("finalises every orphan match", async () => {
+    vi.mocked(findOrphanedMatches).mockResolvedValue(["m-1", "m-2"]);
+    vi.mocked(completeMatchInternal).mockResolvedValue({} as never);
+
+    const res = await POST(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(completeMatchInternal).toHaveBeenCalledTimes(2);
+    expect(completeMatchInternal).toHaveBeenCalledWith("m-1", "abandoned");
+    expect(completeMatchInternal).toHaveBeenCalledWith("m-2", "abandoned");
+    expect(body.swept).toEqual(["m-1", "m-2"]);
+    expect(body.failed).toEqual([]);
+  });
+
+  it("continues past per-match failures and reports them", async () => {
+    vi.mocked(findOrphanedMatches).mockResolvedValue(["m-ok", "m-bad", "m-ok-2"]);
+    vi.mocked(completeMatchInternal).mockImplementation(async (id: string) => {
+      if (id === "m-bad") throw new Error("boom");
+      return {} as never;
+    });
+
+    const res = await POST(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.swept).toEqual(["m-ok", "m-ok-2"]);
+    expect(body.failed).toHaveLength(1);
+    expect(body.failed[0]).toEqual({ matchId: "m-bad", error: "boom" });
+  });
+
+  it("returns 500 when find_orphaned_matches throws", async () => {
+    vi.mocked(findOrphanedMatches).mockRejectedValue(new Error("rpc down"));
+
+    const res = await POST(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toMatch(/rpc down/);
+  });
+});
+```
+
+(Add `import { afterEach } from "vitest";` to the import line if your test file's imports are organized — vitest also picks it up implicitly via globals if `vitest.config.ts` enables them, so check first.)
+
+- [ ] **Step 5.2: Run the test to verify it fails**
+
+```bash
+pnpm test:unit -- tests/unit/app/api/sweepStaleMatches.test.ts
+```
+
+Expected: FAIL — route module does not exist.
+
+- [ ] **Step 5.3: Implement the route**
+
+Create `app/api/cron/sweep-stale-matches/route.ts`:
+
+```typescript
+import { NextResponse } from "next/server";
+
+import { completeMatchInternal } from "@/app/actions/match/completeMatch";
+import { findOrphanedMatches } from "@/lib/match/findOrphanedMatches";
+
+const NO_CACHE_HEADERS = { "Cache-Control": "no-store" } as const;
+
+export async function POST(request: Request): Promise<Response> {
+  const expectedSecret = process.env.CRON_SECRET;
+  if (!expectedSecret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET is not configured." },
+      { status: 500, headers: NO_CACHE_HEADERS },
+    );
+  }
+
+  const auth = request.headers.get("authorization");
+  if (auth !== `Bearer ${expectedSecret}`) {
+    return NextResponse.json(
+      { error: "Unauthorized." },
+      { status: 401, headers: NO_CACHE_HEADERS },
+    );
+  }
+
+  const startedAt = Date.now();
+  let matchIds: string[];
+  try {
+    matchIds = await findOrphanedMatches();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown error";
+    console.error(
+      JSON.stringify({
+        event: "sweep_stale_matches.find_failed",
+        error: message,
+      }),
+    );
+    return NextResponse.json(
+      { error: message },
+      { status: 500, headers: NO_CACHE_HEADERS },
+    );
+  }
+
+  const settled = await Promise.allSettled(
+    matchIds.map((id) => completeMatchInternal(id, "abandoned")),
+  );
+
+  const swept: string[] = [];
+  const failed: Array<{ matchId: string; error: string }> = [];
+  settled.forEach((outcome, index) => {
+    const matchId = matchIds[index];
+    if (outcome.status === "fulfilled") {
+      swept.push(matchId);
+    } else {
+      const reason = outcome.reason;
+      failed.push({
+        matchId,
+        error: reason instanceof Error ? reason.message : String(reason),
+      });
+    }
+  });
+
+  console.log(
+    JSON.stringify({
+      event: "sweep_stale_matches",
+      swept_count: swept.length,
+      failed_count: failed.length,
+      duration_ms: Date.now() - startedAt,
+    }),
+  );
+
+  return NextResponse.json(
+    { swept, failed },
+    { status: 200, headers: NO_CACHE_HEADERS },
+  );
+}
+```
+
+- [ ] **Step 5.4: Run the test to verify it passes**
+
+```bash
+pnpm test:unit -- tests/unit/app/api/sweepStaleMatches.test.ts
+pnpm typecheck
+```
+
+Both expected: PASS. If `afterEach` was missing in the test file, add it to the vitest import line.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add app/api/cron/sweep-stale-matches/route.ts tests/unit/app/api/sweepStaleMatches.test.ts
+git commit -m "feat(api): add /api/cron/sweep-stale-matches with CRON_SECRET auth (#180)"
+```
+
+---
+
+## Task 6: Integration test against real Supabase
+
+**Files:**
+- Create: `tests/integration/api/sweepStaleMatches.spec.ts`
+
+This test runs against the real local Supabase (`pnpm test:integration` boots it). It seeds a stuck match with no live presence, calls the route handler, and asserts the match was finalised.
+
+- [ ] **Step 6.1: Write the integration test**
+
+Create `tests/integration/api/sweepStaleMatches.spec.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterEach, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
+
+import { getServiceRoleClient } from "@/lib/supabase/server";
+import { POST } from "@/app/api/cron/sweep-stale-matches/route";
+
+const SECRET = "test-cron-secret";
+
+async function createPlayer(displayName: string): Promise<string> {
+  const supabase = getServiceRoleClient();
+  const id = randomUUID();
+  const { error } = await supabase.from("players").insert({
+    id,
+    username: `sweep-${id.slice(0, 8)}`,
+    display_name: displayName,
+    status: "in_match",
+  });
+  if (error) throw error;
+  return id;
+}
+
+async function createMatch(
+  playerAId: string,
+  playerBId: string,
+  state: "pending" | "in_progress" | "completed" = "in_progress",
+): Promise<string> {
+  const supabase = getServiceRoleClient();
+  const id = randomUUID();
+  const { error } = await supabase.from("matches").insert({
+    id,
+    state,
+    player_a_id: playerAId,
+    player_b_id: playerBId,
+    board_seed: "test-seed",
+    current_round: 1,
+    round_limit: 10,
+    player_a_timer_ms: 600000,
+    player_b_timer_ms: 600000,
+  });
+  if (error) throw error;
+  return id;
+}
+
+async function setLivePresence(playerId: string): Promise<void> {
+  const supabase = getServiceRoleClient();
+  const { error } = await supabase.from("lobby_presence").upsert({
+    player_id: playerId,
+    connection_id: randomUUID(),
+    mode: "auto",
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+  });
+  if (error) throw error;
+}
+
+async function fetchMatch(id: string) {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("matches")
+    .select("state, ended_reason, winner_id")
+    .eq("id", id)
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+async function fetchPlayerStatus(id: string): Promise<string> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("players")
+    .select("status")
+    .eq("id", id)
+    .single();
+  if (error) throw error;
+  return data.status as string;
+}
+
+function buildRequest(authHeader?: string): Request {
+  const headers = new Headers();
+  if (authHeader !== undefined) headers.set("authorization", authHeader);
+  return new Request("http://localhost/api/cron/sweep-stale-matches", {
+    method: "POST",
+    headers,
+    body: "{}",
+  });
+}
+
+describe("POST /api/cron/sweep-stale-matches (integration)", () => {
+  const createdMatchIds: string[] = [];
+  const createdPlayerIds: string[] = [];
+
+  beforeAll(() => {
+    process.env.CRON_SECRET = SECRET;
+  });
+
+  afterEach(async () => {
+    const supabase = getServiceRoleClient();
+    if (createdMatchIds.length) {
+      await supabase.from("matches").delete().in("id", createdMatchIds);
+    }
+    if (createdPlayerIds.length) {
+      await supabase
+        .from("lobby_presence")
+        .delete()
+        .in("player_id", createdPlayerIds);
+      await supabase.from("players").delete().in("id", createdPlayerIds);
+    }
+    createdMatchIds.length = 0;
+    createdPlayerIds.length = 0;
+  });
+
+  it("finalises an orphaned match (no presence for either player)", async () => {
+    const a = await createPlayer("Alice");
+    const b = await createPlayer("Bob");
+    createdPlayerIds.push(a, b);
+    const matchId = await createMatch(a, b);
+    createdMatchIds.push(matchId);
+
+    const res = await POST(buildRequest(`Bearer ${SECRET}`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.swept).toContain(matchId);
+    expect(body.failed).toEqual([]);
+
+    const match = await fetchMatch(matchId);
+    expect(match.state).toBe("completed");
+    expect(match.ended_reason).toBe("abandoned");
+    expect(match.winner_id).toBeNull();
+
+    expect(await fetchPlayerStatus(a)).toBe("available");
+    expect(await fetchPlayerStatus(b)).toBe("available");
+  });
+
+  it("does not finalise a match with one live presence", async () => {
+    const a = await createPlayer("Alive");
+    const b = await createPlayer("Gone");
+    createdPlayerIds.push(a, b);
+    await setLivePresence(a);
+    const matchId = await createMatch(a, b);
+    createdMatchIds.push(matchId);
+
+    const res = await POST(buildRequest(`Bearer ${SECRET}`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.swept).not.toContain(matchId);
+
+    const match = await fetchMatch(matchId);
+    expect(match.state).toBe("in_progress");
+  });
+
+  it("does not finalise a match already completed", async () => {
+    const a = await createPlayer("Alpha");
+    const b = await createPlayer("Beta");
+    createdPlayerIds.push(a, b);
+    const matchId = await createMatch(a, b, "completed");
+    createdMatchIds.push(matchId);
+
+    const res = await POST(buildRequest(`Bearer ${SECRET}`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.swept).not.toContain(matchId);
+  });
+
+  it("is idempotent — second call is a no-op", async () => {
+    const a = await createPlayer("Idem-A");
+    const b = await createPlayer("Idem-B");
+    createdPlayerIds.push(a, b);
+    const matchId = await createMatch(a, b);
+    createdMatchIds.push(matchId);
+
+    const first = await POST(buildRequest(`Bearer ${SECRET}`));
+    expect(first.status).toBe(200);
+    const firstBody = await first.json();
+    expect(firstBody.swept).toContain(matchId);
+
+    const second = await POST(buildRequest(`Bearer ${SECRET}`));
+    expect(second.status).toBe(200);
+    const secondBody = await second.json();
+    expect(secondBody.swept).not.toContain(matchId);
+  });
+
+  it("does not write a match_ratings row for abandoned matches", async () => {
+    const a = await createPlayer("NoRating-A");
+    const b = await createPlayer("NoRating-B");
+    createdPlayerIds.push(a, b);
+    const matchId = await createMatch(a, b);
+    createdMatchIds.push(matchId);
+
+    await POST(buildRequest(`Bearer ${SECRET}`));
+
+    const supabase = getServiceRoleClient();
+    const { count, error } = await supabase
+      .from("match_ratings")
+      .select("*", { count: "exact", head: true })
+      .eq("match_id", matchId);
+    expect(error).toBeNull();
+    expect(count ?? 0).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 6.2: Run the integration test**
+
+```bash
+pnpm test:integration -- tests/integration/api/sweepStaleMatches.spec.ts
+```
+
+Expected: all tests pass. If the "match_ratings" assertion fails (a row was written), it means `completeMatchInternal` is taking the rating-write path with no winner. Re-check Task 2's idempotency guard plus the rating branch — the function should skip Elo when `winnerId` is null. If needed, add an explicit guard in `applyRatingChanges` (or wherever ratings are written) that returns early when `winnerId === null`.
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add tests/integration/api/sweepStaleMatches.spec.ts
+git commit -m "test(integration): cover sweep-stale-matches end-to-end (#180)"
+```
+
+---
+
+## Task 7: Document `CRON_SECRET` and Supabase settings
+
+**Files:**
+- Modify: `README.md` (env-vars section)
+
+- [ ] **Step 7.1: Locate the env-vars section in README**
+
+Open `README.md` and find the section that lists required env variables. (If the README hands off to `CLAUDE.md` for env vars, edit `CLAUDE.md`'s "Environment Variables" section instead.)
+
+- [ ] **Step 7.2: Add the new env var**
+
+Append to the env-vars list:
+
+```markdown
+- `CRON_SECRET` - Shared secret for `/api/cron/*` routes. Must match the bearer token configured in pg_cron's `app.cron_secret` Postgres setting.
+```
+
+And add a new subsection (place under the env-vars list or wherever ops setup lives):
+
+```markdown
+### pg_cron sweep (Supabase Cloud)
+
+The `/api/cron/sweep-stale-matches` route is called every 30s by pg_cron on Supabase Cloud. After deploy:
+
+1. Set `CRON_SECRET` in Vercel project env (any random value).
+2. In Supabase Cloud SQL editor, run:
+   ```sql
+   alter database postgres set app.app_url = 'https://wottle.example.com';
+   alter database postgres set app.cron_secret = 'same-value-as-CRON_SECRET';
+   ```
+3. Verify in Supabase: `select * from cron.job_run_details where jobname = 'sweep-stale-matches' order by start_time desc limit 5;`
+
+Local Supabase does not have `pg_cron` enabled; the migration creates the SQL function but skips the schedule.
+```
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add README.md  # or CLAUDE.md if that's where env vars live
+git commit -m "docs: document CRON_SECRET + Supabase pg_cron settings (#180)"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 8.1: Run the full test suite**
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test:unit
+pnpm test:integration
+```
+
+All expected: PASS.
+
+- [ ] **Step 8.2: Sanity check the route handler against staging shape**
+
+Manually fire the route from your local Next.js dev server:
+
+```bash
+pnpm dev   # in another terminal
+CRON_SECRET=test-secret  # ensure this matches your local .env.local
+curl -X POST http://localhost:3000/api/cron/sweep-stale-matches \
+  -H "Authorization: Bearer $CRON_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Expected: `200 {"swept":[],"failed":[]}` (empty arrays since no orphans on a clean DB). Without the header: `401`.
+
+- [ ] **Step 8.3: Push and open PR**
+
+```bash
+git push -u origin feat/sweep-stale-matches-180
+gh pr create --title "feat: pg_cron sweep finalises orphaned in_progress matches (#180)" --body "$(cat <<'EOF'
+## Summary
+- Adds `find_orphaned_matches()` SQL function returning `in_progress` matches with no live `lobby_presence` for either player.
+- Adds `POST /api/cron/sweep-stale-matches` (gated by `CRON_SECRET`) that calls `completeMatchInternal(id, 'abandoned')` for each orphan via `Promise.allSettled`.
+- Schedules pg_cron to invoke the route every 30s via `pg_net.http_post` (guarded so local migrations don't fail).
+- Strengthens `completeMatchInternal` idempotency for abandoned matches (null winner).
+- Adds `'abandoned'` to `MatchEndedReason` and the `matches.ended_reason` CHECK constraint.
+
+Phase 6 live-disconnect flow (DisconnectionModal + claim-win) is unchanged.
+
+Closes #180.
+
+## Test plan
+- [ ] `pnpm test:unit`
+- [ ] `pnpm test:integration -- tests/integration/api/sweepStaleMatches.spec.ts`
+- [ ] After deploy: confirm `cron.job_run_details` shows 200s and lobby `players in match` count drops to reality.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Checklist (post-write)
+
+- ✅ Spec coverage: every section of the design spec maps to a task (types → 1, idempotency → 2, migration/SQL/cron → 3, RPC helper → 4, route → 5, integration tests → 6, docs → 7, verification → 8).
+- ✅ No "TODO" / "implement later" / "similar to above" placeholders — every code step has the actual code.
+- ✅ Exact file paths and line ranges where modifying.
+- ✅ Type consistency: `MatchEndedReason` includes `'abandoned'` after Task 1; route uses `'abandoned'` literal in Task 5; `findOrphanedMatches` returns `string[]` consistently used by route.
+- ✅ Frequent commits — one per task at minimum.
+- ✅ TDD ordering: failing test → minimal code → passing test → commit, in every functional task.
+
+## Risk Notes
+
+- **Task 2 type widening.** Changing `winnerId` / `loserId` to `string | null` may surface call-site nulls. Mitigation: only widen if Step 2.4's typecheck demands it; otherwise keep types narrow by returning the existing shape with an extra branch.
+- **Local migration.** If the `do $$` block leaks an unexpected error class on a particular Postgres version, Task 3.2 will fail. Mitigation: the `when others` arm catches any exception; verify by inspecting `pnpm supabase:migrate` output.
+- **Integration test isolation.** Tests run against a shared local DB; the `afterEach` cleanup is critical. If concurrent integration suites flake, gate this spec with `describe.sequential` or move it into the existing serial pool.

--- a/docs/superpowers/specs/2026-04-23-stale-in-match-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-23-stale-in-match-cleanup-design.md
@@ -1,0 +1,176 @@
+# Stale "In Match" Cleanup — Design
+
+**Issue:** [#180](https://github.com/minniai/wottle/issues/180) — Players "in match" should abort and lose the match after 15 seconds if they disconnect.
+
+**Status:** Approved design, ready for implementation plan.
+
+**Date:** 2026-04-23
+
+## Problem
+
+`matches.state = 'in_progress'` records accumulate indefinitely in the database when both players leave without the match ever finalising. Symptoms:
+
+- Lobby stats strip shows phantom "7 players in match" counts with no one actually online.
+- Affected `players` rows stay stuck at `status = 'in_match'`, blocking matchmaking for those accounts on return.
+- Existing recovery (`healStuckInMatchStatus`) only runs when the stuck player themselves reopens the lobby — it cannot resolve an unowned orphan.
+
+The Phase 6 disconnect flow (`DisconnectionModal` + `claimWinAction`) handles the case where one player is *still present* to claim the win, but it depends on an in-memory `setTimeout` that does not survive serverless invocation boundaries, and it does nothing when both players are gone.
+
+## Goals
+
+- No more phantom "in match" records in the lobby count.
+- Orphaned matches (neither player has a live presence) auto-finalise as abandoned without manual intervention.
+- Keep the Phase 6 live-disconnect UX unchanged — the sweep is additive housekeeping.
+- Reuse existing match-completion infrastructure (`completeMatchInternal`) so status resets, broadcasts, and rating rules stay single-sourced.
+
+## Non-goals
+
+- Lowering Phase 6's 90-second modal window. That UX is for a live opponent and is out of scope.
+- Literal 15-second detection. The issue's "15 seconds" is treated as intent ("fast enough"), not a hard SLA. Effective sweep window equals the presence TTL (default 5 minutes) plus up to 30s pg_cron lag. This can be tightened later by lowering `PLAYTEST_PRESENCE_TTL_SECONDS`.
+- Changes to `lobby_presence` stale-row retention — query-time filtering already hides them.
+
+## Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Phase 6 (90s, live) + sweep (orphans only) coexist as distinct flows. | Different failure modes — live opponent vs both gone. Shared threshold would compromise both. |
+| 2 | Sweep runs on Supabase `pg_cron`. | Runs regardless of traffic. No new infra beyond enabling the extension. Project is on Supabase Cloud. |
+| 3 | Orphan condition: `matches.state = 'in_progress'` AND neither player has `lobby_presence.expires_at > now()`. | Single source of truth, directly matches the reported symptom. |
+| 4 | Sweep outcome: `state = 'completed'`, `ended_reason = 'abandoned'`, `winner_id = NULL`, no Elo write, both players' `status` reset to `available`. | Both players vanished — no reliable signal for "who should have won." Don't move ratings on ambiguous data. |
+| 5 | Implementation: TypeScript route `app/api/cron/sweep-stale-matches` that reuses `completeMatchInternal`; pg_cron invokes it via `net.http_post` with a shared secret. | Keeps completion logic single-sourced. Latency isn't critical. Secret-gated HTTP mirrors existing Vercel-cron conventions. |
+
+## Architecture
+
+Two independent mechanisms cover distinct failure modes:
+
+| Mechanism | Scope | Threshold | Status |
+|---|---|---|---|
+| Phase 6 `DisconnectionModal` + `claimWinAction` | Live match; one player present, one gone | 90s countdown (UX) | Already shipped |
+| **Orphan-match sweep (this design)** | Both players have no live presence | ~5min effective (presence TTL + 30s cron) | New |
+
+## Components
+
+### SQL / migration
+
+`supabase/migrations/20260423001_sweep_stale_matches.sql`:
+
+1. `CREATE EXTENSION IF NOT EXISTS pg_cron;` and `pg_net;` (idempotent).
+2. `CREATE OR REPLACE FUNCTION public.find_orphaned_matches() RETURNS SETOF uuid` — returns match ids where `state = 'in_progress'` AND no `lobby_presence` row exists for either player with `expires_at > now()`.
+3. `SELECT cron.schedule('sweep-stale-matches', '*/30 * * * * *', $$ SELECT net.http_post(url := current_setting('app.app_url') || '/api/cron/sweep-stale-matches', headers := jsonb_build_object('Authorization', 'Bearer ' || current_setting('app.cron_secret'), 'Content-Type', 'application/json'), body := '{}'::jsonb) $$);` — schedule every 30 seconds.
+4. `matches.ended_reason` CHECK constraint already accepts `'abandoned'` (verified against `20251115001_playtest.sql`); no schema change needed.
+
+`app.app_url` and `app.cron_secret` are set via `ALTER DATABASE postgres SET app.app_url = '…';` in Supabase Cloud so the schedule body doesn't bake in environment-specific values.
+
+### TypeScript — sweep route
+
+`app/api/cron/sweep-stale-matches/route.ts`:
+
+- `POST` handler.
+- Compares `request.headers.get('authorization')` against `Bearer ${process.env.CRON_SECRET}`; returns 401 on mismatch.
+- Calls `findOrphanedMatches()` → `string[]`.
+- Runs `Promise.allSettled(ids.map(id => completeMatchInternal(id, 'abandoned', null)))`.
+- Returns `200 { swept: string[], failed: Array<{ matchId: string; error: string }> }`.
+- Structured log: `{ event: 'sweep_stale_matches', swept_count, failed_count, duration_ms }`.
+
+### TypeScript — query helper
+
+`lib/match/findOrphanedMatches.ts`:
+
+```ts
+export async function findOrphanedMatches(): Promise<string[]>
+```
+
+Implementation: `supabase.rpc('find_orphaned_matches')` → map rows to ids. Left-anti-join is cleanest in SQL; this avoids an N+1 from the TypeScript side.
+
+### Reused, unchanged
+
+- `completeMatchInternal(matchId, endedReason, forcedWinnerId)` — passing `'abandoned'` + `null` leaves `winner_id` null, skips the `match_ratings` write, triggers `resetPlayerStatuses(both)`, and broadcasts the match-completed event.
+- `resetPlayerStatuses` — already called inside `completeMatchInternal`.
+
+### Not changed
+
+- `app/actions/match/handleDisconnect.ts`, `claimWin.ts`, `DisconnectionModal`, `useCountdown` — Phase 6 keeps its 90s live-disconnect flow.
+- `app/api/lobby/stats/matches-in-progress/route.ts` and `fetchLobbySnapshot` — naturally return correct numbers once orphans flip to `'completed'`.
+
+## Data Flow
+
+```
+pg_cron tick (every 30s)
+   │
+   └─► net.http_post → POST /api/cron/sweep-stale-matches
+            │  Authorization: Bearer ${cron_secret}
+            │
+            ├─► verify secret → 401 on mismatch
+            │
+            ├─► supabase.rpc('find_orphaned_matches')
+            │       │
+            │       └─ SQL: SELECT m.id FROM matches m
+            │               WHERE m.state = 'in_progress'
+            │                 AND NOT EXISTS (
+            │                   SELECT 1 FROM lobby_presence lp
+            │                   WHERE lp.player_id IN (m.player_a_id, m.player_b_id)
+            │                     AND lp.expires_at > now()
+            │                 );
+            │
+            ├─► for each matchId (Promise.allSettled):
+            │       completeMatchInternal(matchId, 'abandoned', null)
+            │           ├─ matches.state = 'completed'
+            │           ├─ matches.ended_reason = 'abandoned'
+            │           ├─ matches.winner_id = NULL
+            │           ├─ matches.completed_at = now()
+            │           ├─ resetPlayerStatuses(both) → players.status = 'available'
+            │           ├─ skip match_ratings write (no winner)
+            │           └─ broadcast match-completed event (best-effort)
+            │
+            └─► 200 { swept: [ids], failed: [{matchId, error}] }
+```
+
+The Phase 6 path is unchanged and runs in parallel. If its in-memory `setTimeout` misses (e.g., serverless recycled the process), the sweep eventually catches the match once the remaining player's presence also expires.
+
+## Error Handling
+
+| Failure | Behaviour | Why |
+|---|---|---|
+| `find_orphaned_matches` RPC errors | Log + return 500; pg_cron retries on next tick (30s later). | Transient DB errors shouldn't poison the sweep. |
+| `completeMatchInternal` throws for one match | `Promise.allSettled` captures it; sweep continues; failure reported in `failed[]`. | One bad match shouldn't block cleanup of the rest. |
+| Same match swept twice (race with Phase 6) | `completeMatchInternal` guards on `state` — if not `'in_progress'`, it no-ops. Idempotent. | pg_cron + Phase 6 can fire concurrently. |
+| Missing `CRON_SECRET` env var | Route returns 500 on first invocation; production deploy gate catches it. | Loud failure beats silent bypass. |
+| `pg_net.http_post` fails (network blip) | pg_cron logs to `cron.job_run_details`; next tick fires 30s later. | No retry needed at our layer. |
+| `pg_cron` / `pg_net` not available in target environment | Migration fails loudly during `pnpm supabase:migrate`. | Caught in CI / pre-deploy, not at runtime. |
+| Local dev (no pg_cron in local image) | Migration creates the SQL function unconditionally; the `cron.schedule` call is wrapped in a `DO $$ BEGIN … EXCEPTION … $$` guard so absence of pg_cron does not break `pnpm quickstart`. Integration tests invoke the RPC and the route directly. | Local dev must stay frictionless. |
+
+**Observability:**
+
+- Sweep route: structured JSON log per invocation with counts and duration.
+- Per-match completion: existing `completeMatchInternal` instrumentation.
+- pg_cron: `cron.job_run_details` gives visibility on schedule ticks and `net.http_post` exit statuses.
+
+## Testing
+
+| Test | Type | Location | Verifies |
+|---|---|---|---|
+| `findOrphanedMatches` RPC result mapping | Unit (RPC mocked) | `tests/unit/lib/match/findOrphanedMatches.test.ts` | Returns ids when both presence rows are absent/expired; excludes matches with one live presence; excludes `completed`/`pending` matches. |
+| Sweep route auths via `CRON_SECRET` | Integration | `tests/integration/api/sweepStaleMatches.spec.ts` | 401 without header / wrong header; 200 with valid header. |
+| Sweep route finalises orphans | Integration | same file | Seed 1 orphan + 1 live + 1 completed → only the orphan transitions to `completed` / `abandoned` / `winner_id=null`. |
+| Sweep route is idempotent and concurrent-safe | Integration | same file | Second call is a no-op; no `match_ratings` row inserted for abandoned matches. |
+| Sweep continues past per-match failures | Unit | `tests/unit/api/sweepStaleMatches.test.ts` | Mock `completeMatchInternal` to throw for one id; others still finalise; response body lists `failed[]`. |
+| `completeMatchInternal('abandoned', null)` resets statuses, skips Elo | Unit (extends existing) | `tests/unit/app/actions/completeMatch.test.ts` | `players.status='available'` for both; no `match_ratings` insert. |
+| RPC SQL function behaves correctly against live DB | Integration (real DB) | `tests/integration/db/sweepRpc.spec.ts` | Direct `.rpc('find_orphaned_matches')` returns expected rows across seeded scenarios. |
+| Lobby `matches-in-progress` count drops after sweep | Integration (extend) | `tests/integration/api/lobbyStats.spec.ts` | Insert orphan match → count = 1; run sweep → count = 0. |
+
+**Not tested:**
+
+- pg_cron schedule firing itself (Postgres-internal; `cron.job_run_details` covers it in production).
+- Full Phase 6 ↔ sweep race in E2E — covered logically by the idempotency unit test.
+
+## Rollout
+
+1. Land migration + route + tests in one PR.
+2. Set `CRON_SECRET` in Vercel env and `app.cron_secret` + `app.app_url` in Supabase Cloud (`ALTER DATABASE ...`). Document both in README under "Environment Variables".
+3. After deploy, confirm `cron.job_run_details` shows 200 responses and `swept_count` matches expectations.
+4. Follow-up (separate PR): consider lowering `PLAYTEST_PRESENCE_TTL_SECONDS` from 300 → 60 to tighten the effective sweep window closer to the issue's 15s intuition, with matching heartbeat-interval review.
+
+## Open questions / follow-ups
+
+- Should `healStuckInMatchStatus` be deprecated once the sweep is live? Current answer: keep it as a defensive fast-path on lobby load. Revisit after two weeks of sweep telemetry.
+- Should we expose a dashboard metric on `swept_count` for regression tracking? Out of scope for this PR; add when observability work lands.

--- a/lib/match/findOrphanedMatches.ts
+++ b/lib/match/findOrphanedMatches.ts
@@ -1,0 +1,12 @@
+import { getServiceRoleClient } from "@/lib/supabase/server";
+
+export async function findOrphanedMatches(): Promise<string[]> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase.rpc("find_orphaned_matches");
+
+  if (error) {
+    throw new Error(`find_orphaned_matches failed: ${error.message}`);
+  }
+
+  return (data as string[] | null) ?? [];
+}

--- a/lib/types/match.ts
+++ b/lib/types/match.ts
@@ -38,6 +38,7 @@ export type MatchEndedReason =
   | "timeout"
   | "disconnect"
   | "forfeit"
+  | "abandoned"
   | "error";
 
 export type ClockCheckResult = { allowed: true } | { allowed: false; remainingMs: number };

--- a/supabase/migrations/20260423001_sweep_stale_matches.sql
+++ b/supabase/migrations/20260423001_sweep_stale_matches.sql
@@ -1,0 +1,79 @@
+-- Stale "in match" cleanup (issue #180).
+-- Adds 'abandoned' to matches.ended_reason, ships the SQL fn used by
+-- the /api/cron/sweep-stale-matches route, and (where pg_cron is
+-- available) schedules the sweep every 30 seconds via pg_net.
+-- pg_cron + pg_net are Supabase Cloud features; the schedule block is
+-- guarded so local Supabase (no pg_cron) does not break migrations.
+
+-- 1. Extend matches.ended_reason CHECK to allow 'abandoned'.
+alter table public.matches
+  drop constraint if exists matches_ended_reason_check;
+
+alter table public.matches
+  add constraint matches_ended_reason_check
+  check (
+    ended_reason is null
+    or ended_reason in (
+      'round_limit',
+      'timeout',
+      'disconnect',
+      'forfeit',
+      'draw',
+      'abandoned'
+    )
+  );
+
+-- 2. find_orphaned_matches() — returns ids of in_progress matches where
+--    neither player has a live lobby_presence row.
+create or replace function public.find_orphaned_matches()
+returns setof uuid
+language sql
+stable
+as $$
+  select m.id
+  from public.matches m
+  where m.state = 'in_progress'
+    and not exists (
+      select 1
+      from public.lobby_presence lp
+      where lp.player_id in (m.player_a_id, m.player_b_id)
+        and lp.expires_at > now()
+    );
+$$;
+
+comment on function public.find_orphaned_matches() is
+  'Issue #180: matches stuck in_progress with no live presence for either player. Consumed by /api/cron/sweep-stale-matches.';
+
+-- 3. Schedule the sweep — guarded so local environments without
+--    pg_cron/pg_net do not fail. Production Supabase Cloud has both.
+do $$
+begin
+  create extension if not exists pg_cron;
+  create extension if not exists pg_net;
+
+  -- Unschedule any prior version (idempotent re-runs).
+  perform cron.unschedule(jobid)
+    from cron.job
+    where jobname = 'sweep-stale-matches';
+
+  perform cron.schedule(
+    'sweep-stale-matches',
+    '*/30 * * * * *',
+    $cron$
+      select net.http_post(
+        url := current_setting('app.app_url', true) || '/api/cron/sweep-stale-matches',
+        headers := jsonb_build_object(
+          'Authorization', 'Bearer ' || current_setting('app.cron_secret', true),
+          'Content-Type', 'application/json'
+        ),
+        body := '{}'::jsonb
+      );
+    $cron$
+  );
+exception
+  when undefined_file then
+    raise notice 'pg_cron/pg_net unavailable in this environment; skipping schedule. Function find_orphaned_matches() is still available for direct invocation.';
+  when others then
+    raise notice 'pg_cron schedule skipped: %', sqlerrm;
+end;
+$$;

--- a/tests/unit/app/actions/completeMatchAbandoned.test.ts
+++ b/tests/unit/app/actions/completeMatchAbandoned.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({ getServiceRoleClient: vi.fn() }));
+vi.mock("@/lib/match/statePublisher", () => ({
+  publishMatchState: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/match/logWriter", () => ({
+  writeMatchLog: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/observability/log", () => ({
+  trackMatchResult: vi.fn(),
+}));
+vi.mock("@/lib/rating/persistRatingChanges", () => ({
+  persistRatingChanges: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { completeMatchInternal } from "@/app/actions/match/completeMatch";
+import { persistRatingChanges } from "@/lib/rating/persistRatingChanges";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+
+const MATCH_ID = "00000000-0000-0000-0000-000000000099";
+const PLAYER_A = "player-a-id";
+const PLAYER_B = "player-b-id";
+
+interface MockState {
+  match: {
+    id: string;
+    state: string;
+    player_a_id: string;
+    player_b_id: string;
+    winner_id: string | null;
+    ended_reason: string | null;
+    round_limit: number;
+    frozen_tiles: Record<string, unknown> | null;
+  };
+  matchUpdatePayloads: Record<string, unknown>[];
+}
+
+function buildSupabase(state: MockState) {
+  const matchesUpdateChain = {
+    eq: vi.fn().mockResolvedValue({ error: null }),
+  };
+  const matchesUpdate = vi.fn((payload: Record<string, unknown>) => {
+    state.matchUpdatePayloads.push(payload);
+    return matchesUpdateChain;
+  });
+
+  const matchesSelectSingle = vi
+    .fn()
+    .mockResolvedValue({ data: state.match, error: null });
+  const matchesSelectEq = vi.fn(() => ({ single: matchesSelectSingle }));
+  const matchesSelect = vi.fn(() => ({ eq: matchesSelectEq }));
+
+  const scoreboardMaybeSingle = vi
+    .fn()
+    .mockResolvedValue({ data: null, error: null });
+  const scoreboardLimit = vi.fn(() => ({ maybeSingle: scoreboardMaybeSingle }));
+  const scoreboardOrder = vi.fn(() => ({ limit: scoreboardLimit }));
+  const scoreboardEq = vi.fn(() => ({ order: scoreboardOrder }));
+  const scoreboardSelect = vi.fn(() => ({ eq: scoreboardEq }));
+
+  const playersUpdateChain = {
+    in: vi.fn().mockResolvedValue({ error: null }),
+  };
+  const playersUpdate = vi.fn(() => playersUpdateChain);
+
+  const presenceUpdateChain = {
+    in: vi.fn().mockResolvedValue({ error: null }),
+  };
+  const presenceUpdate = vi.fn(() => presenceUpdateChain);
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table === "matches") {
+        return { select: matchesSelect, update: matchesUpdate };
+      }
+      if (table === "scoreboard_snapshots") {
+        return { select: scoreboardSelect };
+      }
+      if (table === "players") {
+        return { update: playersUpdate };
+      }
+      if (table === "lobby_presence") {
+        return { update: presenceUpdate };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    }),
+  };
+}
+
+function freshState(): MockState {
+  return {
+    match: {
+      id: MATCH_ID,
+      state: "in_progress",
+      player_a_id: PLAYER_A,
+      player_b_id: PLAYER_B,
+      winner_id: null,
+      ended_reason: null,
+      round_limit: 10,
+      frozen_tiles: {},
+    },
+    matchUpdatePayloads: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("completeMatchInternal — abandoned reason", () => {
+  test("finalises a fresh in_progress match with winner_id=null", async () => {
+    const state = freshState();
+    vi.mocked(getServiceRoleClient).mockReturnValue(buildSupabase(state) as never);
+
+    const result = await completeMatchInternal(MATCH_ID, "abandoned");
+
+    expect(result.matchId).toBe(MATCH_ID);
+    expect(result.winnerId).toBeNull();
+    expect(result.loserId).toBeNull();
+    expect(result.endedReason).toBe("abandoned");
+    expect(state.matchUpdatePayloads).toHaveLength(1);
+    expect(state.matchUpdatePayloads[0]).toMatchObject({
+      state: "completed",
+      winner_id: null,
+      ended_reason: "abandoned",
+    });
+  });
+
+  test("does not write match_ratings for abandoned matches", async () => {
+    const state = freshState();
+    vi.mocked(getServiceRoleClient).mockReturnValue(buildSupabase(state) as never);
+
+    await completeMatchInternal(MATCH_ID, "abandoned");
+
+    expect(persistRatingChanges).not.toHaveBeenCalled();
+  });
+
+  test("short-circuits when match already completed with no winner", async () => {
+    const state = freshState();
+    state.match.state = "completed";
+    state.match.winner_id = null;
+    state.match.ended_reason = "abandoned";
+    vi.mocked(getServiceRoleClient).mockReturnValue(buildSupabase(state) as never);
+
+    const result = await completeMatchInternal(MATCH_ID, "abandoned");
+
+    expect(result.winnerId).toBeNull();
+    expect(result.endedReason).toBe("abandoned");
+    expect(state.matchUpdatePayloads).toHaveLength(0);
+    expect(persistRatingChanges).not.toHaveBeenCalled();
+  });
+
+  test("still short-circuits when match already completed with a winner", async () => {
+    const state = freshState();
+    state.match.state = "completed";
+    state.match.winner_id = PLAYER_A;
+    state.match.ended_reason = "round_limit";
+    vi.mocked(getServiceRoleClient).mockReturnValue(buildSupabase(state) as never);
+
+    const result = await completeMatchInternal(MATCH_ID, "abandoned");
+
+    expect(result.winnerId).toBe(PLAYER_A);
+    expect(result.endedReason).toBe("round_limit");
+    expect(state.matchUpdatePayloads).toHaveLength(0);
+  });
+});

--- a/tests/unit/app/api/sweepStaleMatches.test.ts
+++ b/tests/unit/app/api/sweepStaleMatches.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/match/findOrphanedMatches", () => ({
+  findOrphanedMatches: vi.fn(),
+}));
+
+vi.mock("@/app/actions/match/completeMatch", () => ({
+  completeMatchInternal: vi.fn(),
+}));
+
+import { POST } from "@/app/api/cron/sweep-stale-matches/route";
+import { completeMatchInternal } from "@/app/actions/match/completeMatch";
+import { findOrphanedMatches } from "@/lib/match/findOrphanedMatches";
+
+const ORIGINAL_SECRET = process.env.CRON_SECRET;
+
+function buildRequest(authHeader?: string): Request {
+  const headers = new Headers();
+  if (authHeader !== undefined) {
+    headers.set("authorization", authHeader);
+  }
+  return new Request("http://localhost/api/cron/sweep-stale-matches", {
+    method: "POST",
+    headers,
+    body: "{}",
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.CRON_SECRET = "test-secret";
+});
+
+afterEach(() => {
+  if (ORIGINAL_SECRET === undefined) {
+    delete process.env.CRON_SECRET;
+  } else {
+    process.env.CRON_SECRET = ORIGINAL_SECRET;
+  }
+});
+
+describe("POST /api/cron/sweep-stale-matches", () => {
+  test("returns 401 when authorization header is missing", async () => {
+    const res = await POST(buildRequest());
+
+    expect(res.status).toBe(401);
+    expect(findOrphanedMatches).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when bearer token mismatches", async () => {
+    const res = await POST(buildRequest("Bearer wrong"));
+
+    expect(res.status).toBe(401);
+    expect(findOrphanedMatches).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 when CRON_SECRET is unset", async () => {
+    delete process.env.CRON_SECRET;
+
+    const res = await POST(buildRequest("Bearer anything"));
+
+    expect(res.status).toBe(500);
+    expect(findOrphanedMatches).not.toHaveBeenCalled();
+  });
+
+  test("returns 200 with empty result when there are no orphans", async () => {
+    vi.mocked(findOrphanedMatches).mockResolvedValue([]);
+
+    const res = await POST(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ swept: [], failed: [] });
+    expect(completeMatchInternal).not.toHaveBeenCalled();
+  });
+
+  test("finalises every orphan match", async () => {
+    vi.mocked(findOrphanedMatches).mockResolvedValue(["m-1", "m-2"]);
+    vi.mocked(completeMatchInternal).mockResolvedValue({} as never);
+
+    const res = await POST(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(completeMatchInternal).toHaveBeenCalledTimes(2);
+    expect(completeMatchInternal).toHaveBeenCalledWith("m-1", "abandoned");
+    expect(completeMatchInternal).toHaveBeenCalledWith("m-2", "abandoned");
+    expect(body.swept).toEqual(["m-1", "m-2"]);
+    expect(body.failed).toEqual([]);
+  });
+
+  test("continues past per-match failures and reports them", async () => {
+    vi.mocked(findOrphanedMatches).mockResolvedValue(["m-ok", "m-bad", "m-ok-2"]);
+    vi.mocked(completeMatchInternal).mockImplementation(async (id: string) => {
+      if (id === "m-bad") throw new Error("boom");
+      return {} as never;
+    });
+
+    const res = await POST(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.swept).toEqual(["m-ok", "m-ok-2"]);
+    expect(body.failed).toHaveLength(1);
+    expect(body.failed[0]).toEqual({ matchId: "m-bad", error: "boom" });
+  });
+
+  test("returns 500 when find_orphaned_matches throws", async () => {
+    vi.mocked(findOrphanedMatches).mockRejectedValue(new Error("rpc down"));
+
+    const res = await POST(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toMatch(/rpc down/);
+  });
+});

--- a/tests/unit/lib/match/findOrphanedMatches.test.ts
+++ b/tests/unit/lib/match/findOrphanedMatches.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+import { findOrphanedMatches } from "@/lib/match/findOrphanedMatches";
+import { getServiceRoleClient } from "@/lib/supabase/server";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("findOrphanedMatches", () => {
+  test("returns ids returned by the SQL function", async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: ["match-1", "match-2"],
+      error: null,
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue({ rpc } as never);
+
+    const result = await findOrphanedMatches();
+
+    expect(rpc).toHaveBeenCalledWith("find_orphaned_matches");
+    expect(result).toEqual(["match-1", "match-2"]);
+  });
+
+  test("returns empty array when no orphans exist", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+    vi.mocked(getServiceRoleClient).mockReturnValue({ rpc } as never);
+
+    expect(await findOrphanedMatches()).toEqual([]);
+  });
+
+  test("returns empty array when RPC returns null data", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+    vi.mocked(getServiceRoleClient).mockReturnValue({ rpc } as never);
+
+    expect(await findOrphanedMatches()).toEqual([]);
+  });
+
+  test("throws when the RPC errors", async () => {
+    const rpc = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: "boom" } });
+    vi.mocked(getServiceRoleClient).mockReturnValue({ rpc } as never);
+
+    await expect(findOrphanedMatches()).rejects.toThrow(/boom/);
+  });
+});

--- a/tests/unit/lib/types/matchEndedReason.test.ts
+++ b/tests/unit/lib/types/matchEndedReason.test.ts
@@ -18,4 +18,8 @@ describe("MatchEndedReason type", () => {
   it("includes forfeit as a valid value", () => {
     expectTypeOf<"forfeit">().toMatchTypeOf<MatchEndedReason>();
   });
+
+  it("includes abandoned as a valid value", () => {
+    expectTypeOf<"abandoned">().toMatchTypeOf<MatchEndedReason>();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `find_orphaned_matches()` SQL function — returns `in_progress` matches with no live `lobby_presence` for either player.
- Adds `POST /api/cron/sweep-stale-matches` (gated by `CRON_SECRET`) that calls `completeMatchInternal(id, 'abandoned')` for each orphan via `Promise.allSettled`.
- Schedules pg_cron to invoke the route every 30s via `pg_net.http_post`. Schedule block is guarded so local Supabase migrations don't break.
- Strengthens `completeMatchInternal` idempotency for abandoned matches (null winner) and adds an abandoned-aware branch that skips Elo rating writes.
- Adds `'abandoned'` to `MatchEndedReason` union and the `matches.ended_reason` CHECK constraint.

Phase 6 live-disconnect flow (DisconnectionModal + claim-win) is unchanged. The sweep covers the orthogonal failure mode where **both** players have left without finalising.

Closes #180.

## Design + plan
- Spec: `docs/superpowers/specs/2026-04-23-stale-in-match-cleanup-design.md`
- Plan: `docs/superpowers/plans/2026-04-23-stale-in-match-cleanup.md`

## Verification
- Unit suite: 1014 passing, 0 failures.
- Integration suite: 42 passing, 0 failures.
- Migration applies cleanly locally; SQL function returned 244 rows on local DB (pre-existing phantom matches), proving the issue and the fix.
- `cron.job_run_details` will become the production observability hook.

## Deploy steps
1. Set `CRON_SECRET` in Vercel env (any random value).
2. In Supabase SQL editor:
   ```sql
   alter database postgres set app.app_url = 'https://wottle.example.com';
   alter database postgres set app.cron_secret = 'same-value-as-CRON_SECRET';
   ```
3. Tail \`select * from cron.job_run_details where jobname = 'sweep-stale-matches' order by start_time desc limit 5\` to confirm 200 responses.

## Test plan
- [ ] Re-run `pnpm test:unit` and `pnpm test:integration` in CI.
- [ ] After deploy: confirm lobby "players in match" count drops to reality.
- [ ] After deploy: confirm `cron.job_run_details` shows successful 30s ticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)