### PR TITLE
test: skip flaky matchmaking-phase-4b two-player pair test (#192)

### DIFF
--- a/tests/integration/ui/matchmaking-phase-4b.spec.ts
+++ b/tests/integration/ui/matchmaking-phase-4b.spec.ts
@@ -72,7 +72,10 @@ test.describe("@matchmaking Phase 4b matchmaking screen", () => {
     }
   });
 
-  test("two players matching navigate through found/starting into /match/:id", async ({
+  // Skipped — fails consistently on CI when a stale queue entry from the prior
+  // cancel-search test pairs with one of the two new players, leaving the other
+  // unpaired and timing out on `matchmaking-vs-block`. Tracked in #192.
+  test.fixme("two players matching navigate through found/starting into /match/:id", async ({
     browser,
   }) => {
     const ctxA = await browser.newContext();


### PR DESCRIPTION
## Summary
Wraps `tests/integration/ui/matchmaking-phase-4b.spec.ts:75 › two players matching navigate through found/starting into /match/:id` in \`test.fixme\` until #192 fixes the underlying matchmaking queue cleanup.

The test fails on 9 of the last 10 main CI runs (e.g. [run 24851721088](https://github.com/minniai/wottle/actions/runs/24851721088)). Root cause: a stale queue entry from the prior cancel-search test (line 48) sometimes pairs with one of the two new players, leaving the other unpaired and timing out on \`matchmaking-vs-block\`.

## Tracking
- Issue: #192 (proposes server-side queue cleanup, stronger cancellation, or per-test queue isolation)
- Comment in spec points future readers to the issue.

## Test plan
- [ ] CI green.
- [ ] Test 75 reported as skipped (not failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)