### PR TITLE
fix(summary): align player colors with design tokens (#196)

### DIFF
--- a/components/match/FinalSummary.tsx
+++ b/components/match/FinalSummary.tsx
@@ -140,9 +140,9 @@ function RatingDeltaDisplay({
   const sign = ratingDelta > 0 ? "+" : "";
   const color =
     ratingDelta > 0
-      ? "text-emerald-400"
+      ? "text-good"
       : ratingDelta < 0
-        ? "text-rose-400"
+        ? "text-bad"
         : "text-ink-soft";
 
   return (
@@ -191,7 +191,8 @@ export function FinalSummary({
   const playerA = players[0];
   const playerB = players[1];
 
-  // Determine slot-based colors: players[0] = player_a (blue), players[1] = player_b (red)
+  // Slot-based colors resolve to design tokens via lib/constants/playerColors:
+  // players[0] = player_a (warm ochre, --p1), players[1] = player_b (design blue, --p2).
   const currentIsPlayerA = currentPlayerId === playerA?.id;
   const currentPlayerColor = currentIsPlayerA ? PLAYER_A_HEX : PLAYER_B_HEX;
   const opponentColor = currentIsPlayerA ? PLAYER_B_HEX : PLAYER_A_HEX;

--- a/components/match/PostGameScoreboard.tsx
+++ b/components/match/PostGameScoreboard.tsx
@@ -1,4 +1,5 @@
 import { PlayerAvatar } from "@/components/match/PlayerAvatar";
+import { getPlayerColors } from "@/lib/constants/playerColors";
 
 type Slot = "player_a" | "player_b";
 
@@ -19,11 +20,6 @@ interface PostGameScoreboardProps {
   entries: [ScoreboardEntry, ScoreboardEntry];
 }
 
-const SLOT_COLOR_HEX: Record<Slot, string> = {
-  player_a: "oklch(0.68 0.14 60)",
-  player_b: "oklch(0.56 0.08 220)",
-};
-
 function ratingLabel(delta: number | undefined): string {
   if (delta === undefined) return "Rating pending";
   if (delta === 0) return "±0 rating";
@@ -37,6 +33,7 @@ function Card({ entry }: { entry: ScoreboardEntry }) {
     entry.slot === "player_a" ? "hud-card hud-card--you" : "hud-card hud-card--opp";
   const scoreClass =
     entry.slot === "player_a" ? "text-p1-deep" : "text-p2-deep";
+  const { hex: avatarColor } = getPlayerColors(entry.slot);
 
   return (
     <div
@@ -47,7 +44,7 @@ function Card({ entry }: { entry: ScoreboardEntry }) {
         <PlayerAvatar
           displayName={entry.displayName}
           avatarUrl={null}
-          playerColor={SLOT_COLOR_HEX[entry.slot]}
+          playerColor={avatarColor}
           size="md"
         />
         <div className="flex min-w-0 flex-col">

--- a/components/match/RoundByRoundChart.tsx
+++ b/components/match/RoundByRoundChart.tsx
@@ -60,7 +60,7 @@ export function RoundByRoundChart({
                   style={{ height: `${aH}px` }}
                 >
                   {row.playerADelta > 0 && aH >= LABEL_MIN_BAR_PX ? (
-                    <span className="absolute inset-x-0 top-0.5 text-center font-mono text-[9px] leading-none text-white/90">
+                    <span className="absolute inset-x-0 top-0.5 text-center font-mono text-[9px] leading-none text-ink/90">
                       {row.playerADelta}
                     </span>
                   ) : null}
@@ -77,7 +77,7 @@ export function RoundByRoundChart({
                   style={{ height: `${bH}px` }}
                 >
                   {row.playerBDelta > 0 && bH >= LABEL_MIN_BAR_PX ? (
-                    <span className="absolute inset-x-0 bottom-0.5 text-center font-mono text-[9px] leading-none text-white/90">
+                    <span className="absolute inset-x-0 bottom-0.5 text-center font-mono text-[9px] leading-none text-ink/90">
                       {row.playerBDelta}
                     </span>
                   ) : null}

--- a/lib/constants/playerColors.ts
+++ b/lib/constants/playerColors.ts
@@ -1,20 +1,26 @@
 import type { PlayerSlot } from "@/lib/types/match";
 
-// --- Hex base colors ---
-export const PLAYER_A_HEX = "#38BDF8"; // sky-400 (brighter blue for dark backgrounds)
-export const PLAYER_B_HEX = "#EF4444"; // red-500
+// Player slot colors — single source of truth, resolves to the OKLCH design
+// tokens defined in app/globals.css (--p1 = warm ochre / "player A",
+// --p2 = design blue / "player B"). String values are usable in inline styles
+// (`style={{ color }}`, `backgroundColor: playerColor`) where the browser
+// resolves the var at paint time. Keeping the var indirection means a future
+// theme flip retunes every player surface in one place.
 
-// --- Frozen tile overlays (40% opacity) ---
-export const PLAYER_A_OVERLAY = "rgba(56, 189, 248, 0.4)";
-export const PLAYER_B_OVERLAY = "rgba(239, 68, 68, 0.4)";
+export const PLAYER_A_HEX = "var(--p1)";
+export const PLAYER_B_HEX = "var(--p2)";
 
-// --- Scored tile highlights (60% opacity) ---
-export const PLAYER_A_HIGHLIGHT = "rgba(56, 189, 248, 0.6)";
-export const PLAYER_B_HIGHLIGHT = "rgba(239, 68, 68, 0.6)";
+// Frozen-tile overlays (40% alpha)
+export const PLAYER_A_OVERLAY = "oklch(0.68 0.14 60 / 0.4)";
+export const PLAYER_B_OVERLAY = "oklch(0.56 0.08 220 / 0.4)";
 
-// --- Both-player gradient (split diagonal) ---
+// Scored-tile highlights (60% alpha)
+export const PLAYER_A_HIGHLIGHT = "oklch(0.68 0.14 60 / 0.6)";
+export const PLAYER_B_HIGHLIGHT = "oklch(0.56 0.08 220 / 0.6)";
+
+// Both-player gradient (split diagonal) for shared / contested tiles
 export const BOTH_GRADIENT =
-  "linear-gradient(135deg, rgba(56, 189, 248, 0.4) 50%, rgba(239, 68, 68, 0.4) 50%)";
+  "linear-gradient(135deg, oklch(0.68 0.14 60 / 0.4) 50%, oklch(0.56 0.08 220 / 0.4) 50%)";
 
 export interface PlayerColorSet {
   hex: string;


### PR DESCRIPTION
## Summary

The Game Summary page rendered the same player in two different colors top-to-bottom (issue #196 screenshot):

- **Top of page** (HUD-style panels in \`FinalSummary\`) — \`player_a\` rendered in sky-blue, \`player_b\` in red, via the legacy \`PLAYER_A_HEX = "#38BDF8"\` / \`PLAYER_B_HEX = "#EF4444"\` constants (file comment: "for dark backgrounds").
- **Bottom of page** (\`PostGameScoreboard\` cards) — \`player_a\` in warm ochre, \`player_b\` in design blue, via inline OKLCH literals that match the \`--p1\` / \`--p2\` design tokens.

The Warm Editorial OKLCH token flip never reached \`lib/constants/playerColors.ts\`, so two palettes were live in parallel. The summary page is where they collide most visibly, but the same legacy palette also drove the in-match scored-tile glow and frozen-tile overlays.

## Approach

Single source of truth: \`lib/constants/playerColors.ts\` now resolves every player color to the OKLCH design tokens. CSS variables resolve at paint time in inline \`style\` props, so no consumer needed code changes — the constants change alone fixes the FinalSummary HUD panels.

### Files changed

| File | Change |
|---|---|
| \`lib/constants/playerColors.ts\` | \`PLAYER_A_HEX\` → \`var(--p1)\`, \`PLAYER_B_HEX\` → \`var(--p2)\`. OVERLAY / HIGHLIGHT / BOTH_GRADIENT switched from rgba sky-blue/red to OKLCH-with-alpha matching --p1 / --p2. |
| \`components/match/FinalSummary.tsx\` | Fixed misleading comment ("player_a (blue)" → "player_a (warm ochre, --p1)"). Swapped \`text-emerald-400\` / \`text-rose-400\` rating-delta colors for design-system \`text-good\` / \`text-bad\` (consistent with rest of file). |
| \`components/match/RoundByRoundChart.tsx\` | Per-bar delta labels were \`text-white/90\` — invisible on light-mode \`bg-p1\` / \`bg-p2\` bars. Now \`text-ink/90\`. |
| \`components/match/PostGameScoreboard.tsx\` | Dropped duplicated inline \`SLOT_COLOR_HEX\` constant; uses \`getPlayerColors(slot).hex\` so the palette can't drift again. |

## Verification

- \`pnpm typecheck\` ✅
- \`pnpm lint\` ✅
- \`pnpm test:unit\` — **1029 passed, 0 failures**

After this lands, every player color across the app reads from one palette:
- FinalSummary HUD panels ↔ frozen-tile overlays ↔ PostGameScoreboard cards ↔ in-match HUD all match.
- In-match scored-tile glow now matches the player's HUD-card stripe (was bright sky-blue / red, now warm ochre / design blue).
- RoundByRoundChart delta labels are legible.

## Test plan
- [ ] CI green
- [ ] Visual smoke on \`/match/[id]/summary\`: same player has the same color top-to-bottom (avatar, score, frozen-tile overlay, scoreboard card).
- [ ] In-match: scored-tile glow matches HUD card stripe color.

Closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)