### PR TITLE
feat(match): shared-store heartbeat for disconnect safety net (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,6 +367,7 @@ RLS policies enforced on all tables: players, lobby_presence, matches, rounds, m
 - Player marked disconnected in match state (realtime broadcast)
 - Other player sees centered `DisconnectionModal` with 90s countdown + Claim win CTA (Phase 6)
 - Reconnection within 90s clears the flag; past 90s `claimWinAction` or the auto-finalise awards the non-disconnected player (forced-winner path on `completeMatchInternal`)
+- Detection has two layers: (1) fast path via `disconnectStore` (in-memory, populated by `pagehide`/`sendBeacon`, Realtime `system: CLOSED`, or `onOpponentLeave` presence leave); (2) shared-store safety net via `match_heartbeats` upserted on every `/api/match/[matchId]/state` poll — `loadMatchState` surfaces the stale player after `HEARTBEAT_STALE_MS` (10s) with a grace window for match launch (issue #164).
 
 ## Key Entities
 

--- a/app/api/match/[matchId]/state/route.ts
+++ b/app/api/match/[matchId]/state/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import { readLobbySession } from "@/lib/matchmaking/profile";
 import { loadMatchState } from "@/lib/match/stateLoader";
+import { recordHeartbeat } from "@/lib/match/heartbeatRepository";
 import { getServiceRoleClient } from "@/lib/supabase/server";
 
 const NO_CACHE_HEADERS = {
@@ -43,6 +44,11 @@ export async function GET(
       { status: 403, headers: NO_CACHE_HEADERS },
     );
   }
+
+  // Record the caller's liveness heartbeat on every poll (issue #164).
+  // Fire-and-forget so the state response doesn't wait on the upsert;
+  // recordHeartbeat swallows errors and logs them.
+  void recordHeartbeat(supabase, matchId, playerId);
 
   return NextResponse.json(state, { status: 200, headers: NO_CACHE_HEADERS });
 }

--- a/lib/match/heartbeatRepository.ts
+++ b/lib/match/heartbeatRepository.ts
@@ -1,0 +1,100 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+type AnyClient = SupabaseClient<any, any, any>;
+
+/**
+ * A player is considered disconnected when their last heartbeat is older
+ * than this threshold. The surviving client polls /state every ~2s, so the
+ * upper bound on modal latency is roughly HEARTBEAT_STALE_MS + 2s.
+ *
+ * The acceptance criterion in issue #164 is ≤15s, so 10s gives a healthy
+ * margin while avoiding false positives on transient network blips that
+ * recover within 5 missed polls.
+ */
+export const HEARTBEAT_STALE_MS = 10_000;
+
+/**
+ * Matches created in the last HEARTBEAT_STALE_MS are skipped entirely —
+ * both players' first poll may not have landed yet, and a missing
+ * heartbeat row is not a signal during that grace window.
+ */
+const GRACE_WINDOW_MS = HEARTBEAT_STALE_MS;
+
+export interface FindStaleParticipantOptions {
+  matchId: string;
+  playerAId: string;
+  playerBId: string;
+  matchCreatedAt: Date;
+  now?: Date;
+}
+
+/**
+ * Upsert the caller's heartbeat on every state poll. Keyed by
+ * (match_id, player_id) so concurrent polls from the same player
+ * collapse into a single row update.
+ */
+export async function recordHeartbeat(
+  client: AnyClient,
+  matchId: string,
+  playerId: string,
+): Promise<void> {
+  const { error } = await client
+    .from("match_heartbeats")
+    .upsert(
+      {
+        match_id: matchId,
+        player_id: playerId,
+        last_seen_at: new Date().toISOString(),
+      },
+      { onConflict: "match_id,player_id" },
+    );
+  if (error) {
+    // Non-fatal — heartbeats are a safety net, not a hard requirement for
+    // state delivery. Log and continue so the poll still returns the match
+    // snapshot to the caller.
+    console.warn("[heartbeat] recordHeartbeat failed:", error.message);
+  }
+}
+
+/**
+ * Returns the player id whose heartbeat has gone stale, or null when both
+ * participants are fresh (or the match is still inside the grace window).
+ *
+ * Called from `loadMatchState` on every poll — this is the fallback that
+ * detects network drops where neither `pagehide` → `sendBeacon` nor
+ * Realtime presence leave fired (issue #164).
+ */
+export async function findStaleParticipant(
+  client: AnyClient,
+  opts: FindStaleParticipantOptions,
+): Promise<string | null> {
+  const now = opts.now ?? new Date();
+
+  if (now.getTime() - opts.matchCreatedAt.getTime() < GRACE_WINDOW_MS) {
+    return null;
+  }
+
+  const { data, error } = await client
+    .from("match_heartbeats")
+    .select("player_id, last_seen_at")
+    .eq("match_id", opts.matchId);
+
+  if (error || !data) {
+    return null;
+  }
+
+  const lastSeenByPlayer = new Map<string, number>();
+  for (const row of data as Array<{ player_id: string; last_seen_at: string }>) {
+    lastSeenByPlayer.set(row.player_id, new Date(row.last_seen_at).getTime());
+  }
+
+  const threshold = now.getTime() - HEARTBEAT_STALE_MS;
+
+  for (const playerId of [opts.playerAId, opts.playerBId]) {
+    const lastSeen = lastSeenByPlayer.get(playerId);
+    if (lastSeen === undefined || lastSeen <= threshold) {
+      return playerId;
+    }
+  }
+  return null;
+}

--- a/lib/match/stateLoader.ts
+++ b/lib/match/stateLoader.ts
@@ -15,6 +15,7 @@ import type {
 import { generateBoard } from "@/scripts/supabase/generateBoard";
 import { computeElapsedMs, computeRemainingMs, isClockExpired } from "./clockEnforcer";
 import { getDisconnectRecord } from "./disconnectStore";
+import { findStaleParticipant } from "./heartbeatRepository";
 
 type AnyClient = SupabaseClient<any, any, any>;
 
@@ -300,7 +301,8 @@ export async function loadMatchState(
         player_a_timer_ms,
         player_b_timer_ms,
         frozen_tiles,
-        winner_id
+        winner_id,
+        created_at
       `,
     )
     .eq("id", matchId)
@@ -478,17 +480,38 @@ export async function loadMatchState(
     playerBStatus = "running";
   }
 
-  // Surface disconnect state in the polled snapshot. Sourced from
-  // `disconnectStore`, which is populated by `handlePlayerDisconnect` when the
-  // disconnecting client notifies us via sendBeacon, the Realtime `system:
-  // CLOSED` handler, or the surviving client's `onOpponentLeave` presence
-  // callback. The previous heartbeat-staleness fallback was removed in the
-  // hotfix for issue #161 — the per-process Map gave inconsistent results
-  // across serverless instances and produced flickering false positives.
-  const disconnectedPlayerId =
+  // Surface disconnect state in the polled snapshot. Two sources are
+  // consulted in order:
+  //   1. `disconnectStore` — in-memory, populated by `handlePlayerDisconnect`
+  //      when the disconnecting client notifies us via `sendBeacon`, the
+  //      Realtime `system: CLOSED` handler, or the surviving client's
+  //      `onOpponentLeave` presence callback. Fast path for the common
+  //      tab-close / resign-connection cases.
+  //   2. `match_heartbeats` — shared-store fallback (issue #164). Every
+  //      /state poll upserts the caller's row; a participant with a
+  //      heartbeat older than HEARTBEAT_STALE_MS is marked disconnected.
+  //      Catches the case where the network dropped without firing any of
+  //      the signals above and is instance-independent on Vercel.
+  //
+  // The previous in-memory heartbeat was per-process and false-positived
+  // on Vercel multi-instance (issue #161 / #163 hotfix). The shared
+  // Postgres row resolves that.
+  const inMemoryDisconnect =
     getDisconnectRecord(match.id, match.player_a_id)?.playerId ??
     getDisconnectRecord(match.id, match.player_b_id)?.playerId ??
     null;
+
+  const staleFromHeartbeat =
+    match.state === "in_progress" && (match as { created_at?: string }).created_at
+      ? await findStaleParticipant(client, {
+          matchId: match.id,
+          playerAId: match.player_a_id,
+          playerBId: match.player_b_id,
+          matchCreatedAt: new Date((match as { created_at: string }).created_at),
+        })
+      : null;
+
+  const disconnectedPlayerId = inMemoryDisconnect ?? staleFromHeartbeat;
 
   return {
     matchId: match.id,

--- a/scripts/supabase/policies/check.ts
+++ b/scripts/supabase/policies/check.ts
@@ -25,6 +25,7 @@ const TABLES = [
   "word_score_entries",
   "scoreboard_snapshots",
   "match_logs",
+  "match_heartbeats",
 ];
 
 async function fetchPolicies() {

--- a/scripts/supabase/verify.ts
+++ b/scripts/supabase/verify.ts
@@ -47,6 +47,7 @@ export async function verifySupabase(options: VerifyOptions = {}): Promise<Verif
         supabase.from("rounds").select("id").limit(1),
         supabase.from("move_submissions").select("id").limit(1),
         supabase.from("match_logs").select("id").limit(1),
+        supabase.from("match_heartbeats").select("match_id").limit(1),
       ]);
 
       const failed = checks.find((result) => result.error);

--- a/supabase/migrations/20260423001_match_heartbeats.sql
+++ b/supabase/migrations/20260423001_match_heartbeats.sql
@@ -1,0 +1,39 @@
+-- match_heartbeats: per-player liveness tracker for the disconnect safety
+-- net (issue #164). Upserted on every /api/match/[matchId]/state poll
+-- (~2s cadence). `loadMatchState` surfaces `disconnectedPlayerId` when the
+-- opponent's `last_seen_at` falls behind HEARTBEAT_STALE_MS in code.
+--
+-- Why Postgres instead of an in-memory Map (see issue #161/#163 post-mortem):
+-- per-process state on Vercel's multi-instance serverless runtime gave each
+-- instance only a partial view of peer activity and caused false-positive
+-- disconnect modals during normal play. A shared row is authoritative for
+-- every request that lands in the state endpoint, regardless of which
+-- instance served it.
+
+CREATE TABLE IF NOT EXISTS public.match_heartbeats (
+  match_id uuid NOT NULL REFERENCES public.matches(id) ON DELETE CASCADE,
+  player_id uuid NOT NULL REFERENCES public.players(id) ON DELETE CASCADE,
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (match_id, player_id)
+);
+
+ALTER TABLE public.match_heartbeats ENABLE ROW LEVEL SECURITY;
+
+-- Participants may read heartbeats for their own matches. Writes go through
+-- service_role only (the /state API route upserts the caller's heartbeat
+-- after session verification).
+CREATE POLICY "match_heartbeats_select_participants"
+  ON public.match_heartbeats FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.matches m
+      WHERE m.id = match_id
+        AND (m.player_a_id = auth.uid() OR m.player_b_id = auth.uid())
+    )
+  );
+
+COMMENT ON TABLE public.match_heartbeats IS
+  'Per-player liveness heartbeat. Upserted on every /api/match/[matchId]/state '
+  'poll; loadMatchState flags a player as disconnected when last_seen_at '
+  'is older than HEARTBEAT_STALE_MS. Safety net for the case where '
+  'pagehide/sendBeacon and Realtime presence both fail to fire (issue #164).';

--- a/supabase/policies/policies.snapshot.json
+++ b/supabase/policies/policies.snapshot.json
@@ -1,4 +1,205 @@
 {
-  "generatedAt": "1970-01-01T00:00:00.000Z",
-  "policies": []
+  "generatedAt": "2026-04-23T18:39:37.557Z",
+  "policies": [
+    {
+      "schemaname": "public",
+      "tablename": "boards",
+      "policyname": "anon_read_boards",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "(auth.role() = 'anon'::text)",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "boards",
+      "policyname": "service_all_boards",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "ALL",
+      "qual": "(auth.role() = 'service_role'::text)",
+      "with_check": "(auth.role() = 'service_role'::text)"
+    },
+    {
+      "schemaname": "public",
+      "tablename": "lobby_presence",
+      "policyname": "lobby_presence_delete_own",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "DELETE",
+      "qual": "(player_id = auth.uid())",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "lobby_presence",
+      "policyname": "lobby_presence_insert_own",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "INSERT",
+      "qual": null,
+      "with_check": "(player_id = auth.uid())"
+    },
+    {
+      "schemaname": "public",
+      "tablename": "lobby_presence",
+      "policyname": "lobby_presence_select_authenticated",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "(auth.role() = 'authenticated'::text)",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "lobby_presence",
+      "policyname": "lobby_presence_update_own",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "UPDATE",
+      "qual": "(player_id = auth.uid())",
+      "with_check": "(player_id = auth.uid())"
+    },
+    {
+      "schemaname": "public",
+      "tablename": "match_heartbeats",
+      "policyname": "match_heartbeats_select_participants",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "(EXISTS ( SELECT 1\n   FROM matches m\n  WHERE ((m.id = match_heartbeats.match_id) AND ((m.player_a_id = auth.uid()) OR (m.player_b_id = auth.uid())))))",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "match_invitations",
+      "policyname": "match_invitations_insert_own",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "INSERT",
+      "qual": null,
+      "with_check": "(sender_id = auth.uid())"
+    },
+    {
+      "schemaname": "public",
+      "tablename": "match_invitations",
+      "policyname": "match_invitations_select_participants",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "((sender_id = auth.uid()) OR (recipient_id = auth.uid()))",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "match_invitations",
+      "policyname": "match_invitations_update_recipient",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "UPDATE",
+      "qual": "(recipient_id = auth.uid())",
+      "with_check": "(recipient_id = auth.uid())"
+    },
+    {
+      "schemaname": "public",
+      "tablename": "match_logs",
+      "policyname": "match_logs_select_participants",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "(EXISTS ( SELECT 1\n   FROM matches m\n  WHERE ((m.id = match_logs.match_id) AND ((m.player_a_id = auth.uid()) OR (m.player_b_id = auth.uid())))))",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "matches",
+      "policyname": "matches_select_participants",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "((player_a_id = auth.uid()) OR (player_b_id = auth.uid()))",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "move_submissions",
+      "policyname": "move_submissions_insert_own",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "INSERT",
+      "qual": null,
+      "with_check": "(player_id = auth.uid())"
+    },
+    {
+      "schemaname": "public",
+      "tablename": "move_submissions",
+      "policyname": "move_submissions_select_participants",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "(EXISTS ( SELECT 1\n   FROM (rounds r\n     JOIN matches m ON ((m.id = r.match_id)))\n  WHERE ((r.id = move_submissions.round_id) AND ((m.player_a_id = auth.uid()) OR (m.player_b_id = auth.uid())))))",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "moves",
+      "policyname": "service_all_moves",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "ALL",
+      "qual": "(auth.role() = 'service_role'::text)",
+      "with_check": "(auth.role() = 'service_role'::text)"
+    },
+    {
+      "schemaname": "public",
+      "tablename": "players",
+      "policyname": "players_select_authenticated",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "(auth.role() = 'authenticated'::text)",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "players",
+      "policyname": "players_update_own",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "UPDATE",
+      "qual": "(id = auth.uid())",
+      "with_check": "(id = auth.uid())"
+    },
+    {
+      "schemaname": "public",
+      "tablename": "rounds",
+      "policyname": "rounds_select_participants",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "(EXISTS ( SELECT 1\n   FROM matches m\n  WHERE ((m.id = rounds.match_id) AND ((m.player_a_id = auth.uid()) OR (m.player_b_id = auth.uid())))))",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "scoreboard_snapshots",
+      "policyname": "scoreboard_snapshots_select_participants",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "(EXISTS ( SELECT 1\n   FROM matches m\n  WHERE ((m.id = scoreboard_snapshots.match_id) AND ((m.player_a_id = auth.uid()) OR (m.player_b_id = auth.uid())))))",
+      "with_check": null
+    },
+    {
+      "schemaname": "public",
+      "tablename": "word_score_entries",
+      "policyname": "word_score_entries_select_participants",
+      "permissive": "PERMISSIVE",
+      "roles": "{public}",
+      "cmd": "SELECT",
+      "qual": "(EXISTS ( SELECT 1\n   FROM matches m\n  WHERE ((m.id = word_score_entries.match_id) AND ((m.player_a_id = auth.uid()) OR (m.player_b_id = auth.uid())))))",
+      "with_check": null
+    }
+  ]
 }

--- a/tests/unit/lib/match/heartbeatRepository.test.ts
+++ b/tests/unit/lib/match/heartbeatRepository.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import {
+  HEARTBEAT_STALE_MS,
+  recordHeartbeat,
+  findStaleParticipant,
+} from "@/lib/match/heartbeatRepository";
+
+const MATCH_ID = "11111111-1111-1111-1111-111111111111";
+const PLAYER_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const PLAYER_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+function makeSelectClient(rows: Array<{ player_id: string; last_seen_at: string }>) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => Promise.resolve({ data: rows, error: null })),
+      })),
+    })),
+  };
+}
+
+function makeUpsertClient() {
+  const upsert = vi.fn().mockResolvedValue({ error: null });
+  return {
+    upsert,
+    client: {
+      from: vi.fn(() => ({ upsert })),
+    },
+  };
+}
+
+describe("heartbeatRepository", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-23T12:00:00Z"));
+  });
+
+  describe("recordHeartbeat", () => {
+    it("upserts the (matchId, playerId) row with last_seen_at set to now", async () => {
+      const { upsert, client } = makeUpsertClient();
+
+      await recordHeartbeat(client as never, MATCH_ID, PLAYER_A);
+
+      expect(upsert).toHaveBeenCalledWith(
+        {
+          match_id: MATCH_ID,
+          player_id: PLAYER_A,
+          last_seen_at: "2026-04-23T12:00:00.000Z",
+        },
+        { onConflict: "match_id,player_id" },
+      );
+    });
+  });
+
+  describe("findStaleParticipant", () => {
+    it("returns null inside the grace window after match creation", async () => {
+      // Match is 5s old, threshold is 15s → within grace → no staleness check.
+      const matchCreatedAt = new Date("2026-04-23T11:59:55Z");
+      const client = makeSelectClient([]);
+
+      const stale = await findStaleParticipant(client as never, {
+        matchId: MATCH_ID,
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+        matchCreatedAt,
+      });
+
+      expect(stale).toBeNull();
+    });
+
+    it("flags a participant whose last_seen_at is older than the stale threshold", async () => {
+      const matchCreatedAt = new Date("2026-04-23T11:30:00Z");
+      const client = makeSelectClient([
+        { player_id: PLAYER_A, last_seen_at: "2026-04-23T11:59:58Z" }, // 2s ago — fresh
+        { player_id: PLAYER_B, last_seen_at: "2026-04-23T11:59:30Z" }, // 30s ago — stale
+      ]);
+
+      const stale = await findStaleParticipant(client as never, {
+        matchId: MATCH_ID,
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+        matchCreatedAt,
+      });
+
+      expect(stale).toBe(PLAYER_B);
+    });
+
+    it("flags a participant with no heartbeat row once past the grace window", async () => {
+      const matchCreatedAt = new Date("2026-04-23T11:30:00Z");
+      const client = makeSelectClient([
+        { player_id: PLAYER_A, last_seen_at: "2026-04-23T11:59:58Z" },
+      ]);
+
+      const stale = await findStaleParticipant(client as never, {
+        matchId: MATCH_ID,
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+        matchCreatedAt,
+      });
+
+      expect(stale).toBe(PLAYER_B);
+    });
+
+    it("returns null when both participants are fresh", async () => {
+      const matchCreatedAt = new Date("2026-04-23T11:30:00Z");
+      const client = makeSelectClient([
+        { player_id: PLAYER_A, last_seen_at: "2026-04-23T11:59:58Z" },
+        { player_id: PLAYER_B, last_seen_at: "2026-04-23T11:59:59Z" },
+      ]);
+
+      const stale = await findStaleParticipant(client as never, {
+        matchId: MATCH_ID,
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+        matchCreatedAt,
+      });
+
+      expect(stale).toBeNull();
+    });
+
+    it("returns player A when only A is stale", async () => {
+      const matchCreatedAt = new Date("2026-04-23T11:30:00Z");
+      const client = makeSelectClient([
+        { player_id: PLAYER_A, last_seen_at: "2026-04-23T11:59:30Z" },
+        { player_id: PLAYER_B, last_seen_at: "2026-04-23T11:59:58Z" },
+      ]);
+
+      const stale = await findStaleParticipant(client as never, {
+        matchId: MATCH_ID,
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+        matchCreatedAt,
+      });
+
+      expect(stale).toBe(PLAYER_A);
+    });
+
+    it("returns null on query error without throwing", async () => {
+      const matchCreatedAt = new Date("2026-04-23T11:30:00Z");
+      const client = {
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({
+            eq: vi.fn(() =>
+              Promise.resolve({ data: null, error: { message: "boom" } }),
+            ),
+          })),
+        })),
+      };
+
+      const stale = await findStaleParticipant(client as never, {
+        matchId: MATCH_ID,
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+        matchCreatedAt,
+      });
+
+      expect(stale).toBeNull();
+    });
+  });
+
+  it("exports HEARTBEAT_STALE_MS within the ≤15s acceptance criterion", () => {
+    // Acceptance: surviving client sees modal within ≤15s of network drop.
+    // Staleness + one 2s poll loop must stay under that.
+    expect(HEARTBEAT_STALE_MS).toBeLessThanOrEqual(13_000);
+    expect(HEARTBEAT_STALE_MS).toBeGreaterThanOrEqual(6_000);
+  });
+});

--- a/tests/unit/lib/match/stateLoader.test.ts
+++ b/tests/unit/lib/match/stateLoader.test.ts
@@ -33,10 +33,13 @@ type SubmissionFixture = {
     status?: string;
 };
 
+type HeartbeatFixture = { player_id: string; last_seen_at: string };
+
 function makeMockClient(
     matchData: Record<string, unknown>,
     roundData: Record<string, unknown> | null,
     submissionsData: SubmissionFixture[] | null = null,
+    heartbeatsData: HeartbeatFixture[] | null = null,
 ) {
     const matchChain = {
         eq: vi.fn().mockReturnThis(),
@@ -55,6 +58,11 @@ function makeMockClient(
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockResolvedValue(submissionsResponse),
     };
+    const heartbeatsResponse = { data: heartbeatsData ?? [], error: null };
+    const heartbeatsSelectChain = {
+        eq: vi.fn().mockResolvedValue(heartbeatsResponse),
+    };
+    const heartbeatsUpsert = vi.fn().mockResolvedValue({ error: null });
 
     return {
         from: vi.fn((table: string) => {
@@ -66,6 +74,10 @@ function makeMockClient(
             if (table === "move_submissions") return moveSubmissionsChain;
             if (table === "scoreboard_snapshots") return { select: vi.fn(() => scoreboardChain) };
             if (table === "word_score_entries") return { select: vi.fn(() => ({ eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: [], error: null }) })) };
+            if (table === "match_heartbeats") return {
+                select: vi.fn(() => heartbeatsSelectChain),
+                upsert: heartbeatsUpsert,
+            };
             return {
                 select: vi.fn(() => ({
                     eq: vi.fn().mockReturnThis(),
@@ -686,5 +698,161 @@ describe("stateLoader self-heal (stuck resolving / post-round / missing winner)"
         await new Promise((r) => setImmediate(r));
 
         expect(recoverStuckRound).not.toHaveBeenCalled();
+    });
+});
+
+describe("stateLoader heartbeat-based disconnect detection (issue #164)", () => {
+    const BOARD = Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A"));
+
+    beforeEach(() => {
+        vi.mocked(advanceRound).mockClear();
+        vi.mocked(recoverStuckRound).mockClear();
+        __resetSelfHealTrackerForTests();
+    });
+
+    it("surfaces the opponent as disconnectedPlayerId when their heartbeat is stale past the grace window", async () => {
+        const matchCreatedAt = new Date(Date.now() - 60_000);
+        const mockClient = makeMockClient(
+            {
+                id: MATCH_ID,
+                state: "in_progress",
+                current_round: 3,
+                board_seed: "seed-1",
+                player_a_id: PLAYER_A,
+                player_b_id: PLAYER_B,
+                player_a_timer_ms: 250_000,
+                player_b_timer_ms: 240_000,
+                winner_id: null,
+                frozen_tiles: {},
+                created_at: matchCreatedAt.toISOString(),
+            },
+            {
+                id: "round-3",
+                state: "collecting",
+                board_snapshot_before: BOARD,
+                board_snapshot_after: null,
+                started_at: new Date(Date.now() - 5_000).toISOString(),
+            },
+            null,
+            [
+                // Player A is live (1s ago); Player B went silent 30s ago.
+                { player_id: PLAYER_A, last_seen_at: new Date(Date.now() - 1_000).toISOString() },
+                { player_id: PLAYER_B, last_seen_at: new Date(Date.now() - 30_000).toISOString() },
+            ],
+        );
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        const state = await loadMatchState(mockClient as never, MATCH_ID);
+
+        expect(state!.disconnectedPlayerId).toBe(PLAYER_B);
+    });
+
+    it("does NOT surface a disconnected player when both heartbeats are fresh", async () => {
+        const matchCreatedAt = new Date(Date.now() - 60_000);
+        const mockClient = makeMockClient(
+            {
+                id: MATCH_ID,
+                state: "in_progress",
+                current_round: 3,
+                board_seed: "seed-1",
+                player_a_id: PLAYER_A,
+                player_b_id: PLAYER_B,
+                player_a_timer_ms: 250_000,
+                player_b_timer_ms: 240_000,
+                winner_id: null,
+                frozen_tiles: {},
+                created_at: matchCreatedAt.toISOString(),
+            },
+            {
+                id: "round-3",
+                state: "collecting",
+                board_snapshot_before: BOARD,
+                board_snapshot_after: null,
+                started_at: new Date(Date.now() - 5_000).toISOString(),
+            },
+            null,
+            [
+                { player_id: PLAYER_A, last_seen_at: new Date(Date.now() - 1_500).toISOString() },
+                { player_id: PLAYER_B, last_seen_at: new Date(Date.now() - 1_200).toISOString() },
+            ],
+        );
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        const state = await loadMatchState(mockClient as never, MATCH_ID);
+
+        expect(state!.disconnectedPlayerId).toBeNull();
+    });
+
+    it("does NOT flag missing heartbeats inside the grace window after match creation", async () => {
+        // Match is 2s old → both players may still be mid-first-poll. Avoid
+        // flickering a disconnect modal during the natural join latency.
+        const mockClient = makeMockClient(
+            {
+                id: MATCH_ID,
+                state: "in_progress",
+                current_round: 1,
+                board_seed: "seed-1",
+                player_a_id: PLAYER_A,
+                player_b_id: PLAYER_B,
+                player_a_timer_ms: 300_000,
+                player_b_timer_ms: 300_000,
+                winner_id: null,
+                frozen_tiles: {},
+                created_at: new Date(Date.now() - 2_000).toISOString(),
+            },
+            {
+                id: "round-1",
+                state: "collecting",
+                board_snapshot_before: BOARD,
+                board_snapshot_after: null,
+                started_at: new Date(Date.now() - 1_000).toISOString(),
+            },
+            null,
+            [],
+        );
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        const state = await loadMatchState(mockClient as never, MATCH_ID);
+
+        expect(state!.disconnectedPlayerId).toBeNull();
+    });
+
+    it("skips the heartbeat query for completed matches", async () => {
+        // No heartbeat read should happen once the match is over — completed
+        // matches don't poll anymore and a stale heartbeat would incorrectly
+        // flag the winner as disconnected on the post-game screen.
+        const mockClient = makeMockClient(
+            {
+                id: MATCH_ID,
+                state: "completed",
+                current_round: 11,
+                board_seed: "seed-1",
+                player_a_id: PLAYER_A,
+                player_b_id: PLAYER_B,
+                player_a_timer_ms: 10_000,
+                player_b_timer_ms: 0,
+                winner_id: PLAYER_A,
+                frozen_tiles: {},
+                created_at: new Date(Date.now() - 60_000).toISOString(),
+            },
+            {
+                id: "round-10",
+                state: "completed",
+                board_snapshot_before: BOARD,
+                board_snapshot_after: BOARD,
+                started_at: new Date(Date.now() - 30_000).toISOString(),
+                resolution_started_at: new Date(Date.now() - 25_000).toISOString(),
+            },
+            null,
+            [
+                // Even with a stale heartbeat on record, completed state wins.
+                { player_id: PLAYER_B, last_seen_at: new Date(Date.now() - 60_000).toISOString() },
+            ],
+        );
+        vi.mocked(getServiceRoleClient).mockReturnValue(mockClient as never);
+
+        const state = await loadMatchState(mockClient as never, MATCH_ID);
+
+        expect(state!.disconnectedPlayerId).toBeNull();
     });
 });

--- a/tests/unit/scripts/verify.test.ts
+++ b/tests/unit/scripts/verify.test.ts
@@ -87,6 +87,7 @@ describe("verifySupabase instrumentation", () => {
       "rounds",
       "move_submissions",
       "match_logs",
+      "match_heartbeats",
     ]);
     expect(stub.history.boardSelectColumns).toEqual(["board_id"]);
     expect(stub.history.boardSelectFilters).toEqual([


### PR DESCRIPTION
## Summary
Closes #164.

Reinstates the disconnect safety net that PR #163 (hotfix for #161) removed, backed by a Postgres row so every serverless instance sees the same liveness view. Before this, if \`pagehide\`/\`sendBeacon\`, Realtime presence \`onOpponentLeave\`, and Realtime \`system: CLOSED\` all missed (abrupt network drops, degraded WebSocket, etc.) the surviving player sat at a frozen board until their own clock ran out.

## Design

Two-layer disconnect detection:
1. **Fast path** — existing \`disconnectStore\` (in-memory), populated by \`pagehide\`/beacon/Realtime signals. Unchanged.
2. **Safety net (new)** — \`match_heartbeats\` table upserted on every \`/api/match/[matchId]/state\` poll. \`loadMatchState\` flags the stale player as \`disconnectedPlayerId\` when their row is older than \`HEARTBEAT_STALE_MS\` (10s), gated by a 10s grace window anchored on \`matches.created_at\` to avoid first-poll flicker. Skipped entirely for completed matches.

\`HEARTBEAT_STALE_MS = 10s\` + one 2s safety poll ≈ 12s worst-case → well inside the ≤15s acceptance criterion.

## Files
- **New:** \`supabase/migrations/20260423001_match_heartbeats.sql\` — table + RLS (participants-only SELECT; service_role writes).
- **New:** \`lib/match/heartbeatRepository.ts\` — \`recordHeartbeat\` + \`findStaleParticipant\`.
- **Modified:** \`app/api/match/[matchId]/state/route.ts\` — fire-and-forget heartbeat on every poll.
- **Modified:** \`lib/match/stateLoader.ts\` — consults heartbeats as fallback, also reads \`matches.created_at\` for the grace window.
- **Modified:** \`scripts/supabase/verify.ts\`, \`scripts/supabase/policies/check.ts\` — include new table in sweeps.
- **Modified:** \`CLAUDE.md\` — documents the two-layer model.

## Test plan
- [x] 12 new unit tests: repository read/write/staleness/grace/errors (8), stateLoader integration (4 — stale opponent surfaces, both-fresh doesn't, grace window suppresses, completed match skips), and the verify-script table sweep regression.
- [x] \`pnpm test\` — 1013 passing / 2 skipped.
- [x] \`supabase db reset\` — migration applies cleanly; \`pnpm supabase:verify\` returns healthy against the new table; \`pnpm supabase:policies\` snapshot records the new RLS policy.
- [x] Typecheck + lint clean.
- [ ] Existing Playwright \`disconnect-modal.spec.ts\` still passes (exercises the fast path via \`notifyServerOfDisconnect\`).
- [ ] Manual: in a two-player match, kill one browser's network (DevTools offline) without closing the tab; verify the modal appears on the other side within ~12s.

## Acceptance-criteria mapping (issue #164)
- [x] *Disconnect detection works regardless of which instance serves which client* — shared Postgres row is authoritative.
- [x] *≤15s from network drop to modal* — 10s stale threshold + 2s poll = ~12s worst case.
- [x] *No false positives on normal play* — 10s threshold spans 5 missed 2s polls; grace window prevents startup flash.
- [x] *Playwright spec reinstated* — spec was already in place; the new path is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)