### PR TITLE
fix(scoring): per-letter coverage rule for cross-word validation (#195)

### DIFF
--- a/lib/game-engine/crossValidator.ts
+++ b/lib/game-engine/crossValidator.ts
@@ -1,5 +1,5 @@
 import type { BoardGrid, BoardWord } from "@/lib/types/board";
-import type { FrozenTileMap, ScoredAxis } from "@/lib/types/match";
+import type { FrozenTileMap } from "@/lib/types/match";
 import { BOARD_SIZE } from "@/lib/constants/board";
 import { DEFAULT_GAME_CONFIG } from "@/lib/constants/game-config";
 import {
@@ -8,26 +8,56 @@ import {
 } from "./scorer";
 
 /**
- * Check whether a word creates an invalid perpendicular cross-word
- * with established tiles (frozen tiles + extra scored tiles).
+ * Does `runChars` contain a dictionary word of length >=
+ * `minLen` that includes the tile at `tileIdx`?
  *
- * For each tile in the word, the perpendicular direction is traced
- * through neighboring established positions.
+ * This is the per-letter coverage check: each letter of a
+ * newly-scored word must sit inside some valid sub-run in every
+ * direction where it has scored neighbors (issue #195).
+ */
+function runContainsValidSubRunCoveringIndex(
+  runChars: string[],
+  tileIdx: number,
+  dictionary: Set<string>,
+  minLen: number,
+): boolean {
+  const runLen = runChars.length;
+  if (runLen < minLen) return false;
+  for (let start = 0; start <= tileIdx; start++) {
+    const minEnd = Math.max(tileIdx + 1, start + minLen);
+    for (let end = minEnd; end <= runLen; end++) {
+      const sub = runChars
+        .slice(start, end)
+        .join("")
+        .normalize("NFC")
+        .toLowerCase();
+      if (dictionary.has(sub)) return true;
+      const rev = [...sub].reverse().join("");
+      if (dictionary.has(rev)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check whether a candidate word creates an invalid perpendicular
+ * scored run through any of its tiles.
  *
- * Rules (per PRD §1.2, minimumWordLength = 3):
- *   - cross length 1 → no perpendicular neighbor → no constraint.
- *   - cross length 2..(minimumWordLength-1) → below the minimum word
- *     length, inherently not a valid word → violation.
- *   - cross length >= minimumWordLength → must be in the dictionary
- *     (in either reading direction) → otherwise violation.
+ * Rule (issue #195): for each tile of the candidate, trace the
+ * maximal contiguous scored run on the cross-axis through that
+ * tile. Every frozen tile physically on the board counts, regardless
+ * of which axis it was originally scored on — this is about the
+ * physical board state, not metadata. The run is OK iff:
+ *   - length 1 (no scored neighbors), OR
+ *   - contains a dict-valid sub-run of length >= `minimumWordLength`
+ *     that includes this tile.
+ * A run of length 2..(minimumWordLength-1) is always a violation:
+ * it cannot contain any sub-run of length >= `minimumWordLength`.
  *
- * When `frozenTileMap` is provided, frozen tiles only participate in
- * the cross sequence if their `scoredAxes` includes the cross-axis. A
- * tile that was scored only on a parallel axis is treated as an
- * incidental adjacency, not an extension of a perpendicular word — so
- * it doesn't trigger the cross-word constraint. See issue #136.
- * Same-round `extraTileSet` tiles always count (they're still being
- * cross-validated mutually within the subset).
+ * Replaces the pre-#185 "combined run must itself be a dict word"
+ * rule (too strict — rejected BÆN/BÁS in #136) and the #185
+ * `scoredAxes`-based skip (too lenient — admitted "ML", "NÐ",
+ * "TKH", etc. in #195).
  */
 export function hasCrossWordViolation(
   board: BoardGrid,
@@ -35,27 +65,16 @@ export function hasCrossWordViolation(
   frozenTileSet: Set<string>,
   dictionary: Set<string>,
   extraTileSet: Set<string> = new Set(),
-  frozenTileMap?: FrozenTileMap,
 ): boolean {
   const { minimumWordLength } = DEFAULT_GAME_CONFIG;
   const isHorizontal =
     word.direction === "right" || word.direction === "left";
   const dx = isHorizontal ? 0 : 1;
   const dy = isHorizontal ? 1 : 0;
-  const crossAxis: ScoredAxis = isHorizontal ? "vertical" : "horizontal";
 
   const isEstablished = (x: number, y: number) => {
     const key = `${x},${y}`;
-    if (extraTileSet.has(key)) return true;
-    if (!frozenTileSet.has(key)) return false;
-    // When scoredAxes metadata is available, only count the frozen tile
-    // as established for the cross-axis if it was actually scored on
-    // that axis. Tiles without metadata (legacy) keep the strict
-    // behavior so existing matches don't change shape.
-    if (!frozenTileMap) return true;
-    const meta = frozenTileMap[key];
-    if (!meta || !meta.scoredAxes) return true;
-    return meta.scoredAxes.includes(crossAxis);
+    return extraTileSet.has(key) || frozenTileSet.has(key);
   };
 
   for (const tile of word.tiles) {
@@ -97,26 +116,22 @@ export function hasCrossWordViolation(
       fy += dy;
     }
 
-    const crossLength = beforeChars.length + 1 + afterChars.length;
-    if (crossLength === 1) continue; // no perpendicular neighbor — no cross-word
-    if (crossLength < minimumWordLength) {
-      // Any contiguous perpendicular sequence shorter than the minimum word
-      // length is inherently invalid: it cannot satisfy the 3-letter rule
-      // regardless of dictionary contents (PRD §1.2). Reject the placement.
-      return true;
-    }
-    const crossWord = [
+    const runChars = [
       ...beforeChars,
       board[tile.y][tile.x],
       ...afterChars,
-    ]
-      .join("")
-      .normalize("NFC")
-      .toLowerCase();
-    const crossWordReversed = [...crossWord].reverse().join("");
+    ];
+    const tileIdx = beforeChars.length;
+    const runLen = runChars.length;
+    if (runLen === 1) continue; // no scored neighbor — no constraint
+    if (runLen < minimumWordLength) return true;
     if (
-      !dictionary.has(crossWord) &&
-      !dictionary.has(crossWordReversed)
+      !runContainsValidSubRunCoveringIndex(
+        runChars,
+        tileIdx,
+        dictionary,
+        minimumWordLength,
+      )
     ) {
       return true;
     }
@@ -137,66 +152,42 @@ function scoreWord(word: BoardWord): number {
  * the global cross-validation invariant (FR-014, FR-014a).
  *
  * Algorithm:
- * 1. Filter candidates that fail cross-validation against frozen tiles alone
- * 2. Generate all subsets of remaining candidates
- * 3. For each subset, verify mutual cross-validation consistency
- * 4. Return the subset with the maximum total score
+ * 1. Generate all non-empty subsets of candidates.
+ * 2. For each subset, verify mutual cross-validation consistency.
+ * 3. Return the subset with the maximum total score.
+ *
+ * No individual pre-filter: a candidate's per-letter coverage can
+ * depend on another candidate in the same round (BÁS in #136 relies
+ * on BÆN's tiles to reach a length-3+ horizontal scored run that
+ * contains BÆN). Defer all cross-validation to the subset stage so
+ * mutual extras are available.
  */
 export function selectOptimalCombination(
   candidates: BoardWord[],
   board: BoardGrid,
   frozenTiles: FrozenTileMap,
   dictionary: Set<string>,
-  playerSlot: "player_a" | "player_b",
+  _playerSlot: "player_a" | "player_b",
 ): BoardWord[] {
   if (candidates.length === 0) return [];
 
   const frozenTileSet = new Set(Object.keys(frozenTiles));
 
-  // Step 1: Filter candidates that fail cross-validation against
-  // frozen tiles alone (no other candidates considered).
-  // `frozenTiles` is forwarded so cross-word checks can consult
-  // `scoredAxes` and skip incidental cross-axis adjacencies (issue #136).
-  const viable = candidates.filter(
-    (word) =>
-      !hasCrossWordViolation(
-        board,
-        word,
-        frozenTileSet,
-        dictionary,
-        new Set(),
-        frozenTiles,
-      ) &&
-      !violatesFrozenAdjacencyOnSameAxis(
-        word,
-        board,
-        frozenTileSet,
-        dictionary,
-        frozenTiles,
-      ),
-  );
-
-  if (viable.length === 0) return [];
-
-  // Step 2: Generate all non-empty subsets and find the best valid one
   let bestSubset: BoardWord[] = [];
   let bestScore = -1;
 
-  const n = viable.length;
-  // Brute-force: enumerate all 2^n - 1 non-empty subsets
+  const n = candidates.length;
   for (let mask = 1; mask < (1 << n); mask++) {
     const subset: BoardWord[] = [];
     for (let i = 0; i < n; i++) {
       if (mask & (1 << i)) {
-        subset.push(viable[i]);
+        subset.push(candidates[i]);
       }
     }
 
-    // Step 3a: Skip subsets with same-axis overlap or adjacency
     if (!hasNoSameAxisConflict(subset)) continue;
 
-    // Step 3b: Verify mutual cross-validation within the subset
-    if (isSubsetValid(subset, board, frozenTileSet, dictionary, frozenTiles)) {
+    if (isSubsetValid(subset, board, frozenTileSet, dictionary)) {
       const totalScore = subset.reduce(
         (sum, word) => sum + scoreWord(word),
         0,
@@ -209,133 +200,6 @@ export function selectOptimalCombination(
   }
 
   return bestSubset;
-}
-
-/**
- * Check whether a candidate word is adjacent to a frozen scored word
- * on the same axis and the combined sequence is NOT a valid word.
- *
- * Uses `scoredAxes` metadata on frozen tiles to determine whether an
- * adjacent tile was scored on the same axis as the candidate word.
- * Falls back to the valid-word heuristic for legacy frozen tiles
- * that lack `scoredAxes`.
- */
-function violatesFrozenAdjacencyOnSameAxis(
-  word: BoardWord,
-  board: BoardGrid,
-  frozenTileSet: Set<string>,
-  dictionary: Set<string>,
-  frozenTileMap?: FrozenTileMap,
-): boolean {
-  const isHorizontal =
-    word.direction === "right" || word.direction === "left";
-  const wordAxis: ScoredAxis = isHorizontal
-    ? "horizontal"
-    : "vertical";
-  const dx = isHorizontal ? 1 : 0;
-  const dy = isHorizontal ? 0 : 1;
-
-  // Get axis-sorted tiles
-  const sortedTiles = [...word.tiles].sort((a, b) =>
-    isHorizontal ? a.x - b.x : a.y - b.y,
-  );
-  const first = sortedTiles[0];
-  const last = sortedTiles[sortedTiles.length - 1];
-
-  const wordChars = sortedTiles.map((t) => board[t.y][t.x]);
-
-  // Collect frozen runs on each side
-  const beforeRun = collectFrozenRun(
-    first.x - dx, first.y - dy, -dx, -dy,
-  );
-  const afterRun = collectFrozenRun(
-    last.x + dx, last.y + dy, dx, dy,
-  );
-
-  // Check each side independently
-  if (beforeRun && isInvalidCombined(beforeRun, true)) return true;
-  if (afterRun && isInvalidCombined(afterRun, false)) return true;
-
-  // Sandwich check: both sides have frozen runs, validate full sequence
-  if (beforeRun && afterRun) {
-    const full = [
-      ...beforeRun.chars.slice().reverse(),
-      ...wordChars,
-      ...afterRun.chars,
-    ];
-    const fullText = full
-      .join("")
-      .normalize("NFC")
-      .toLowerCase();
-    const fullReversed = [...fullText].reverse().join("");
-    if (!dictionary.has(fullText) && !dictionary.has(fullReversed)) {
-      return true;
-    }
-  }
-
-  return false;
-
-  function isPartOfSameAxisRun(x: number, y: number): boolean {
-    const key = `${x},${y}`;
-    if (!frozenTileSet.has(key)) return false;
-    // When scoredAxes metadata is available, only count the frozen tile
-    // as continuing the candidate's own-axis sequence if it was actually
-    // scored on that axis. A tile scored only on a perpendicular axis
-    // is an incidental neighbor — placing a new word next to it doesn't
-    // extend any existing same-axis word. See issue #136.
-    if (!frozenTileMap) return true;
-    const meta = frozenTileMap[key];
-    if (!meta || !meta.scoredAxes) return true;
-    return meta.scoredAxes.includes(wordAxis);
-  }
-
-  function collectFrozenRun(
-    startX: number,
-    startY: number,
-    stepX: number,
-    stepY: number,
-  ): { chars: string[] } | null {
-    if (
-      startX < 0 || startX >= BOARD_SIZE ||
-      startY < 0 || startY >= BOARD_SIZE ||
-      !isPartOfSameAxisRun(startX, startY)
-    ) {
-      return null;
-    }
-
-    const chars: string[] = [];
-    let cx = startX;
-    let cy = startY;
-    while (
-      cx >= 0 && cx < BOARD_SIZE &&
-      cy >= 0 && cy < BOARD_SIZE &&
-      isPartOfSameAxisRun(cx, cy)
-    ) {
-      chars.push(board[cy][cx]);
-      cx += stepX;
-      cy += stepY;
-    }
-
-    return { chars };
-  }
-
-  function isInvalidCombined(
-    run: { chars: string[] },
-    isBefore: boolean,
-  ): boolean {
-    const combined = isBefore
-      ? [...[...run.chars].reverse(), ...wordChars]
-      : [...wordChars, ...run.chars];
-    const combinedText = combined
-      .join("")
-      .normalize("NFC")
-      .toLowerCase();
-    const combinedReversed = [...combinedText].reverse().join("");
-    return (
-      !dictionary.has(combinedText) &&
-      !dictionary.has(combinedReversed)
-    );
-  }
 }
 
 /**
@@ -407,7 +271,6 @@ function isSubsetValid(
   board: BoardGrid,
   frozenTileSet: Set<string>,
   dictionary: Set<string>,
-  frozenTileMap?: FrozenTileMap,
 ): boolean {
   for (let i = 0; i < subset.length; i++) {
     // Build extra tile set from all OTHER words in the subset
@@ -426,7 +289,6 @@ function isSubsetValid(
         frozenTileSet,
         dictionary,
         extraTiles,
-        frozenTileMap,
       )
     ) {
       return false;

--- a/tests/unit/lib/game-engine/crossValidator.test.ts
+++ b/tests/unit/lib/game-engine/crossValidator.test.ts
@@ -642,7 +642,7 @@ describe("selectOptimalCombination", () => {
   });
 
   // T040: Rejects word adjacent to frozen tiles on same axis when combined is invalid
-  test("T040: rejects word adjacent to frozen tiles on same axis when combined sequence is invalid", () => {
+  test("T040: allows word adjacent to frozen tiles on same axis even when full combined sequence is not a dict word (per-letter rule, issue #195)", () => {
     const localDict = new Set(["uma", "xy"]);
     const board = emptyBoard();
     // "uma" vertically at column 0, rows 0-2
@@ -656,8 +656,10 @@ describe("selectOptimalCombination", () => {
       "0,4": { owner: "player_b" },
     };
 
-    // "uma" is adjacent to frozen tile (0,3) on the same vertical axis
-    // Combined: "uma" + "xy" = "umaxy" ∉ dict → reject "uma"
+    // Under the per-letter rule: each letter of "uma" is covered by the
+    // sub-run "uma" (valid dict word) within the maximal same-axis run
+    // "umaxy". The full run need not itself be a dict word — #195 only
+    // forbids scored letters that have no valid covering sub-run.
     const candidates = [vWord("uma", 0, 0)];
     const result = selectOptimalCombination(
       candidates,
@@ -667,7 +669,8 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("uma");
   });
 
   // T041: Allows word adjacent to frozen tiles on same axis when combined IS valid
@@ -697,8 +700,8 @@ describe("selectOptimalCombination", () => {
     expect(result[0].text).toBe("ab");
   });
 
-  // T042: Word with frozen tiles before it on same axis — combined invalid
-  test("T042: rejects word when frozen tiles precede it on same axis with invalid combined", () => {
+  // T042: Word with frozen tiles before it on same axis — combined not in dict
+  test("T042: allows word when frozen tiles precede it on same axis even with combined not a dict word (per-letter rule)", () => {
     const localDict = new Set(["cd", "ab"]);
     const board = emptyBoard();
     placeH(board, "abcd", 0, 0);
@@ -709,8 +712,10 @@ describe("selectOptimalCombination", () => {
       "1,0": { owner: "player_a" },
     };
 
-    // New word "cd" at (2,0)-(3,0) — frozen "ab" immediately before it
-    // Combined: "ab" + "cd" = "abcd" — put "abcd" NOT in dict for this test
+    // Under the per-letter rule: "cd" is itself a valid sub-run covering
+    // its own tiles. The full combined "abcd" not being in dict no
+    // longer matters — each scored letter is covered by at least one
+    // valid dict sub-run.
     const candidates = [hWord("cd", 2, 0)];
     const result = selectOptimalCombination(
       candidates,
@@ -720,8 +725,8 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    // "abcd" ∉ localDict → reject "cd"
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("cd");
   });
 
   // Additional: empty candidates returns empty result
@@ -810,9 +815,12 @@ describe("selectOptimalCombination", () => {
   });
 
   // T047: Sandwich — word between two frozen runs, pairwise valid but full sequence invalid
-  test("T047: rejects word sandwiched between frozen runs when full combined sequence is invalid", () => {
+  test("T047: allows word sandwiched between frozen runs even when full combined sequence isn't a dict word (per-letter rule)", () => {
     // "ab", "cd", "ef" are valid words; "abcd", "cdef", "bcd" are valid;
-    // but "abcdef" is NOT valid — the full frozen sequence would be invalid
+    // but "abcdef" is NOT. Under the per-letter rule each scored letter
+    // only needs some valid covering sub-run — "abcd"/"cdef"/"bcd"
+    // cover every letter in "cd" — so the full "abcdef" need not itself
+    // be a dict word.
     const localDict = new Set(["ab", "cd", "ef", "abcd", "cdef", "bcd"]);
     const board = emptyBoard();
     placeH(board, "abcdef", 0, 0);
@@ -836,11 +844,8 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    // "cd" at cols 2-3:
-    //   Backward frozen: "ab" at cols 0-1 → "ab" ∈ dict → combined "abcd" ∈ dict ✓
-    //   Forward frozen: "ef" at cols 4-5 → "ef" ∈ dict → combined "cdef" ∈ dict ✓
-    //   BUT full sequence "abcdef" ∉ dict → sandwich violation → reject "cd"
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("cd");
   });
 
   // T048: Sandwich — full combined sequence IS valid → word accepted
@@ -906,7 +911,7 @@ describe("selectOptimalCombination", () => {
   // physical adjacency on the horizontal axis means it physically extends
   // the sequence horizontally. Therefore, the combined sequence MUST be a valid
   // word, regardless of the tile's scoredAxes metadata.
-  test("T049: rejects horizontal word adjacent to single frozen tile even if scoredAxes is horizontal", () => {
+  test("T049: allows horizontal word adjacent to a frozen tile regardless of its scoredAxes (per-letter rule)", () => {
     const localDict = new Set(["tað"]);
     const board = emptyBoard();
     board[0][3] = "a";
@@ -925,8 +930,10 @@ describe("selectOptimalCombination", () => {
       "player_b",
     );
 
-    // Combined "atað" ∉ dict → TAÐ rejected
-    expect(result).toHaveLength(0);
+    // Maximal same-axis run "atað" is not a dict word, but "tað" is
+    // a valid sub-run covering every letter of the new word. Accepted.
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("tað");
   });
 
   test("T049b: ALLOWS horizontal word adjacent to a frozen tile scored only on a perpendicular axis (issue #136)", () => {
@@ -959,7 +966,7 @@ describe("selectOptimalCombination", () => {
     expect(result[0].text).toBe("tað");
   });
 
-  test("T049c: rejects horizontal word adjacent to multi-axis frozen tile", () => {
+  test("T049c: allows horizontal word adjacent to multi-axis frozen tile (per-letter rule)", () => {
     const localDict = new Set(["tað"]);
     const board = emptyBoard();
     board[0][3] = "x";
@@ -978,11 +985,13 @@ describe("selectOptimalCombination", () => {
       "player_b",
     );
 
-    // Combined "xtað" ∉ dict → rejected
-    expect(result).toHaveLength(0);
+    // Same-axis run "xtað" not in dict, but "tað" covers all its
+    // letters → accepted under per-letter rule.
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("tað");
   });
 
-  test("T049d: always triggers combined-sequence check when frozen tile is adjacent (legacy, no scoredAxes)", () => {
+  test("T049d: allows word adjacent to legacy (no-scoredAxes) frozen tiles when new word itself is a valid covering sub-run", () => {
     const localDict = new Set(["uma", "xy"]);
     const board = emptyBoard();
     placeV(board, "uma", 0, 0);
@@ -1003,18 +1012,17 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    // Adjacent frozen "xy" → combined "umaxy" ∉ dict → rejected
-    expect(result).toHaveLength(0);
+    // Combined "umaxy" is not a dict word, but "uma" is a valid
+    // covering sub-run for every letter of the new word. Accepted.
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("uma");
   });
 
-  // T050: NÖS regression — frozen single letter above a new vertical word
-  // must cause the combined run to be validated (the scoring bug reported in
-  // the game: player swapped S to form NÖS but R was frozen above N,
-  // making the full column run RNÖS which is not a valid word).
-  test("T050: rejects vertical word when a single frozen letter above it makes an invalid combined run", () => {
-    // Column x=3: R(frozen, row 1), N(row 2), Ö(row 3), S(row 4)
-    // New word: nös (down, col 3, rows 2-4)
-    // Combined run: R + nös = "rnös" — not a valid word → reject
+  // T050: NÖS regression — under the per-letter rule (issue #195), a
+  // new word sitting directly below a frozen single letter is allowed
+  // as long as the new word itself covers its letters. The combined
+  // run need not be a dict word.
+  test("T050: allows vertical word when a single frozen letter above it extends the run but nös itself covers its letters", () => {
     const localDict = new Set(["nös"]);
     const board = emptyBoard();
     board[1][3] = "R";
@@ -1023,7 +1031,7 @@ describe("selectOptimalCombination", () => {
     board[4][3] = "S";
 
     const frozenTiles: FrozenTileMap = {
-      "3,1": { owner: "player_b" }, // R is frozen from a prior round, no scoredAxes
+      "3,1": { owner: "player_b" },
     };
 
     const candidates = [vWord("nös", 3, 2)];
@@ -1035,8 +1043,8 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    // R(frozen) + NÖS = "rnös" ∉ dict → nös must be rejected
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("nös");
   });
 
   // T051: NÖS regression — same scenario but combined run IS a valid word → accept
@@ -1068,12 +1076,11 @@ describe("selectOptimalCombination", () => {
     expect(result[0].text).toBe("nös");
   });
 
-  // T052: Single-letter frozen run with no scoredAxes — used to silently
-  // bypass the check (old heuristic bug). Verify fix applies to horizontal too.
-  test("T052: rejects horizontal word when a single frozen letter precedes it making an invalid combined run", () => {
-    // Row y=2: X(frozen, col 1), A(col 2), B(col 3)
-    // New horizontal word: "ab" at (2,2)
-    // Combined: x + ab = "xab" — not a valid word
+  // T052: Same-axis frozen letter precedes the new word — under the
+  // per-letter rule the new word covers its own letters and the combined
+  // run need not be a dict word. Contrived 2-letter candidate; the real
+  // scanner would never emit one.
+  test("T052: allows horizontal word when a single frozen letter precedes it (per-letter rule)", () => {
     const localDict = new Set(["ab"]);
     const board = emptyBoard();
     board[2][1] = "X";
@@ -1081,7 +1088,7 @@ describe("selectOptimalCombination", () => {
     board[2][3] = "B";
 
     const frozenTiles: FrozenTileMap = {
-      "1,2": { owner: "player_b" }, // single letter, no scoredAxes
+      "1,2": { owner: "player_b" },
     };
 
     const candidates = [hWord("ab", 2, 2)];
@@ -1093,8 +1100,8 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    // X(frozen) + AB = "xab" ∉ dict → ab rejected
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("ab");
   });
 });
 

--- a/tests/unit/lib/game-engine/wordEngine.test.ts
+++ b/tests/unit/lib/game-engine/wordEngine.test.ts
@@ -175,11 +175,13 @@ describe("wordEngine", () => {
       expect(words).toContain("bás");
     });
 
-    test("still rejects when the adjacent frozen tile WAS scored on the same axis (combined sequence must be a word)", async () => {
+    test("still scores BÆN when the adjacent frozen tile was scored on the same axis (per-letter rule, issue #195)", async () => {
       const board = makeBoardWithFrozenNeighbor();
       // Same D, but this time it was scored on a horizontal word that
-      // ends at (1,2). Placing BÆN to its right extends that horizontal
-      // sequence into "DBÆN" which is not a word — must reject.
+      // ends at (1,2). The combined same-axis run "DBÆN" is not a dict
+      // word, but under the per-letter rule (issue #195) each letter of
+      // the new word only needs SOME valid covering sub-run — and
+      // "bæn" covers b, æ, n. Scored.
       const frozenTiles: FrozenTileMap = {
         "1,2": { owner: "player_b", scoredAxes: ["horizontal"] },
       };
@@ -204,7 +206,7 @@ describe("wordEngine", () => {
       });
 
       const words = result.playerAWords.map((w) => w.word);
-      expect(words).not.toContain("bæn");
+      expect(words).toContain("bæn");
     });
   });
 
@@ -970,6 +972,77 @@ describe("wordEngine", () => {
       expect(result.finalBoard[0][2]).toBe("r");
       expect(result.finalBoard[5][0]).toBe("b");
       expect(result.finalBoard[5][2]).toBe("r");
+    });
+  });
+
+  describe("issue #195: no below-min or uncovered scored runs", () => {
+    // The invalid scored runs reported in #195 all share a structure:
+    // a newly-scored tile ends up in a contiguous scored run whose
+    // every sub-run of length >= minimumWordLength that includes the
+    // new tile is NOT in the dictionary. The pipeline must refuse to
+    // score a word that would create such a state.
+
+    function makeNosBoardWithLeftNeighbor(
+      leftLetter: string | undefined,
+    ): BoardGrid {
+      const board = emptyBoard();
+      if (leftLetter !== undefined) board[2][2] = leftLetter;
+      board[2][3] = "q"; // pre-swap placeholder at (3,2)
+      board[3][3] = "ö";
+      board[4][3] = "s";
+      board[9][9] = "n"; // swap source
+      return board;
+    }
+
+    const nosSwap = {
+      playerId: PLAYER_A,
+      fromX: 9,
+      fromY: 9,
+      toX: 3,
+      toY: 2,
+      submittedAt: "2026-01-01T00:00:00Z",
+    };
+
+    test("baseline: vertical 'nös' scores fine when the cross-axis neighbor is unscored", async () => {
+      // Confirms the scan + scoring pipeline actually reaches 'nös' in
+      // this setup — otherwise the rejection test below would pass
+      // vacuously.
+      const board = makeNosBoardWithLeftNeighbor("x");
+      const result = await processRoundScoring({
+        matchId: MATCH_ID,
+        roundId: ROUND_ID,
+        boardBefore: board,
+        acceptedMoves: [nosSwap],
+        frozenTiles: EMPTY_FROZEN, // (2,2) NOT frozen
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+      });
+      expect(result.playerAWords.map((w) => w.word)).toContain("nös");
+    });
+
+    test("rejects vertical 'nös' when the horizontal cross-axis neighbor is a frozen tile (creates a 2-letter scored run below minimumWordLength)", async () => {
+      // Same board as the baseline, but (2,2) is frozen with
+      // scoredAxes=["vertical"]. Scoring 'nös' would leave row 2 with
+      // a 2-letter frozen run "xn" — below minimumWordLength and no
+      // covering sub-run. Per the issue-#195 rule this placement must
+      // be rejected. (Post-#185 incorrectly skipped 'x' on the
+      // horizontal cross-check because its scoredAxes didn't include
+      // "horizontal", letting "nös" score and creating the invalid
+      // state.)
+      const board = makeNosBoardWithLeftNeighbor("x");
+      const frozenTiles: FrozenTileMap = {
+        "2,2": { owner: "player_b", scoredAxes: ["vertical"] },
+      };
+      const result = await processRoundScoring({
+        matchId: MATCH_ID,
+        roundId: ROUND_ID,
+        boardBefore: board,
+        acceptedMoves: [nosSwap],
+        frozenTiles,
+        playerAId: PLAYER_A,
+        playerBId: PLAYER_B,
+      });
+      expect(result.playerAWords.map((w) => w.word)).not.toContain("nös");
     });
   });
 });


### PR DESCRIPTION
Closes #195.

## Bug

PR #185 weakened cross-word validation by skipping a frozen neighbor whenever its `scoredAxes` didn't include the current cross-axis. That let below-minimum scored runs like "ML", "NÐ", "US" and uncovered 3+ letter runs like "TKH", "RNÝ", "ÆLÁGA" slip through at placement time.

Concrete path for "ML" at (7,0):
- L scored earlier as part of a vertical word → frozen with `scoredAxes=["vertical"]`.
- A later vertical scoring through (7,0)=M runs its cross-axis (horizontal) check. Neighbor (8,0)=L is frozen but `scoredAxes` lacks `"horizontal"` → #185 skips it → cross-run looks like `[M]` length 1 → no violation → M scored.
- Row 0 now has the 2-letter scored run "ML" that no Icelandic word covers.

The root mismatch: pre-#185 validation demanded the full same-axis combined run be itself a dictionary word — too strict, which is what #136 pushed back against — and #185 responded by skipping perpendicular-axis frozen tiles altogether, which was too lenient.

## Fix

Replace both with the rule #195 actually states: every scored letter must be part of a valid word in some direction, and no scored letter may sit in an invalid run. Concretely, for each tile of a newly-scored word, the maximal contiguous scored run on the cross-axis must either be length 1 or contain a dict word of length ≥ `minimumWordLength` that includes the tile. Below-min runs fail automatically. Every frozen tile physically on the board counts — `scoredAxes` metadata no longer gates the check.

Under this rule BÆN/BÁS from #136 still score (each of their letters is covered by the new word itself) and the six #195 patterns are all rejected at placement time.

## Changes

- `lib/game-engine/crossValidator.ts`
  - New `runContainsValidSubRunCoveringIndex` helper.
  - `hasCrossWordViolation` uses it and no longer consults `FrozenTile.scoredAxes`.
  - Deleted `violatesFrozenAdjacencyOnSameAxis` and its three helpers — the new word is itself a same-axis covering sub-run for its tiles, so the check is obsolete.
  - Dropped the individual `viable` pre-filter in `selectOptimalCombination` so a candidate whose coverage depends on another candidate in the same round (BÁS leaning on BÆN) isn't pruned before mutual validation.
- `tests/unit/lib/game-engine/crossValidator.test.ts`
  - Flipped T040, T042, T047, T049, T049c, T049d, T050, T052 — all encoded the old "combined must be a dict word" rule.
  - Tests for below-min cross-runs and uncovered 3+ letter cross-runs remain asserting rejection (T029, T029b, T029c, T032, T032b, T043).
- `tests/unit/lib/game-engine/wordEngine.test.ts`
  - Flipped the PR-#185 "still rejects when scoredAxes is horizontal" test — BÆN now scores regardless of the neighbor's `scoredAxes`.
  - Added `describe("issue #195")` block: a baseline confirming the candidate is reachable, plus the regression proper pinning the "ML/NÐ-pattern".

Net: `+204 / -262` across 3 files.

## Tests

- `pnpm typecheck`: clean
- `pnpm exec eslint --max-warnings 0` on touched files: clean
- `pnpm test:unit`: 1031 passed / 2 skipped
- `pnpm test:integration`: 42 passed

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit`
- [x] `pnpm test:integration`
- [x] `pnpm exec eslint --max-warnings 0 lib/game-engine/crossValidator.ts tests/unit/lib/game-engine/crossValidator.test.ts tests/unit/lib/game-engine/wordEngine.test.ts`
- [ ] **Manual (two browsers)**: reproduce the #195 board — attempt a swap that would create a below-min or uncovered scored run, confirm the word is rejected. Verify BÆN+BÁS from the #136 screenshot still score when B is swapped into (2,2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)