### PR TITLE
chore(supabase): disable edge_runtime (no Edge Functions in this proj…

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -23,3 +23,10 @@ file_size_limit = "50MiB"
 
 [analytics]
 enabled = false
+
+# Edge Runtime (Deno) hosts Supabase Edge Functions. This project ships no
+# Edge Functions (no supabase/functions/ directory), so leaving the service
+# on only costs startup time and a flaky health check in CI — its 502 has
+# aborted `pnpm quickstart` on the Artillery Perf Gate runs.
+[edge_runtime]
+enabled = false


### PR DESCRIPTION
…ect)

After the retry-cleanup fix unblocked the port-binding case, the next quickstart failure in Artillery Perf Gate (PR #205) was a 502 from supabase_edge_runtime during its health check:

    supabase_edge_runtime_wottle-local container logs:
    Stopping containers...
    Error status 502:

The project ships no Edge Functions — no supabase/functions/ directory, zero references to deno / edge runtime / supabase.functions in app/, lib/, or components/. The service was running only to cost startup time and expose us to a flaky health check in CI.

Turning it off in config.toml eliminates the container entirely.