### PR TITLE
fix(scoring): same-axis standalone invariant across rounds (#200)

### DIFF
--- a/docs/prd_and_requirements/wottle_game_rules.md
+++ b/docs/prd_and_requirements/wottle_game_rules.md
@@ -22,7 +22,7 @@
 10. [Change log of scoring regressions](#10-change-log-of-scoring-regressions)
 11. [Code references](#11-code-references)
 
-> **Two rules, two axes**. The cross-axis uses per-letter coverage (§4) and is **physical** (ignores `scoredAxes`). The same-axis uses the standalone invariant (§3.5a, §7.4) and *does* consult `scoredAxes` to decide whether a frozen neighbor extends a prior scored word on this axis. Do not conflate the two. Most past regressions came from applying one rule where the other belonged.
+> **Two rules, two axes — both physical**. The cross-axis uses per-letter coverage (§4): every new tile must sit inside some dict sub-run of length ≥ min. The same-axis uses the standalone invariant (§3.5a, §7.4): if the new word physically abuts a frozen tile on its axis, the maximal combined same-axis scored run must itself be a dict word. Both rules consult only the physical frozen state — `scoredAxes` is audit-only (§4.4). Most past regressions came from gating validation on `scoredAxes`; do not reintroduce that.
 
 ---
 
@@ -79,17 +79,19 @@ Two new words scored in the same round on the same axis (both horizontal or both
 
 Perpendicular new words (one horizontal, one vertical) may share exactly one tile — the crossing — and that is valid and expected.
 
-### 3.5a Same-axis conflict with prior-round scored words
+### 3.5a Same-axis conflict with prior-round scored tiles
 
-The standalone invariant (§3.5) also applies **across rounds**: a new word *W* on axis *a* must not be physically adjacent to a frozen tile that was itself scored on axis *a* in an earlier round, **unless** the maximal combined same-axis scored run is itself a dict word.
+The standalone invariant (§3.5) also applies **across rounds**, and the rule is purely physical: a new word *W* on axis *a* must not be physically adjacent — at either endpoint along *a* — to a **frozen** tile, unless the maximal contiguous same-axis scored run containing *W*'s tiles is itself a dict word.
 
-Formal statement: let *t* be a frozen tile immediately adjacent to *W*'s first or last tile along axis *a*. *t* counts as a **same-axis extension** iff *a* ∈ *t*.scoredAxes (legacy tiles without `scoredAxes` are treated as same-axis when the contiguous frozen run they belong to is itself a dict word — i.e., was almost certainly scored on this axis). If any same-axis extension exists, the sequence formed by `(before extension) + W + (after extension)` — using maximal contiguous same-axis extensions on both sides — MUST be a dict word. Otherwise *W* is rejected.
+Formal statement: let *t* be a tile immediately adjacent to *W*'s first or last tile along axis *a*. If *t* is frozen, trace the maximal contiguous frozen run *E* outward from *W* along *a*. *W* is valid only if the full concatenation `E_before ⧺ W ⧺ E_after` (NFC-normalized, lowercased, either forward or reversed) is in the dictionary.
 
-This is the *only* place in the spec where `scoredAxes` **is** consulted: the question "did this tile previously end a scored word on *this* axis?" is a scoring-history question, not a physical-coverage question, and §4.4's argument against `scoredAxes` does not apply. The cross-axis check (§4) remains purely physical.
+`scoredAxes` is **not** consulted. "Frozen" is the only signal that matters. This works because in a real game a frozen tile cannot exist in isolation on its axis: if a tile is frozen, it was part of a ≥ `minimumWordLength` scored word, so the other tiles of that prior word are also frozen, and those tiles sit somewhere along the same axis as the prior word.
 
-**Accepts** (issue #136, preserved): Frozen `Þ` at `(1,2)` with `scoredAxes = ["vertical"]`. Player swaps `B` into `(2,2)` to form horizontal `BÆN`. Horizontal is not in Þ's scoredAxes → no same-axis extension → no concatenation check → `BÆN` scores.
+**Accepts** (real #136, preserved): Player swaps `B` into `(2,2)` to form horizontal `BÆN`. The adjacent `Þ` at `(1,2)` is **unfrozen** (plain letter, never scored). Unfrozen tiles never trigger this rule → `BÆN` scores.
 
-**Rejects** (issue #200, `ÖRLTEL`): Frozen `Ö`, `R`, `L` at column 1 rows 1–3, all with `scoredAxes = ["vertical"]` (prior vertical `ÖRL`). Player scores vertical `TEL` at rows 4–6. Vertical IS in the frozen tiles' scoredAxes → the same-axis extension is `ÖRL`. Combined run `ÖRLTEL` is not a dict word → `TEL` is rejected.
+**Rejects** (issue #200, `ÖRLTEL`): Frozen `Ö`, `R`, `L` at column 1 rows 1–3 (from a prior vertical `ÖRL`). Player scores vertical `TEL` at rows 4–6. The same-axis frozen extension is `ÖRL`. Combined run `ÖRLTEL` is not a dict word → `TEL` is rejected.
+
+**Rejects** (issue #200, `NMÚL`): Frozen `N` at `(5,3)` (from any prior scoring, horizontal or vertical — does not matter). Player scores vertical `MÚL` at `(5,4)`–`(5,6)`. The same-axis frozen extension is `N`. Combined run `NMÚL` is not a dict word → `MÚL` is rejected.
 
 ### 3.6 Per-letter coverage
 
@@ -126,19 +128,17 @@ A candidate scoring event that violates this condition for any tile of the new w
 
 ### 4.3 Two canonical examples
 
-**Accepts** (issue #136): Frozen `Þ` at `(1,2)`, scored earlier on a vertical word. Player swaps `B` into `(2,2)`, forming `BÆN` at cols 2–4 row 2. The horizontal scored run at row 2 is `Þ B Æ N` (length 4). The sub-run `BÆN` (length 3) is in the dictionary and contains B, Æ, and N (every new letter). Per-letter coverage holds. **`BÆN` scores.**
+**Accepts** (real #136): Player swaps `B` into `(2,2)`, forming `BÆN` at cols 2–4 row 2. The adjacent `Þ` at `(1,2)` is unfrozen (just a plain letter on the board). The cross-axis check for each of `B`/`Æ`/`N` sees no frozen neighbors → per-letter coverage trivially holds. **`BÆN` scores.** (The same-axis standalone check — §3.5a — also sees no frozen neighbor on the horizontal axis and does not fire.)
 
 **Rejects** (issue #195, "ML" at `(7,0)`): Frozen `M` at `(7,0)`, scored earlier on a vertical word. Player attempts a vertical scoring through `L` at `(8,0)`. After the hypothetical freeze, row 0 would have the scored run `M L` (length 2). No sub-run of length ≥ 3 fits. Per-letter coverage fails for the new tile `L`. **The candidate is rejected.**
 
-### 4.4 Why `scoredAxes` doesn't gate the **cross-axis** check
+### 4.4 Why `scoredAxes` doesn't gate validation
 
-A frozen tile's `scoredAxes` records which axes it was scored on in the past. It is tempting — and wrong — to skip a frozen neighbor in the **cross-axis** check when its `scoredAxes` doesn't include the cross-axis. PR #185 did this and produced #195.
+A frozen tile's `scoredAxes` records which axes it was scored on in the past. It is tempting — and wrong — to skip a frozen neighbor in validation when its `scoredAxes` doesn't include the relevant axis. PR #185 did this for the cross-axis check and produced #195.
 
-The cross-axis rule is about **physical scored state**, not scoring history. The letter `M` is physically on the board adjacent to `L`; after `L` freezes, row 0 physically contains a two-letter scored run. That run either has a valid covering dictionary word or it doesn't, and the tile's `scoredAxes` metadata is irrelevant to that question.
+Both the cross-axis rule (§4) and the same-axis rule (§3.5a) are about **physical scored state**, not scoring history. A frozen letter is physically on the board regardless of which axis it was originally scored on; any validation rule that skips it based on `scoredAxes` leaks bugs of the #195 / #200 family.
 
-Do not reintroduce a `scoredAxes`-gated check **for the cross-axis**. See §10 for receipts.
-
-> **Note**: The §3.5a / §7.4 same-axis standalone check is a different rule and *does* consult `scoredAxes`. That check asks a scoring-history question — "did this tile previously end a scored word on *this* axis?" — which `scoredAxes` is the authoritative answer to. §4.4's prohibition applies only to cross-axis per-letter coverage.
+`scoredAxes` is audit/telemetry data only. Do not reintroduce a `scoredAxes`-gated check. See §10 for receipts.
 
 ---
 
@@ -239,19 +239,16 @@ For each tile *t* of a candidate word *W*, in the cross-axis (perpendicular to *
 
 ### 7.4 The same-axis standalone check (`violatesFrozenAdjacencyOnSameAxis`)
 
-Per-letter coverage is trivially satisfied on the candidate's own axis (the candidate itself is a dict sub-run of length ≥ min covering its own tiles). The rule that bites here is the **standalone invariant** (§3.5a): the candidate must not concatenate with a prior same-axis scored word into an invalid combined run.
+Per-letter coverage is trivially satisfied on the candidate's own axis (the candidate itself is a dict sub-run of length ≥ min covering its own tiles). The rule that bites here is the **standalone invariant** (§3.5a): the candidate must not concatenate with a prior scored word into an invalid combined run.
 
-For a candidate *W* on axis *a* (with `wordAxis = "horizontal"` if *W* reads L/R else `"vertical"`):
+For a candidate *W* on axis *a*:
 
-1. From *W*'s first tile, step backward along axis *a* and collect a `beforeRun` of contiguous frozen tiles that satisfy:
-   - With `scoredAxes` metadata: `wordAxis ∈ t.scoredAxes`.
-   - Legacy (no `scoredAxes`): always collect, but gate the invariance check on the collected run itself being a dict word (single letters and non-word pairs never trigger).
-2. Symmetrically collect `afterRun` from *W*'s last tile forward.
-3. If `beforeRun` exists, reject when `[reverse(beforeRun), W]` is not a dict word (modulo the legacy dict-gate).
-4. If `afterRun` exists, reject when `[W, afterRun]` is not a dict word (modulo the legacy dict-gate).
-5. If both exist (sandwich), reject when the full `[reverse(beforeRun), W, afterRun]` is not a dict word.
+1. From *W*'s first tile, step backward along *a* and collect `beforeChars` of contiguous frozen tiles until the trace hits an unfrozen tile or the board edge.
+2. Symmetrically collect `afterChars` from *W*'s last tile forward.
+3. If both extensions are empty → no adjacency, return OK.
+4. Otherwise, build the full run `beforeChars ⧺ W ⧺ afterChars` and accept only if the resulting string (or its reverse), NFC-normalized and lowercased, is in the dictionary.
 
-This is the **only** place `scoredAxes` is consulted (§4.4 notwithstanding): whether a frozen tile extends a prior scored word *on this axis* is a scoring-history question that `scoredAxes` is the authoritative answer to. The cross-axis check in §7.3 remains purely physical.
+The check is purely physical — `scoredAxes` is not consulted. In a real game a frozen tile cannot be an "isolated perpendicular scored neighbor" on its axis: a frozen tile was part of a prior ≥ `minimumWordLength` scored word, and the other tiles of that word are also frozen, contiguous, on the same axis as that prior word. An unfrozen adjacent letter (like `Þ` in the real #136) never triggers the check.
 
 ### 7.5 The coverage helper (`runContainsValidSubRunCoveringIndex`)
 
@@ -272,7 +269,7 @@ These are board-global post-conditions. A scoring event that would break any of 
 | I5 | The board always has ≥ `MIN_UNFROZEN_TILES` (24) unfrozen tiles. | `freezeTiles` partial-freeze logic |
 | I6 | No swap ever targets a frozen tile (including tiles frozen earlier in the same round). | `processPlayerMove` rejection branch |
 | I7 | No two scored words in the same round on the same axis overlap or are physically adjacent. | `hasNoSameAxisConflict` |
-| I7a | No newly-scored word is physically adjacent on its own axis to a frozen tile that was previously scored on the same axis, unless the combined maximal same-axis scored run is itself a dict word. | §3.5a, `violatesFrozenAdjacencyOnSameAxis` |
+| I7a | No newly-scored word is physically adjacent on its own axis to any frozen tile, unless the combined maximal same-axis scored run (new word + frozen extensions on both sides) is itself a dict word. | §3.5a, `violatesFrozenAdjacencyOnSameAxis` |
 
 If you add a new scoring-related feature, state which invariant(s) your change affects and which it must continue to uphold. If you find an invariant is missing from this list, add it here and write a test that pins it.
 
@@ -309,7 +306,7 @@ Read this section before editing anything in `lib/game-engine/crossValidator.ts`
 | 2026-04-23 | #182 | #130 | Next round's `board_snapshot_before` was seeded from the raw sequential swap result instead of the word engine's `scoringFinalBoard`, so the next round could start on a board that contradicted the prior round's scoring. | N/A (out of scope for this doc — it was a board-seeding bug, not a rule bug). |
 | 2026-04-23 | #185 | #136 | Over-correction: `hasCrossWordViolation` and `violatesFrozenAdjacencyOnSameAxis` were modified to skip frozen tiles whose `scoredAxes` didn't include the current axis. This fixed the false rejection of `BÆN`/`BÁS` but opened §1's hole: a frozen tile physically on the board could be ignored during validation if it had been scored on a perpendicular axis, letting below-min and uncovered scored runs slip through. | §4.4 — `scoredAxes` must not gate validation. |
 | 2026-04-24 | #198 | #195 | The `scoredAxes`-based skip from #185 allowed invalid scored runs like `ML`, `NÐ`, `US` (length 2, below min) and `TKH`, `RNÝ`, `ÆLÁGA` (≥ 3 letters, not in dict, no covering sub-run) to be created at scoring time. Fixed by adopting the per-letter coverage rule: every frozen tile counts physically, and every new tile must be covered by a dict sub-run in every direction where its maximal scored run has length ≥ 2. `violatesFrozenAdjacencyOnSameAxis` was deleted; the new word itself is a same-axis covering sub-run for its tiles. | §4 (entire section) — the per-letter coverage rule. |
-| 2026-04-24 | #201 | #200 | Deleting `violatesFrozenAdjacencyOnSameAxis` in #198 lost the cross-round enforcement of the standalone invariant. The per-letter rule is trivially satisfied on the candidate's own axis (the candidate *is* a covering sub-run), so a new dict word could be placed physically adjacent to a prior same-axis scored dict word — producing invalid visual runs like `ÖRLTEL` (`ÖRL` + `TEL`), `ÞESSINÓK` (`ÞESSI` + `NÓK`), and `NEFÞEMA` (`NEF` + `ÞEMA`). Fixed by restoring the same-axis check as a sibling to `hasCrossWordViolation`: if a frozen same-axis extension exists (gated by `scoredAxes` when present, or by the run being a dict word in the legacy case), the combined sequence must itself be a dict word. `#136` is preserved because `Þ.scoredAxes = ["vertical"]` does not count as a horizontal extension for `BÆN`. | §3.5a and I7a — the cross-round standalone invariant, enforced by `violatesFrozenAdjacencyOnSameAxis`. |
+| 2026-04-24 | #201 | #200 | Deleting `violatesFrozenAdjacencyOnSameAxis` in #198 lost the cross-round enforcement of the standalone invariant. The per-letter rule is trivially satisfied on the candidate's own axis (the candidate *is* a covering sub-run), so a new dict word could be placed physically adjacent to a frozen tile — producing invalid visual runs like `ÖRLTEL` (`ÖRL` + `TEL`), `NMÚL` (`N` + `MÚL`), `ÞESSINÓK` (`ÞESSI` + `NÓK`), `NEFÞEMA` (`NEF` + `ÞEMA`), and `SMÁD` (`SMÁ` + `D`). Fixed by restoring the same-axis check as a sibling to `hasCrossWordViolation`, purely physical: any frozen tile abutting the candidate on its axis triggers the check; the maximal combined same-axis scored run must itself be a dict word. Real #136 is preserved because the adjacent `Þ` in that screenshot is **unfrozen** — an unfrozen neighbor never triggers the rule. (Earlier formulations of the spec's #136 example claimed `Þ` was frozen with `scoredAxes = ["vertical"]`; that was incorrect and has been removed.) | §3.5a and I7a — the cross-round standalone invariant, enforced by `violatesFrozenAdjacencyOnSameAxis`. |
 
 When you land a scoring-related fix, append a row here with: date, PR number, issue number, one-sentence description of what went wrong, and the rule section that now prevents it. If the fix exposes a rule that was not previously documented, document it in this file *in the same PR*.
 

--- a/docs/prd_and_requirements/wottle_game_rules.md
+++ b/docs/prd_and_requirements/wottle_game_rules.md
@@ -22,6 +22,8 @@
 10. [Change log of scoring regressions](#10-change-log-of-scoring-regressions)
 11. [Code references](#11-code-references)
 
+> **Two rules, two axes**. The cross-axis uses per-letter coverage (§4) and is **physical** (ignores `scoredAxes`). The same-axis uses the standalone invariant (§3.5a, §7.4) and *does* consult `scoredAxes` to decide whether a frozen neighbor extends a prior scored word on this axis. Do not conflate the two. Most past regressions came from applying one rule where the other belonged.
+
 ---
 
 ## 1. Board and tile state
@@ -77,6 +79,18 @@ Two new words scored in the same round on the same axis (both horizontal or both
 
 Perpendicular new words (one horizontal, one vertical) may share exactly one tile — the crossing — and that is valid and expected.
 
+### 3.5a Same-axis conflict with prior-round scored words
+
+The standalone invariant (§3.5) also applies **across rounds**: a new word *W* on axis *a* must not be physically adjacent to a frozen tile that was itself scored on axis *a* in an earlier round, **unless** the maximal combined same-axis scored run is itself a dict word.
+
+Formal statement: let *t* be a frozen tile immediately adjacent to *W*'s first or last tile along axis *a*. *t* counts as a **same-axis extension** iff *a* ∈ *t*.scoredAxes (legacy tiles without `scoredAxes` are treated as same-axis when the contiguous frozen run they belong to is itself a dict word — i.e., was almost certainly scored on this axis). If any same-axis extension exists, the sequence formed by `(before extension) + W + (after extension)` — using maximal contiguous same-axis extensions on both sides — MUST be a dict word. Otherwise *W* is rejected.
+
+This is the *only* place in the spec where `scoredAxes` **is** consulted: the question "did this tile previously end a scored word on *this* axis?" is a scoring-history question, not a physical-coverage question, and §4.4's argument against `scoredAxes` does not apply. The cross-axis check (§4) remains purely physical.
+
+**Accepts** (issue #136, preserved): Frozen `Þ` at `(1,2)` with `scoredAxes = ["vertical"]`. Player swaps `B` into `(2,2)` to form horizontal `BÆN`. Horizontal is not in Þ's scoredAxes → no same-axis extension → no concatenation check → `BÆN` scores.
+
+**Rejects** (issue #200, `ÖRLTEL`): Frozen `Ö`, `R`, `L` at column 1 rows 1–3, all with `scoredAxes = ["vertical"]` (prior vertical `ÖRL`). Player scores vertical `TEL` at rows 4–6. Vertical IS in the frozen tiles' scoredAxes → the same-axis extension is `ÖRL`. Combined run `ÖRLTEL` is not a dict word → `TEL` is rejected.
+
 ### 3.6 Per-letter coverage
 
 The word must not create an **uncovered scored letter** in any reading direction. This is the single most important and most often-misunderstood rule. It has its own section: §4.
@@ -116,13 +130,15 @@ A candidate scoring event that violates this condition for any tile of the new w
 
 **Rejects** (issue #195, "ML" at `(7,0)`): Frozen `M` at `(7,0)`, scored earlier on a vertical word. Player attempts a vertical scoring through `L` at `(8,0)`. After the hypothetical freeze, row 0 would have the scored run `M L` (length 2). No sub-run of length ≥ 3 fits. Per-letter coverage fails for the new tile `L`. **The candidate is rejected.**
 
-### 4.4 Why `scoredAxes` doesn't gate this
+### 4.4 Why `scoredAxes` doesn't gate the **cross-axis** check
 
-A frozen tile's `scoredAxes` records which axes it was scored on in the past. It is tempting — and wrong — to skip a frozen neighbor in the cross-axis check when its `scoredAxes` doesn't include the cross-axis. PR #185 did this and produced #195.
+A frozen tile's `scoredAxes` records which axes it was scored on in the past. It is tempting — and wrong — to skip a frozen neighbor in the **cross-axis** check when its `scoredAxes` doesn't include the cross-axis. PR #185 did this and produced #195.
 
-The rule is about **physical scored state**, not scoring history. The letter `M` is physically on the board adjacent to `L`; after `L` freezes, row 0 physically contains a two-letter scored run. That run either has a valid covering dictionary word or it doesn't, and the tile's `scoredAxes` metadata is irrelevant to that question.
+The cross-axis rule is about **physical scored state**, not scoring history. The letter `M` is physically on the board adjacent to `L`; after `L` freezes, row 0 physically contains a two-letter scored run. That run either has a valid covering dictionary word or it doesn't, and the tile's `scoredAxes` metadata is irrelevant to that question.
 
-Do not reintroduce a `scoredAxes`-gated check. See §10 for receipts.
+Do not reintroduce a `scoredAxes`-gated check **for the cross-axis**. See §10 for receipts.
+
+> **Note**: The §3.5a / §7.4 same-axis standalone check is a different rule and *does* consult `scoredAxes`. That check asks a scoring-history question — "did this tile previously end a scored word on *this* axis?" — which `scoredAxes` is the authoritative answer to. §4.4's prohibition applies only to cross-axis per-letter coverage.
 
 ---
 
@@ -204,13 +220,13 @@ For each round:
 Given the list of candidate words for one player's move:
 
 1. **Enumerate all non-empty subsets** of candidates (2^*n* − 1). *n* is small in practice (a handful of candidates per swap).
-2. For each subset, **prune same-axis conflicts** (`hasNoSameAxisConflict`, §3.5).
-3. For each surviving subset, **check per-letter coverage** (`isSubsetValid`): for each candidate word in the subset, treat *all other subset candidates' tiles* as "extra established" tiles, then apply `hasCrossWordViolation` (§7.3).
+2. For each subset, **prune same-axis conflicts** between candidates (`hasNoSameAxisConflict`, §3.5).
+3. For each surviving subset, **check per-letter coverage** and **same-axis standalone invariant** (`isSubsetValid`): for each candidate word in the subset, treat *all other subset candidates' tiles* as "extra established" tiles, then apply both `hasCrossWordViolation` (§7.3, cross-axis) and `violatesFrozenAdjacencyOnSameAxis` (§7.4, same-axis).
 4. Among subsets that pass, pick the one with the **maximum total score** (letter points + length bonus per word, summed).
 
 There is **no individual pre-filter** before subset enumeration. A candidate's coverage can depend on another candidate in the same round (BÁS in #136 only reaches a length-3 horizontal scored run if BÆN is also in the subset), so pruning a candidate before mutual validation is unsound.
 
-### 7.3 The per-letter check (`hasCrossWordViolation`)
+### 7.3 The per-letter check (`hasCrossWordViolation`, cross-axis)
 
 For each tile *t* of a candidate word *W*, in the cross-axis (perpendicular to *W*):
 
@@ -221,9 +237,23 @@ For each tile *t* of a candidate word *W*, in the cross-axis (perpendicular to *
    - `runLen < minimumWordLength` → **violation** (2-letter runs are always invalid).
    - `runLen ≥ minimumWordLength` and `runContainsValidSubRunCoveringIndex(runChars, tileIdx, dict, min) == false` → **violation** (no dict sub-run covers *t*).
 
-The same-axis (parallel) direction is not separately checked: for any candidate *W* of length ≥ `minimumWordLength`, *W* itself is a contiguous dict sub-run of length ≥ min containing every one of its tiles. So same-axis coverage is automatically satisfied for scanner-emitted candidates.
+### 7.4 The same-axis standalone check (`violatesFrozenAdjacencyOnSameAxis`)
 
-### 7.4 The coverage helper (`runContainsValidSubRunCoveringIndex`)
+Per-letter coverage is trivially satisfied on the candidate's own axis (the candidate itself is a dict sub-run of length ≥ min covering its own tiles). The rule that bites here is the **standalone invariant** (§3.5a): the candidate must not concatenate with a prior same-axis scored word into an invalid combined run.
+
+For a candidate *W* on axis *a* (with `wordAxis = "horizontal"` if *W* reads L/R else `"vertical"`):
+
+1. From *W*'s first tile, step backward along axis *a* and collect a `beforeRun` of contiguous frozen tiles that satisfy:
+   - With `scoredAxes` metadata: `wordAxis ∈ t.scoredAxes`.
+   - Legacy (no `scoredAxes`): always collect, but gate the invariance check on the collected run itself being a dict word (single letters and non-word pairs never trigger).
+2. Symmetrically collect `afterRun` from *W*'s last tile forward.
+3. If `beforeRun` exists, reject when `[reverse(beforeRun), W]` is not a dict word (modulo the legacy dict-gate).
+4. If `afterRun` exists, reject when `[W, afterRun]` is not a dict word (modulo the legacy dict-gate).
+5. If both exist (sandwich), reject when the full `[reverse(beforeRun), W, afterRun]` is not a dict word.
+
+This is the **only** place `scoredAxes` is consulted (§4.4 notwithstanding): whether a frozen tile extends a prior scored word *on this axis* is a scoring-history question that `scoredAxes` is the authoritative answer to. The cross-axis check in §7.3 remains purely physical.
+
+### 7.5 The coverage helper (`runContainsValidSubRunCoveringIndex`)
 
 Returns `true` iff there exists `start ≤ tileIdx < end`, `end − start ≥ min`, such that the sub-run from `start` to `end` (or its reverse), NFC-normalized and lowercased, is in the dictionary. *O(runLen²)* dict lookups; runs are bounded by `BOARD_SIZE = 10`, so ≤ 45 lookups per tile per axis.
 
@@ -242,6 +272,7 @@ These are board-global post-conditions. A scoring event that would break any of 
 | I5 | The board always has ≥ `MIN_UNFROZEN_TILES` (24) unfrozen tiles. | `freezeTiles` partial-freeze logic |
 | I6 | No swap ever targets a frozen tile (including tiles frozen earlier in the same round). | `processPlayerMove` rejection branch |
 | I7 | No two scored words in the same round on the same axis overlap or are physically adjacent. | `hasNoSameAxisConflict` |
+| I7a | No newly-scored word is physically adjacent on its own axis to a frozen tile that was previously scored on the same axis, unless the combined maximal same-axis scored run is itself a dict word. | §3.5a, `violatesFrozenAdjacencyOnSameAxis` |
 
 If you add a new scoring-related feature, state which invariant(s) your change affects and which it must continue to uphold. If you find an invariant is missing from this list, add it here and write a test that pins it.
 
@@ -278,6 +309,7 @@ Read this section before editing anything in `lib/game-engine/crossValidator.ts`
 | 2026-04-23 | #182 | #130 | Next round's `board_snapshot_before` was seeded from the raw sequential swap result instead of the word engine's `scoringFinalBoard`, so the next round could start on a board that contradicted the prior round's scoring. | N/A (out of scope for this doc — it was a board-seeding bug, not a rule bug). |
 | 2026-04-23 | #185 | #136 | Over-correction: `hasCrossWordViolation` and `violatesFrozenAdjacencyOnSameAxis` were modified to skip frozen tiles whose `scoredAxes` didn't include the current axis. This fixed the false rejection of `BÆN`/`BÁS` but opened §1's hole: a frozen tile physically on the board could be ignored during validation if it had been scored on a perpendicular axis, letting below-min and uncovered scored runs slip through. | §4.4 — `scoredAxes` must not gate validation. |
 | 2026-04-24 | #198 | #195 | The `scoredAxes`-based skip from #185 allowed invalid scored runs like `ML`, `NÐ`, `US` (length 2, below min) and `TKH`, `RNÝ`, `ÆLÁGA` (≥ 3 letters, not in dict, no covering sub-run) to be created at scoring time. Fixed by adopting the per-letter coverage rule: every frozen tile counts physically, and every new tile must be covered by a dict sub-run in every direction where its maximal scored run has length ≥ 2. `violatesFrozenAdjacencyOnSameAxis` was deleted; the new word itself is a same-axis covering sub-run for its tiles. | §4 (entire section) — the per-letter coverage rule. |
+| 2026-04-24 | #201 | #200 | Deleting `violatesFrozenAdjacencyOnSameAxis` in #198 lost the cross-round enforcement of the standalone invariant. The per-letter rule is trivially satisfied on the candidate's own axis (the candidate *is* a covering sub-run), so a new dict word could be placed physically adjacent to a prior same-axis scored dict word — producing invalid visual runs like `ÖRLTEL` (`ÖRL` + `TEL`), `ÞESSINÓK` (`ÞESSI` + `NÓK`), and `NEFÞEMA` (`NEF` + `ÞEMA`). Fixed by restoring the same-axis check as a sibling to `hasCrossWordViolation`: if a frozen same-axis extension exists (gated by `scoredAxes` when present, or by the run being a dict word in the legacy case), the combined sequence must itself be a dict word. `#136` is preserved because `Þ.scoredAxes = ["vertical"]` does not count as a horizontal extension for `BÆN`. | §3.5a and I7a — the cross-round standalone invariant, enforced by `violatesFrozenAdjacencyOnSameAxis`. |
 
 When you land a scoring-related fix, append a row here with: date, PR number, issue number, one-sentence description of what went wrong, and the rule section that now prevents it. If the fix exposes a rule that was not previously documented, document it in this file *in the same PR*.
 
@@ -288,7 +320,7 @@ When you land a scoring-related fix, append a row here with: date, PR number, is
 - **Rules surface** — this document is the source of truth; `lib/constants/game-config.ts` holds the numeric constants (`minimumWordLength`, `maxRounds`, `timePerRoundMs`, `boardSize`, `language`).
 - **Pipeline entry point** — `lib/game-engine/wordEngine.ts::processRoundScoring`.
 - **Scanner** — `lib/game-engine/boardScanner.ts::scanFromSwapCoordinates`.
-- **Cross-validator** — `lib/game-engine/crossValidator.ts::selectOptimalCombination`, `hasCrossWordViolation`, `runContainsValidSubRunCoveringIndex`.
+- **Cross-validator** — `lib/game-engine/crossValidator.ts::selectOptimalCombination`, `hasCrossWordViolation` (cross-axis, §7.3), `violatesFrozenAdjacencyOnSameAxis` (same-axis standalone, §7.4), `runContainsValidSubRunCoveringIndex`.
 - **Scorer** — `lib/game-engine/scorer.ts::calculateLetterPoints`, `calculateLengthBonus`.
 - **Freezer** — `lib/game-engine/frozenTiles.ts::freezeTiles`.
 - **Dictionary** — `lib/game-engine/dictionary.ts::loadDictionary`; wordlist at `data/wordlists/word_list_is.txt`.

--- a/lib/game-engine/crossValidator.ts
+++ b/lib/game-engine/crossValidator.ts
@@ -1,5 +1,5 @@
 import type { BoardGrid, BoardWord } from "@/lib/types/board";
-import type { FrozenTileMap } from "@/lib/types/match";
+import type { FrozenTileMap, ScoredAxis } from "@/lib/types/match";
 import { BOARD_SIZE } from "@/lib/constants/board";
 import { DEFAULT_GAME_CONFIG } from "@/lib/constants/game-config";
 import {
@@ -141,6 +141,125 @@ export function hasCrossWordViolation(
 }
 
 /**
+ * Does a candidate word physically abut a prior same-axis scored run
+ * such that the combined sequence is not a dict word?
+ *
+ * Enforces the standalone invariant (game_rules §3.5, I7) across
+ * rounds: a scored word must end at an unscored tile or the board
+ * edge, or — if it meets another scored word head-on on the same
+ * axis — the combined sequence must itself be a dict word. The
+ * within-round version lives in `hasNoSameAxisConflict`; this one
+ * catches the cross-round case (issue #200, ÖRLTEL / ÞESSINÓK /
+ * NEFÞEMA pattern).
+ *
+ * Uses `scoredAxes` metadata when available: a frozen tile extends
+ * the new word's axis iff it was previously scored on that axis.
+ * Legacy tiles without `scoredAxes` fall back to a physical-run
+ * heuristic: the extension counts only if the contiguous frozen run
+ * is itself a dict word (meaning it was almost certainly scored on
+ * this axis). This preserves #136 (Þ scored vertically, adjacent to
+ * horizontal BÆN, does not extend a horizontal scored run) and #195
+ * (cross-axis per-letter coverage is independent).
+ */
+function violatesFrozenAdjacencyOnSameAxis(
+  word: BoardWord,
+  board: BoardGrid,
+  frozenTileSet: Set<string>,
+  frozenTileMap: FrozenTileMap,
+  dictionary: Set<string>,
+): boolean {
+  const isHorizontal =
+    word.direction === "right" || word.direction === "left";
+  const wordAxis: ScoredAxis = isHorizontal ? "horizontal" : "vertical";
+  const dx = isHorizontal ? 1 : 0;
+  const dy = isHorizontal ? 0 : 1;
+
+  const sortedTiles = [...word.tiles].sort((a, b) =>
+    isHorizontal ? a.x - b.x : a.y - b.y,
+  );
+  const first = sortedTiles[0];
+  const last = sortedTiles[sortedTiles.length - 1];
+  const wordChars = sortedTiles.map((t) => board[t.y][t.x]);
+
+  const beforeRun = collectFrozenRun(first.x - dx, first.y - dy, -dx, -dy);
+  const afterRun = collectFrozenRun(last.x + dx, last.y + dy, dx, dy);
+
+  if (beforeRun && isInvalidCombined(beforeRun, true)) return true;
+  if (afterRun && isInvalidCombined(afterRun, false)) return true;
+
+  if (beforeRun && afterRun) {
+    const full = [
+      ...[...beforeRun.chars].reverse(),
+      ...wordChars,
+      ...afterRun.chars,
+    ];
+    if (!isDictWord(full)) return true;
+  }
+
+  return false;
+
+  function isDictWord(chars: string[]): boolean {
+    const text = chars.join("").normalize("NFC").toLowerCase();
+    const reversed = [...text].reverse().join("");
+    return dictionary.has(text) || dictionary.has(reversed);
+  }
+
+  function isSameAxisFrozen(x: number, y: number): boolean {
+    if (x < 0 || x >= BOARD_SIZE || y < 0 || y >= BOARD_SIZE) return false;
+    if (!frozenTileSet.has(`${x},${y}`)) return false;
+    const meta = frozenTileMap[`${x},${y}`];
+    // Legacy frozen tiles without scoredAxes: count as same-axis and
+    // let the dict-gate on the frozen run decide.
+    if (!meta || !meta.scoredAxes) return true;
+    return meta.scoredAxes.includes(wordAxis);
+  }
+
+  function hasScoredAxes(x: number, y: number): boolean {
+    const meta = frozenTileMap[`${x},${y}`];
+    return Boolean(meta?.scoredAxes);
+  }
+
+  function collectFrozenRun(
+    startX: number,
+    startY: number,
+    stepX: number,
+    stepY: number,
+  ): { chars: string[]; allHaveScoredAxes: boolean } | null {
+    if (!isSameAxisFrozen(startX, startY)) return null;
+
+    const chars: string[] = [];
+    let allHaveScoredAxes = true;
+    let cx = startX;
+    let cy = startY;
+    while (isSameAxisFrozen(cx, cy)) {
+      chars.push(board[cy][cx]);
+      if (!hasScoredAxes(cx, cy)) allHaveScoredAxes = false;
+      cx += stepX;
+      cy += stepY;
+    }
+    return { chars, allHaveScoredAxes };
+  }
+
+  function isInvalidCombined(
+    run: { chars: string[]; allHaveScoredAxes: boolean },
+    isBefore: boolean,
+  ): boolean {
+    // Legacy gate: when any tile in the frozen run lacks scoredAxes,
+    // only treat the run as a prior same-axis scored word if its
+    // letters form a dict word. Single letters (never dict words) are
+    // skipped — this preserves #136 where a single Þ is a perpendicular
+    // incidental neighbor, not an extension.
+    if (!run.allHaveScoredAxes) {
+      if (!isDictWord(run.chars)) return false;
+    }
+    const combined = isBefore
+      ? [...[...run.chars].reverse(), ...wordChars]
+      : [...wordChars, ...run.chars];
+    return !isDictWord(combined);
+  }
+}
+
+/**
  * Calculate total score for a word (letter points + length bonus).
  */
 function scoreWord(word: BoardWord): number {
@@ -187,7 +306,15 @@ export function selectOptimalCombination(
 
     if (!hasNoSameAxisConflict(subset)) continue;
 
-    if (isSubsetValid(subset, board, frozenTileSet, dictionary)) {
+    if (
+      isSubsetValid(
+        subset,
+        board,
+        frozenTileSet,
+        frozenTiles,
+        dictionary,
+      )
+    ) {
       const totalScore = subset.reduce(
         (sum, word) => sum + scoreWord(word),
         0,
@@ -270,6 +397,7 @@ function isSubsetValid(
   subset: BoardWord[],
   board: BoardGrid,
   frozenTileSet: Set<string>,
+  frozenTileMap: FrozenTileMap,
   dictionary: Set<string>,
 ): boolean {
   for (let i = 0; i < subset.length; i++) {
@@ -289,6 +417,18 @@ function isSubsetValid(
         frozenTileSet,
         dictionary,
         extraTiles,
+      )
+    ) {
+      return false;
+    }
+
+    if (
+      violatesFrozenAdjacencyOnSameAxis(
+        subset[i],
+        board,
+        frozenTileSet,
+        frozenTileMap,
+        dictionary,
       )
     ) {
       return false;

--- a/lib/game-engine/crossValidator.ts
+++ b/lib/game-engine/crossValidator.ts
@@ -1,5 +1,5 @@
 import type { BoardGrid, BoardWord } from "@/lib/types/board";
-import type { FrozenTileMap, ScoredAxis } from "@/lib/types/match";
+import type { FrozenTileMap } from "@/lib/types/match";
 import { BOARD_SIZE } from "@/lib/constants/board";
 import { DEFAULT_GAME_CONFIG } from "@/lib/constants/game-config";
 import {
@@ -141,36 +141,32 @@ export function hasCrossWordViolation(
 }
 
 /**
- * Does a candidate word physically abut a prior same-axis scored run
- * such that the combined sequence is not a dict word?
+ * Does the candidate word's axis physically abut frozen tiles, and
+ * is the resulting maximal same-axis scored run not a dict word?
  *
- * Enforces the standalone invariant (game_rules §3.5, I7) across
- * rounds: a scored word must end at an unscored tile or the board
+ * Enforces the standalone invariant (game_rules §3.5a / I7a) across
+ * rounds: a scored word must end at an unfrozen tile or the board
  * edge, or — if it meets another scored word head-on on the same
- * axis — the combined sequence must itself be a dict word. The
- * within-round version lives in `hasNoSameAxisConflict`; this one
- * catches the cross-round case (issue #200, ÖRLTEL / ÞESSINÓK /
- * NEFÞEMA pattern).
+ * axis — the full combined scored run must itself be a dict word.
+ * The within-round counterpart lives in `hasNoSameAxisConflict`.
  *
- * Uses `scoredAxes` metadata when available: a frozen tile extends
- * the new word's axis iff it was previously scored on that axis.
- * Legacy tiles without `scoredAxes` fall back to a physical-run
- * heuristic: the extension counts only if the contiguous frozen run
- * is itself a dict word (meaning it was almost certainly scored on
- * this axis). This preserves #136 (Þ scored vertically, adjacent to
- * horizontal BÆN, does not extend a horizontal scored run) and #195
- * (cross-axis per-letter coverage is independent).
+ * Purely physical — ignores `scoredAxes`. A candidate whose start or
+ * end tile is adjacent to a frozen tile on the same axis is extending
+ * the physically scored run. In a real game, an isolated perpendicular
+ * frozen neighbor does not exist: if a tile is frozen, it was part of
+ * a ≥ `minimumWordLength` scored word, so its in-line neighbors on
+ * the axis of that prior word are also frozen. Unfrozen letters
+ * physically adjacent to a new word (e.g. `Þ` next to `BÆN` in #136)
+ * do not trigger this check because they are not frozen.
  */
 function violatesFrozenAdjacencyOnSameAxis(
   word: BoardWord,
   board: BoardGrid,
   frozenTileSet: Set<string>,
-  frozenTileMap: FrozenTileMap,
   dictionary: Set<string>,
 ): boolean {
   const isHorizontal =
     word.direction === "right" || word.direction === "left";
-  const wordAxis: ScoredAxis = isHorizontal ? "horizontal" : "vertical";
   const dx = isHorizontal ? 1 : 0;
   const dy = isHorizontal ? 0 : 1;
 
@@ -181,82 +177,38 @@ function violatesFrozenAdjacencyOnSameAxis(
   const last = sortedTiles[sortedTiles.length - 1];
   const wordChars = sortedTiles.map((t) => board[t.y][t.x]);
 
-  const beforeRun = collectFrozenRun(first.x - dx, first.y - dy, -dx, -dy);
-  const afterRun = collectFrozenRun(last.x + dx, last.y + dy, dx, dy);
-
-  if (beforeRun && isInvalidCombined(beforeRun, true)) return true;
-  if (afterRun && isInvalidCombined(afterRun, false)) return true;
-
-  if (beforeRun && afterRun) {
-    const full = [
-      ...[...beforeRun.chars].reverse(),
-      ...wordChars,
-      ...afterRun.chars,
-    ];
-    if (!isDictWord(full)) return true;
+  const beforeChars: string[] = [];
+  let bx = first.x - dx;
+  let by = first.y - dy;
+  while (
+    bx >= 0 && bx < BOARD_SIZE &&
+    by >= 0 && by < BOARD_SIZE &&
+    frozenTileSet.has(`${bx},${by}`)
+  ) {
+    beforeChars.unshift(board[by][bx]);
+    bx -= dx;
+    by -= dy;
   }
 
-  return false;
-
-  function isDictWord(chars: string[]): boolean {
-    const text = chars.join("").normalize("NFC").toLowerCase();
-    const reversed = [...text].reverse().join("");
-    return dictionary.has(text) || dictionary.has(reversed);
+  const afterChars: string[] = [];
+  let fx = last.x + dx;
+  let fy = last.y + dy;
+  while (
+    fx >= 0 && fx < BOARD_SIZE &&
+    fy >= 0 && fy < BOARD_SIZE &&
+    frozenTileSet.has(`${fx},${fy}`)
+  ) {
+    afterChars.push(board[fy][fx]);
+    fx += dx;
+    fy += dy;
   }
 
-  function isSameAxisFrozen(x: number, y: number): boolean {
-    if (x < 0 || x >= BOARD_SIZE || y < 0 || y >= BOARD_SIZE) return false;
-    if (!frozenTileSet.has(`${x},${y}`)) return false;
-    const meta = frozenTileMap[`${x},${y}`];
-    // Legacy frozen tiles without scoredAxes: count as same-axis and
-    // let the dict-gate on the frozen run decide.
-    if (!meta || !meta.scoredAxes) return true;
-    return meta.scoredAxes.includes(wordAxis);
-  }
+  if (beforeChars.length === 0 && afterChars.length === 0) return false;
 
-  function hasScoredAxes(x: number, y: number): boolean {
-    const meta = frozenTileMap[`${x},${y}`];
-    return Boolean(meta?.scoredAxes);
-  }
-
-  function collectFrozenRun(
-    startX: number,
-    startY: number,
-    stepX: number,
-    stepY: number,
-  ): { chars: string[]; allHaveScoredAxes: boolean } | null {
-    if (!isSameAxisFrozen(startX, startY)) return null;
-
-    const chars: string[] = [];
-    let allHaveScoredAxes = true;
-    let cx = startX;
-    let cy = startY;
-    while (isSameAxisFrozen(cx, cy)) {
-      chars.push(board[cy][cx]);
-      if (!hasScoredAxes(cx, cy)) allHaveScoredAxes = false;
-      cx += stepX;
-      cy += stepY;
-    }
-    return { chars, allHaveScoredAxes };
-  }
-
-  function isInvalidCombined(
-    run: { chars: string[]; allHaveScoredAxes: boolean },
-    isBefore: boolean,
-  ): boolean {
-    // Legacy gate: when any tile in the frozen run lacks scoredAxes,
-    // only treat the run as a prior same-axis scored word if its
-    // letters form a dict word. Single letters (never dict words) are
-    // skipped — this preserves #136 where a single Þ is a perpendicular
-    // incidental neighbor, not an extension.
-    if (!run.allHaveScoredAxes) {
-      if (!isDictWord(run.chars)) return false;
-    }
-    const combined = isBefore
-      ? [...[...run.chars].reverse(), ...wordChars]
-      : [...wordChars, ...run.chars];
-    return !isDictWord(combined);
-  }
+  const fullRun = [...beforeChars, ...wordChars, ...afterChars];
+  const fullText = fullRun.join("").normalize("NFC").toLowerCase();
+  const reversed = [...fullText].reverse().join("");
+  return !dictionary.has(fullText) && !dictionary.has(reversed);
 }
 
 /**
@@ -306,15 +258,7 @@ export function selectOptimalCombination(
 
     if (!hasNoSameAxisConflict(subset)) continue;
 
-    if (
-      isSubsetValid(
-        subset,
-        board,
-        frozenTileSet,
-        frozenTiles,
-        dictionary,
-      )
-    ) {
+    if (isSubsetValid(subset, board, frozenTileSet, dictionary)) {
       const totalScore = subset.reduce(
         (sum, word) => sum + scoreWord(word),
         0,
@@ -397,7 +341,6 @@ function isSubsetValid(
   subset: BoardWord[],
   board: BoardGrid,
   frozenTileSet: Set<string>,
-  frozenTileMap: FrozenTileMap,
   dictionary: Set<string>,
 ): boolean {
   for (let i = 0; i < subset.length; i++) {
@@ -427,7 +370,6 @@ function isSubsetValid(
         subset[i],
         board,
         frozenTileSet,
-        frozenTileMap,
         dictionary,
       )
     ) {

--- a/tests/unit/lib/game-engine/crossValidator.test.ts
+++ b/tests/unit/lib/game-engine/crossValidator.test.ts
@@ -641,13 +641,11 @@ describe("selectOptimalCombination", () => {
     expect(result[0].text).toBe("abc");
   });
 
-  // T040: Rejects word adjacent to frozen tiles on same axis when combined is invalid
-  test("T040: allows word adjacent to frozen tiles on same axis even when full combined sequence is not a dict word (per-letter rule, issue #195)", () => {
+  // T040: Rejects word adjacent to frozen same-axis dict-word run
+  test("T040: rejects word adjacent to a frozen same-axis dict-word run when combined sequence is not a dict word (#200)", () => {
     const localDict = new Set(["uma", "xy"]);
     const board = emptyBoard();
-    // "uma" vertically at column 0, rows 0-2
     placeV(board, "uma", 0, 0);
-    // Frozen tiles at (0,3) and (0,4) with letters "x","y"
     board[3][0] = "x";
     board[4][0] = "y";
 
@@ -656,10 +654,9 @@ describe("selectOptimalCombination", () => {
       "0,4": { owner: "player_b" },
     };
 
-    // Under the per-letter rule: each letter of "uma" is covered by the
-    // sub-run "uma" (valid dict word) within the maximal same-axis run
-    // "umaxy". The full run need not itself be a dict word — #195 only
-    // forbids scored letters that have no valid covering sub-run.
+    // Legacy frozen tiles form "xy", itself a dict word → treated as a
+    // prior same-axis scored word. Combined "umaxy" is not a dict word
+    // → reject (standalone invariant, issue #200).
     const candidates = [vWord("uma", 0, 0)];
     const result = selectOptimalCombination(
       candidates,
@@ -669,8 +666,7 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("uma");
+    expect(result).toHaveLength(0);
   });
 
   // T041: Allows word adjacent to frozen tiles on same axis when combined IS valid
@@ -701,21 +697,18 @@ describe("selectOptimalCombination", () => {
   });
 
   // T042: Word with frozen tiles before it on same axis — combined not in dict
-  test("T042: allows word when frozen tiles precede it on same axis even with combined not a dict word (per-letter rule)", () => {
+  test("T042: rejects word when frozen same-axis dict-word precedes it and combined sequence is not a dict word (#200)", () => {
     const localDict = new Set(["cd", "ab"]);
     const board = emptyBoard();
     placeH(board, "abcd", 0, 0);
 
-    // Frozen "ab" at (0,0)-(1,0)
     const frozenTiles: FrozenTileMap = {
       "0,0": { owner: "player_a" },
       "1,0": { owner: "player_a" },
     };
 
-    // Under the per-letter rule: "cd" is itself a valid sub-run covering
-    // its own tiles. The full combined "abcd" not being in dict no
-    // longer matters — each scored letter is covered by at least one
-    // valid dict sub-run.
+    // Frozen "ab" (dict word) extends the new word's same axis.
+    // Combined "abcd" is not in the dict → reject.
     const candidates = [hWord("cd", 2, 0)];
     const result = selectOptimalCombination(
       candidates,
@@ -725,8 +718,7 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("cd");
+    expect(result).toHaveLength(0);
   });
 
   // Additional: empty candidates returns empty result
@@ -814,19 +806,12 @@ describe("selectOptimalCombination", () => {
     expect(result[0].text).toBe("abc");
   });
 
-  // T047: Sandwich — word between two frozen runs, pairwise valid but full sequence invalid
-  test("T047: allows word sandwiched between frozen runs even when full combined sequence isn't a dict word (per-letter rule)", () => {
-    // "ab", "cd", "ef" are valid words; "abcd", "cdef", "bcd" are valid;
-    // but "abcdef" is NOT. Under the per-letter rule each scored letter
-    // only needs some valid covering sub-run — "abcd"/"cdef"/"bcd"
-    // cover every letter in "cd" — so the full "abcdef" need not itself
-    // be a dict word.
+  // T047: Sandwich — word between two frozen runs, full sequence invalid → reject
+  test("T047: rejects word sandwiched between frozen same-axis dict-word runs when full combined sequence isn't a dict word (#200)", () => {
     const localDict = new Set(["ab", "cd", "ef", "abcd", "cdef", "bcd"]);
     const board = emptyBoard();
     placeH(board, "abcdef", 0, 0);
 
-    // Frozen "ab" at (0,0)-(1,0) from a prior round
-    // Frozen "ef" at (4,0)-(5,0) from a prior round
     const frozenTiles: FrozenTileMap = {
       "0,0": { owner: "player_a" },
       "1,0": { owner: "player_a" },
@@ -834,7 +819,10 @@ describe("selectOptimalCombination", () => {
       "5,0": { owner: "player_b" },
     };
 
-    // New word "cd" at (2,0)-(3,0) fills the gap
+    // Both sides have dict-word frozen extensions ("ab" and "ef"). The
+    // combined "ab" + "cd" is "abcd" (dict) and "cd" + "ef" is "cdef"
+    // (dict) individually, but the full sandwich "abcdef" is not a
+    // dict word → reject (standalone invariant, issue #200).
     const candidates = [hWord("cd", 2, 0)];
     const result = selectOptimalCombination(
       candidates,
@@ -844,8 +832,7 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("cd");
+    expect(result).toHaveLength(0);
   });
 
   // T048: Sandwich — full combined sequence IS valid → word accepted
@@ -904,14 +891,13 @@ describe("selectOptimalCombination", () => {
 
   // ─── T049: Physical Adjacency vs scoredAxes ─────────────────────
 
-  // T049: Single frozen tile with scoredAxes adjacent to
-  // a horizontal word — combined invalid → rejected (THE BUG FIX)
-  //
-  // Even if a tile was originally scored on a perpendicular axis (e.g. vertical),
-  // physical adjacency on the horizontal axis means it physically extends
-  // the sequence horizontally. Therefore, the combined sequence MUST be a valid
-  // word, regardless of the tile's scoredAxes metadata.
-  test("T049: allows horizontal word adjacent to a frozen tile regardless of its scoredAxes (per-letter rule)", () => {
+  // T049: Rejects horizontal word that extends a prior horizontal-scored
+  // frozen tile into a combined run that is not a dict word (issue #200).
+  // The tile at (3,0) was scored on the horizontal axis, so placing a new
+  // horizontal word adjacent to it concatenates two same-axis scored
+  // sequences. The combined "atað" must be a dict word for the
+  // placement to be valid; since it is not, "tað" is rejected.
+  test("T049: rejects horizontal word that extends a same-axis prior-scored tile into a non-dict combined run (#200)", () => {
     const localDict = new Set(["tað"]);
     const board = emptyBoard();
     board[0][3] = "a";
@@ -930,10 +916,7 @@ describe("selectOptimalCombination", () => {
       "player_b",
     );
 
-    // Maximal same-axis run "atað" is not a dict word, but "tað" is
-    // a valid sub-run covering every letter of the new word. Accepted.
-    expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("tað");
+    expect(result).toHaveLength(0);
   });
 
   test("T049b: ALLOWS horizontal word adjacent to a frozen tile scored only on a perpendicular axis (issue #136)", () => {
@@ -966,7 +949,7 @@ describe("selectOptimalCombination", () => {
     expect(result[0].text).toBe("tað");
   });
 
-  test("T049c: allows horizontal word adjacent to multi-axis frozen tile (per-letter rule)", () => {
+  test("T049c: rejects horizontal word adjacent to multi-axis frozen tile when combined run is not a dict word (#200)", () => {
     const localDict = new Set(["tað"]);
     const board = emptyBoard();
     board[0][3] = "x";
@@ -985,13 +968,12 @@ describe("selectOptimalCombination", () => {
       "player_b",
     );
 
-    // Same-axis run "xtað" not in dict, but "tað" covers all its
-    // letters → accepted under per-letter rule.
-    expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("tað");
+    // scoredAxes includes "horizontal" → the frozen tile extends a prior
+    // horizontal scored run. Combined "xtað" is not a dict word → reject.
+    expect(result).toHaveLength(0);
   });
 
-  test("T049d: allows word adjacent to legacy (no-scoredAxes) frozen tiles when new word itself is a valid covering sub-run", () => {
+  test("T049d: rejects word adjacent to legacy (no-scoredAxes) frozen tiles whose letters form a dict word when combined run is not (#200)", () => {
     const localDict = new Set(["uma", "xy"]);
     const board = emptyBoard();
     placeV(board, "uma", 0, 0);
@@ -1012,10 +994,10 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    // Combined "umaxy" is not a dict word, but "uma" is a valid
-    // covering sub-run for every letter of the new word. Accepted.
-    expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("uma");
+    // Legacy frozen tiles (no scoredAxes) form "xy", itself a dict word
+    // → treated as a prior same-axis scored word. Combined "umaxy" is
+    // not a dict word → reject (standalone invariant, issue #200).
+    expect(result).toHaveLength(0);
   });
 
   // T050: NÖS regression — under the per-letter rule (issue #195), a
@@ -1102,6 +1084,171 @@ describe("selectOptimalCombination", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].text).toBe("ab");
+  });
+
+  // ─── Issue #200: cross-round same-axis standalone invariant ─────
+  //
+  // When a new word's endpoint physically abuts a frozen same-axis
+  // scored run, the combined sequence must be a dict word — otherwise
+  // the board ends up showing concatenations like "ÖRLTEL" (= ÖRL +
+  // TEL), "ÞESSINÓK" (= ÞESSI + NÓK), "NEFÞEMA" (= NEF + ÞEMA) that
+  // aren't valid words. This is the per-round `hasNoSameAxisConflict`
+  // rule extended across rounds.
+
+  test("T053 (#200): rejects vertical word that extends a prior-scored same-axis dict word into a non-dict combined run (ÖRL+TEL=ÖRLTEL)", () => {
+    const localDict = new Set(["örl", "tel"]);
+    const board = emptyBoard();
+    // Prior: ÖRL scored vertically at col 1 rows 1-3
+    placeV(board, "örl", 1, 1);
+    // New candidate: TEL vertical at col 1 rows 4-6
+    placeV(board, "tel", 1, 4);
+
+    const frozenTiles: FrozenTileMap = {
+      "1,1": { owner: "player_b", scoredAxes: ["vertical"] },
+      "1,2": { owner: "player_b", scoredAxes: ["vertical"] },
+      "1,3": { owner: "player_b", scoredAxes: ["vertical"] },
+    };
+
+    const candidates = [vWord("tel", 1, 4)];
+    const result = selectOptimalCombination(
+      candidates,
+      board,
+      frozenTiles,
+      localDict,
+      "player_a",
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("T054 (#200): rejects vertical word that concatenates with a prior-scored same-axis dict word above it (ÞESSI+NÓK=ÞESSINÓK)", () => {
+    const localDict = new Set(["þessi", "nók"]);
+    const board = emptyBoard();
+    placeV(board, "þessi", 9, 0);
+    placeV(board, "nók", 9, 5);
+
+    const frozenTiles: FrozenTileMap = {
+      "9,0": { owner: "player_b", scoredAxes: ["vertical"] },
+      "9,1": { owner: "player_b", scoredAxes: ["vertical"] },
+      "9,2": { owner: "player_b", scoredAxes: ["vertical"] },
+      "9,3": { owner: "player_b", scoredAxes: ["vertical"] },
+      "9,4": { owner: "player_b", scoredAxes: ["vertical"] },
+    };
+
+    const candidates = [vWord("nók", 9, 5)];
+    const result = selectOptimalCombination(
+      candidates,
+      board,
+      frozenTiles,
+      localDict,
+      "player_a",
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("T055 (#200): rejects horizontal word that concatenates with a prior-scored same-axis dict word (NEF+ÞEMA=NEFÞEMA)", () => {
+    const localDict = new Set(["nef", "þema"]);
+    const board = emptyBoard();
+    placeH(board, "nef", 1, 9);
+    placeH(board, "þema", 4, 9);
+
+    const frozenTiles: FrozenTileMap = {
+      "1,9": { owner: "player_a", scoredAxes: ["horizontal"] },
+      "2,9": { owner: "player_a", scoredAxes: ["horizontal"] },
+      "3,9": { owner: "player_a", scoredAxes: ["horizontal"] },
+    };
+
+    const candidates = [hWord("þema", 4, 9)];
+    const result = selectOptimalCombination(
+      candidates,
+      board,
+      frozenTiles,
+      localDict,
+      "player_b",
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("T056 (#200): accepts vertical word when combined run with prior-scored same-axis dict word IS a dict word", () => {
+    const localDict = new Set(["nef", "þema", "nefþema"]);
+    const board = emptyBoard();
+    placeH(board, "nef", 1, 9);
+    placeH(board, "þema", 4, 9);
+
+    const frozenTiles: FrozenTileMap = {
+      "1,9": { owner: "player_a", scoredAxes: ["horizontal"] },
+      "2,9": { owner: "player_a", scoredAxes: ["horizontal"] },
+      "3,9": { owner: "player_a", scoredAxes: ["horizontal"] },
+    };
+
+    const candidates = [hWord("þema", 4, 9)];
+    const result = selectOptimalCombination(
+      candidates,
+      board,
+      frozenTiles,
+      localDict,
+      "player_b",
+    );
+
+    // Combined "nefþema" is in the dict → accept.
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("þema");
+  });
+
+  test("T057 (#136 regression): accepts horizontal word adjacent to a perpendicular-axis-only frozen tile (NMÚL-shape, BÆN-shape)", () => {
+    // Frozen N at (5,3) scored only horizontally — does NOT extend the
+    // new vertical word MÚL on its own (vertical) axis.
+    const localDict = new Set(["múl"]);
+    const board = emptyBoard();
+    board[3][5] = "n";
+    placeV(board, "múl", 5, 4);
+
+    const frozenTiles: FrozenTileMap = {
+      "5,3": { owner: "player_a", scoredAxes: ["horizontal"] },
+    };
+
+    const candidates = [vWord("múl", 5, 4)];
+    const result = selectOptimalCombination(
+      candidates,
+      board,
+      frozenTiles,
+      localDict,
+      "player_b",
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("múl");
+  });
+
+  test("T058 (#200): rejects candidate sandwiched between two prior same-axis scored words whose combined sequence is not dict", () => {
+    const localDict = new Set(["ab", "xy", "tel"]);
+    const board = emptyBoard();
+    board[2][0] = "a";
+    board[2][1] = "b";
+    placeH(board, "tel", 2, 2);
+    board[2][5] = "x";
+    board[2][6] = "y";
+
+    const frozenTiles: FrozenTileMap = {
+      "0,2": { owner: "player_b", scoredAxes: ["horizontal"] },
+      "1,2": { owner: "player_b", scoredAxes: ["horizontal"] },
+      "5,2": { owner: "player_b", scoredAxes: ["horizontal"] },
+      "6,2": { owner: "player_b", scoredAxes: ["horizontal"] },
+    };
+
+    const candidates = [hWord("tel", 2, 2)];
+    const result = selectOptimalCombination(
+      candidates,
+      board,
+      frozenTiles,
+      localDict,
+      "player_a",
+    );
+
+    // Combined "abtelxy" (or any extended combinations) not in dict → reject.
+    expect(result).toHaveLength(0);
   });
 });
 

--- a/tests/unit/lib/game-engine/crossValidator.test.ts
+++ b/tests/unit/lib/game-engine/crossValidator.test.ts
@@ -919,22 +919,21 @@ describe("selectOptimalCombination", () => {
     expect(result).toHaveLength(0);
   });
 
-  test("T049b: ALLOWS horizontal word adjacent to a frozen tile scored only on a perpendicular axis (issue #136)", () => {
-    // A frozen tile with scoredAxes=["vertical"] was placed by a vertical
-    // word. Horizontally it's an incidental neighbor — placing a new
-    // horizontal word next to it does NOT extend any prior horizontal
-    // word, so the combined-sequence check should not fire. Previously
-    // this rejected the placement and prevented valid 3-letter words
-    // (e.g. BÆN, BÁS) from scoring whenever a frozen perpendicular-axis
-    // tile happened to sit adjacent. See issue #136.
+  test("T049b (real #136): accepts horizontal word adjacent to an UNFROZEN tile on the same axis", () => {
+    // The actual #136 scenario: Þ at (1,2) is an ordinary unfrozen
+    // tile, not a scored one. An unfrozen neighbor never triggers the
+    // same-axis standalone check, so BÆN / BÁS score normally.
+    // Previous synthetic formulations of this test had Þ frozen with
+    // scoredAxes=["vertical"] — a physically impossible configuration
+    // (a vertical scored word of ≥ 3 tiles would freeze more than one
+    // tile). See T049b-synth for what happens if such a configuration
+    // did exist.
     const localDict = new Set(["tað"]);
     const board = emptyBoard();
-    board[0][3] = "x";
+    board[0][3] = "x"; // unfrozen neighbor
     placeH(board, "tað", 4, 0);
 
-    const frozenTiles: FrozenTileMap = {
-      "3,0": { owner: "player_a", scoredAxes: ["vertical"] },
-    };
+    const frozenTiles: FrozenTileMap = {};
 
     const candidates = [hWord("tað", 4, 0)];
     const result = selectOptimalCombination(
@@ -1000,11 +999,10 @@ describe("selectOptimalCombination", () => {
     expect(result).toHaveLength(0);
   });
 
-  // T050: NÖS regression — under the per-letter rule (issue #195), a
-  // new word sitting directly below a frozen single letter is allowed
-  // as long as the new word itself covers its letters. The combined
-  // run need not be a dict word.
-  test("T050: allows vertical word when a single frozen letter above it extends the run but nös itself covers its letters", () => {
+  // T050 (#200): rejects new word that physically concatenates with a
+  // frozen neighbor on the same axis, regardless of the frozen tile's
+  // scoredAxes, when the combined run isn't a dict word.
+  test("T050 (#200): rejects vertical word when a frozen letter above it extends the physical run into a non-dict combined sequence", () => {
     const localDict = new Set(["nös"]);
     const board = emptyBoard();
     board[1][3] = "R";
@@ -1025,8 +1023,8 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("nös");
+    // Physical same-axis run "RNÖS" is not a dict word → reject.
+    expect(result).toHaveLength(0);
   });
 
   // T051: NÖS regression — same scenario but combined run IS a valid word → accept
@@ -1058,11 +1056,10 @@ describe("selectOptimalCombination", () => {
     expect(result[0].text).toBe("nös");
   });
 
-  // T052: Same-axis frozen letter precedes the new word — under the
-  // per-letter rule the new word covers its own letters and the combined
-  // run need not be a dict word. Contrived 2-letter candidate; the real
-  // scanner would never emit one.
-  test("T052: allows horizontal word when a single frozen letter precedes it (per-letter rule)", () => {
+  // T052 (#200): same structure as the NMÚL / SMÁD reports — a single
+  // frozen letter immediately abutting the new word on its own axis
+  // creates a non-dict combined run and must be rejected.
+  test("T052 (#200): rejects horizontal word when a single frozen letter precedes it and combined run is not a dict word", () => {
     const localDict = new Set(["ab"]);
     const board = emptyBoard();
     board[2][1] = "X";
@@ -1082,8 +1079,8 @@ describe("selectOptimalCombination", () => {
       "player_a",
     );
 
-    expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("ab");
+    // Physical same-axis run "XAB" is not a dict word → reject.
+    expect(result).toHaveLength(0);
   });
 
   // ─── Issue #200: cross-round same-axis standalone invariant ─────
@@ -1197,9 +1194,10 @@ describe("selectOptimalCombination", () => {
     expect(result[0].text).toBe("þema");
   });
 
-  test("T057 (#136 regression): accepts horizontal word adjacent to a perpendicular-axis-only frozen tile (NMÚL-shape, BÆN-shape)", () => {
-    // Frozen N at (5,3) scored only horizontally — does NOT extend the
-    // new vertical word MÚL on its own (vertical) axis.
+  test("T057 (#200): rejects vertical word MÚL when a frozen N above it forms the non-dict combined run NMÚL (exact bug from #200)", () => {
+    // The NMÚL case from issue #200. It does not matter which axis N
+    // was originally scored on — the physical same-axis scored run
+    // after MÚL freezes is "NMÚL", which is not a dict word. Reject.
     const localDict = new Set(["múl"]);
     const board = emptyBoard();
     board[3][5] = "n";
@@ -1218,8 +1216,7 @@ describe("selectOptimalCombination", () => {
       "player_b",
     );
 
-    expect(result).toHaveLength(1);
-    expect(result[0].text).toBe("múl");
+    expect(result).toHaveLength(0);
   });
 
   test("T058 (#200): rejects candidate sandwiched between two prior same-axis scored words whose combined sequence is not dict", () => {

--- a/tests/unit/lib/game-engine/wordEngine.test.ts
+++ b/tests/unit/lib/game-engine/wordEngine.test.ts
@@ -125,8 +125,8 @@ describe("wordEngine", () => {
     expect(result.deltas.playerB).toBe(0);
   });
 
-  describe("issue #136: BÆN + BÁS adjacent to perpendicular-axis frozen tiles", () => {
-    function makeBoardWithFrozenNeighbor(): BoardGrid {
+  describe("issue #136: BÆN + BÁS next to unfrozen neighbors", () => {
+    function makeBoardWithUnfrozenNeighbor(): BoardGrid {
       const board = emptyBoard("X");
       // Letters that complete BÆN horizontally and BÁS vertically once B
       // lands at (2,2).
@@ -136,20 +136,19 @@ describe("wordEngine", () => {
       board[4][2] = "S"; // (2,4)
       // Source tile for the swap.
       board[9][9] = "B";
-      // A neighbor letter on the same row as BÆN, frozen from a prior
-      // VERTICAL word the opponent scored. Without scoredAxes-aware
-      // checks this single tile blocked both BÆN (same-axis combined
-      // "DBÆN" not a word) and BÁS (B's perpendicular cross "DB" was
-      // a 2-letter sequence below the minimum word length).
+      // A neighbor letter on the same row as BÆN. In the real #136
+      // screenshot this tile is UNFROZEN — so the same-axis standalone
+      // check does not fire. Unfrozen neighbors can never extend a
+      // scored run (only frozen tiles can).
       board[2][1] = "D"; // (1,2)
       return board;
     }
 
-    test("scores both BÆN and BÁS even when a perpendicular-axis frozen tile sits adjacent (issue #136)", async () => {
-      const board = makeBoardWithFrozenNeighbor();
-      const frozenTiles: FrozenTileMap = {
-        "1,2": { owner: "player_b", scoredAxes: ["vertical"] },
-      };
+    test("scores both BÆN and BÁS when the adjacent tile is unfrozen (real #136 scenario)", async () => {
+      const board = makeBoardWithUnfrozenNeighbor();
+      // Empty frozenTiles — D at (1,2) is unfrozen, just like Þ in the
+      // real #136 screenshot.
+      const frozenTiles: FrozenTileMap = {};
 
       const result = await processRoundScoring({
         matchId: MATCH_ID,
@@ -175,12 +174,11 @@ describe("wordEngine", () => {
       expect(words).toContain("bás");
     });
 
-    test("rejects BÆN when the adjacent frozen tile was scored on the same (horizontal) axis (#200)", async () => {
-      const board = makeBoardWithFrozenNeighbor();
-      // D at (1,2) scored horizontally in a prior round. Placing BÆN
-      // horizontally next to it concatenates two same-axis scored
-      // sequences into "DBÆN", which is not a dict word — the
-      // cross-round standalone invariant (§3.5 / I7) rejects BÆN.
+    test("rejects BÆN when the adjacent tile is frozen and the combined run is not a dict word (#200)", async () => {
+      const board = makeBoardWithUnfrozenNeighbor();
+      // D at (1,2) is frozen. The physical same-axis scored run after
+      // BÆN freezes would be "DBÆN", which is not a dict word — the
+      // cross-round standalone invariant (§3.5a / I7a) rejects BÆN.
       const frozenTiles: FrozenTileMap = {
         "1,2": { owner: "player_b", scoredAxes: ["horizontal"] },
       };

--- a/tests/unit/lib/game-engine/wordEngine.test.ts
+++ b/tests/unit/lib/game-engine/wordEngine.test.ts
@@ -175,13 +175,12 @@ describe("wordEngine", () => {
       expect(words).toContain("bás");
     });
 
-    test("still scores BÆN when the adjacent frozen tile was scored on the same axis (per-letter rule, issue #195)", async () => {
+    test("rejects BÆN when the adjacent frozen tile was scored on the same (horizontal) axis (#200)", async () => {
       const board = makeBoardWithFrozenNeighbor();
-      // Same D, but this time it was scored on a horizontal word that
-      // ends at (1,2). The combined same-axis run "DBÆN" is not a dict
-      // word, but under the per-letter rule (issue #195) each letter of
-      // the new word only needs SOME valid covering sub-run — and
-      // "bæn" covers b, æ, n. Scored.
+      // D at (1,2) scored horizontally in a prior round. Placing BÆN
+      // horizontally next to it concatenates two same-axis scored
+      // sequences into "DBÆN", which is not a dict word — the
+      // cross-round standalone invariant (§3.5 / I7) rejects BÆN.
       const frozenTiles: FrozenTileMap = {
         "1,2": { owner: "player_b", scoredAxes: ["horizontal"] },
       };
@@ -206,7 +205,7 @@ describe("wordEngine", () => {
       });
 
       const words = result.playerAWords.map((w) => w.word);
-      expect(words).toContain("bæn");
+      expect(words).not.toContain("bæn");
     });
   });
 


### PR DESCRIPTION
## Summary

- Restore the cross-round same-axis standalone invariant that was lost in #198, enforced by a restored `violatesFrozenAdjacencyOnSameAxis`.
- **Purely physical**: any frozen tile abutting the candidate on its axis triggers the check; the maximal combined same-axis scored run must itself be a dict word. No `scoredAxes` gating.
- Catches all 5 words reported in #200: `ÖRLTEL`, `NMÚL`, `ÞESSINÓK`, `NEFÞEMA`, `SMÁD`.
- Preserves real #136: the adjacent `Þ` in the #136 screenshot is **unfrozen**, and unfrozen neighbors never trigger the rule.

## Why this rule works

In a real game a frozen tile cannot exist in isolation on its axis: a ≥ `minimumWordLength` scored word freezes at least 3 contiguous tiles. So there is no need to distinguish "same-axis-scored" vs "perpendicular-scored" frozen neighbors via `scoredAxes` — any frozen neighbor is a real extension of the scored run.

## Spec updates

- Previous spec §4.3 mis-described #136 as "Frozen Þ at (1,2), scored earlier on a vertical word." In the actual screenshot Þ is unfrozen; corrected to reflect that.
- New §3.5a, §7.4, I7a — purely physical same-axis standalone rule.
- §4.4 clarified: both cross-axis and same-axis rules are physical, `scoredAxes` is audit-only.
- §10 change-log row appended.

## Tests

- Flipped the tests that locked in the buggy #198 behavior: T040, T042, T047, T049, T049c, T049d; the wordEngine #195 horizontal variant.
- Flipped T050 and T052 to reject (single frozen tile → combined non-dict run → reject, matching NMÚL / SMÁD).
- Renamed T049b to the real #136 scenario (unfrozen neighbor → accept).
- New T053–T058 — one per reported #200 pattern plus a sandwich case and the exact NMÚL scenario.
- Updated the wordEngine #136 test to use an unfrozen neighbor, matching the real screenshot.

## Verification

- [x] `pnpm test` — 1037 passed, 2 skipped
- [x] `pnpm test:integration` — 42 passed
- [x] `pnpm typecheck` — clean
- [ ] CI runs full Playwright + perf gates

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)