### PR TITLE
chore(ci): free runner disk space before Docker load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,19 @@ jobs:
       - name: Capture CLI version for Docker cache key
         id: supabase-version
         run: echo "version=$(supabase --version)" >> $GITHUB_OUTPUT
+      - name: Free runner disk space
+        # ubuntu-latest ships with ~25 GB of pre-installed tools (Nix, .NET,
+        # Android SDK, GHC, Swift, CodeQL, Ruby/PyPy tool caches) that we
+        # don't use but that crowd the root volume. `docker load` extracts
+        # the Supabase image layers into /var/lib/docker and ran out of
+        # space mid-stream — reclaim ~20 GB before the load runs.
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/share/swift /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY/Ruby" "$AGENT_TOOLSDIRECTORY/PyPy" || true
+          sudo docker image prune -af || true
+          df -h /
       - name: Restore Supabase Docker image cache
         id: docker-cache
         uses: actions/cache@v5
@@ -180,7 +193,11 @@ jobs:
           key: supabase-docker-${{ runner.os }}-${{ steps.supabase-version.outputs.version }}
       - name: Load cached Docker images
         if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/supabase-docker-cache.tar
+        run: |
+          docker load -i /tmp/supabase-docker-cache.tar
+          # Drop the tarball once the images are in Docker's store so we
+          # don't carry ~3 GB on /tmp through the rest of the job.
+          rm -f /tmp/supabase-docker-cache.tar
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run quickstart automation
@@ -249,6 +266,19 @@ jobs:
       - name: Capture CLI version for Docker cache key
         id: supabase-version
         run: echo "version=$(supabase --version)" >> $GITHUB_OUTPUT
+      - name: Free runner disk space
+        # ubuntu-latest ships with ~25 GB of pre-installed tools (Nix, .NET,
+        # Android SDK, GHC, Swift, CodeQL, Ruby/PyPy tool caches) that we
+        # don't use but that crowd the root volume. `docker load` extracts
+        # the Supabase image layers into /var/lib/docker and ran out of
+        # space mid-stream — reclaim ~20 GB before the load runs.
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/share/swift /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY/Ruby" "$AGENT_TOOLSDIRECTORY/PyPy" || true
+          sudo docker image prune -af || true
+          df -h /
       - name: Restore Supabase Docker image cache
         id: docker-cache
         uses: actions/cache@v5
@@ -257,7 +287,11 @@ jobs:
           key: supabase-docker-${{ runner.os }}-${{ steps.supabase-version.outputs.version }}
       - name: Load cached Docker images
         if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/supabase-docker-cache.tar
+        run: |
+          docker load -i /tmp/supabase-docker-cache.tar
+          # Drop the tarball once the images are in Docker's store so we
+          # don't carry ~3 GB on /tmp through the rest of the job.
+          rm -f /tmp/supabase-docker-cache.tar
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Cache Playwright browsers
@@ -583,6 +617,19 @@ jobs:
       - name: Capture CLI version for Docker cache key
         id: supabase-version
         run: echo "version=$(supabase --version)" >> $GITHUB_OUTPUT
+      - name: Free runner disk space
+        # ubuntu-latest ships with ~25 GB of pre-installed tools (Nix, .NET,
+        # Android SDK, GHC, Swift, CodeQL, Ruby/PyPy tool caches) that we
+        # don't use but that crowd the root volume. `docker load` extracts
+        # the Supabase image layers into /var/lib/docker and ran out of
+        # space mid-stream — reclaim ~20 GB before the load runs.
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/share/swift /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY/Ruby" "$AGENT_TOOLSDIRECTORY/PyPy" || true
+          sudo docker image prune -af || true
+          df -h /
       - name: Restore Supabase Docker image cache
         id: docker-cache
         uses: actions/cache@v5
@@ -591,7 +638,11 @@ jobs:
           key: supabase-docker-${{ runner.os }}-${{ steps.supabase-version.outputs.version }}
       - name: Load cached Docker images
         if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/supabase-docker-cache.tar
+        run: |
+          docker load -i /tmp/supabase-docker-cache.tar
+          # Drop the tarball once the images are in Docker's store so we
+          # don't carry ~3 GB on /tmp through the rest of the job.
+          rm -f /tmp/supabase-docker-cache.tar
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Start Supabase stack via quickstart


### PR DESCRIPTION
## Problem
Playwright/perf jobs fail mid-CI with:

\`\`\`
write /nix/store/.../extensions.json: no space left on device
Error: Process completed with exit code 1.
\`\`\`

during \`docker load -i /tmp/supabase-docker-cache.tar\`. The \`/nix/store\` path is a red herring — it's just whichever file the kernel was writing when \`write()\` got \`ENOSPC\`. The real issue is that \`ubuntu-latest\` ships with ~25 GB of pre-installed tooling we don't use (Nix store, .NET, Android SDK, GHC, Swift, CodeQL, Ruby/PyPy tool caches), and Docker's layer extraction has no headroom on the root volume.

## Fix
Two changes, applied to all three docker-loading jobs (quickstart, playwright matrix, perf-gate):

1. **Free runner disk space** step inserted just before \`Restore Supabase Docker image cache\`. Removes unused tooling dirs + \`docker image prune -af\`. Best-effort (\`|| true\`) so a missing dir doesn't fail the job. Typically reclaims ~20 GB.
2. **Drop the cache tarball** after \`docker load\` succeeds so we don't carry the ~3 GB tarball on \`/tmp\` through the rest of the job.

## Test plan
- [x] \`actionlint\` clean on my changes (only pre-existing shellcheck info warnings in other steps).
- [ ] Re-run the failing CI job to confirm disk space is sufficient after the cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)