### PR TITLE
chore(ci): stabilize pnpm quickstart — retry cleanup + disable edge_runtime

### DIFF
--- a/scripts/supabase/quickstart.sh
+++ b/scripts/supabase/quickstart.sh
@@ -82,13 +82,19 @@ function start_supabase_with_retry() {
     retry_count=$((retry_count + 1))
     local wait_seconds=$((2 ** retry_count)) # Exponential backoff: 2, 4, 8, 16 seconds
     echo "Supabase start attempt $retry_count failed, waiting ${wait_seconds}s before retry..." >&2
+    # Clean up containers a partial start may have left behind, otherwise the
+    # next attempt hits "address already in use" on the Supabase DB port.
+    "$SUPABASE_BIN" stop >/dev/null 2>&1 || true
     sleep "$wait_seconds"
   done
 
   if [[ "$start_success" != "true" ]]; then
-    echo "Supabase start failed after $max_retries attempts. Trying to stop and restart..." >&2
+    echo "Supabase start failed after $max_retries attempts. Force-cleaning and retrying..." >&2
     "$SUPABASE_BIN" stop >/dev/null 2>&1 || true
-    sleep 2
+    # Last resort: kill any container still bound to the Supabase DB port
+    # that Supabase CLI's own stop missed (can happen after an aborted start).
+    docker ps --filter "publish=54322" -q | xargs -r docker kill >/dev/null 2>&1 || true
+    sleep 3
     "$SUPABASE_BIN" start >/dev/null || {
       emit_json "supabase.quickstart.error" "message" "Supabase start failed. Ensure Docker is running and accessible."
       exit 1


### PR DESCRIPTION
## Problem

\`pnpm quickstart\` has been failing the Artillery Perf Gate repeatedly. Two distinct failure modes surfaced — fixing the first revealed the second. This PR addresses both.

### Failure 1: Port 54322 already in use

Seen on PR #204's Artillery run. \`supabase start\` retry loop didn't clean up between attempts, so a partial start on attempt 1 left the DB container holding port 54322 and attempts 2-3 hit \"address already in use\" and aborted.

### Failure 2: Edge Runtime 502 during health check

After fix 1 landed on this branch, the next CI run got past the port issue and hit:
\`\`\`
supabase_edge_runtime_wottle-local container logs:
Stopping containers...
Error status 502:
\`\`\`
The Edge Runtime (Deno) service failed its readiness check. This project ships no Edge Functions — there's no \`supabase/functions/\` directory, and \`grep -r edge_runtime\` turns up nothing in \`app/\`, \`lib/\`, or \`components/\`. The service was only running to slow down start and expose us to its flaky health check.

## Fix

Two small, targeted changes:

### \`scripts/supabase/quickstart.sh\` — retry cleanup

Inside \`start_supabase_with_retry\`:

1. Call \`supabase stop\` between each retry attempt so a partial start from attempt N doesn't poison attempt N+1.
2. On final fallback, force-kill any container still publishing port 54322 (\`docker ps --filter publish=54322 -q | xargs -r docker kill\`) before the last restart, as a belt-and-braces for containers the Supabase CLI's state file missed.

Both new commands \`|| true\` — no-ops when nothing is there. No effect on the happy path.

### \`supabase/config.toml\` — disable edge_runtime

\`\`\`toml
[edge_runtime]
enabled = false
\`\`\`

Skips the container entirely. Eliminates the health-check flake and shaves some startup time locally too.

## Verification

- \`bash -n scripts/supabase/quickstart.sh\` — syntax OK.
- \`supabase status\` after config change — parses cleanly.
- Happy-path local \`pnpm quickstart\` still works (attempt 1 succeeds, new cleanup paths not exercised, edge_runtime just never starts).

## Test plan

- [ ] After merge, observe: Artillery Perf Gate clears \`pnpm quickstart\` consistently across several CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)