### PR TITLE
feat(board): color selected tiles in the active player's hue (#209)

### DIFF
--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -128,12 +128,28 @@
   transform: none;
 }
 
+/* Selected (click-to-pick) state — uses the active player's identity color
+ * via `--selected-bg` / `--selected-border` (set inline by BoardGrid per
+ * `playerSlot`). Falls back to the original ochre when no player slot is
+ * provided (e.g. read-only previews / unit tests without a slot). */
 .board-grid__cell--selected {
-  background: color-mix(in oklab, var(--ochre) 70%, transparent) !important;
-  border-color: color-mix(in oklab, var(--ochre) 90%, transparent);
+  background: var(
+    --selected-bg,
+    color-mix(in oklab, var(--ochre) 70%, transparent)
+  ) !important;
+  border-color: var(
+    --selected-border,
+    color-mix(in oklab, var(--ochre) 90%, transparent)
+  );
+  border-width: 2px;
   box-shadow:
     inset 0 1px 0 color-mix(in oklab, var(--p1) 25%, transparent),
-    0 0 0 3px color-mix(in oklab, var(--ochre) 35%, transparent),
+    0 0 0 3px
+      color-mix(
+        in oklab,
+        var(--selected-border, var(--ochre)) 45%,
+        transparent
+      ),
     inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent);
 }
 

--- a/components/game/BoardGrid.tsx
+++ b/components/game/BoardGrid.tsx
@@ -20,6 +20,10 @@ import type { FrozenTileMap } from "@/lib/types/match";
 import {
   PLAYER_A_OVERLAY,
   PLAYER_B_OVERLAY,
+  PLAYER_A_SELECTED_BG,
+  PLAYER_A_SELECTED_BORDER,
+  PLAYER_B_SELECTED_BG,
+  PLAYER_B_SELECTED_BORDER,
 } from "@/lib/constants/playerColors";
 import { usePinchZoom } from "@/components/game/usePinchZoom";
 import { LETTER_SCORING_VALUES_IS } from "@/lib/game-engine/letter-values/letter_scoring_values_is";
@@ -113,6 +117,19 @@ const EMPTY_HIGHLIGHTS: Coordinate[][] = [];
 const FROZEN_COLORS = {
   player_a: PLAYER_A_OVERLAY,
   player_b: PLAYER_B_OVERLAY,
+};
+
+/** Per-player selected-tile colors (issue #209): the click-to-pick highlight
+ * uses the active player's identity color in a deep shade with a dark border,
+ * so it stays distinct from scored/frozen tiles which already use the lighter
+ * shades of the same hue. */
+const SELECTED_BG_COLORS = {
+  player_a: PLAYER_A_SELECTED_BG,
+  player_b: PLAYER_B_SELECTED_BG,
+};
+const SELECTED_BORDER_COLORS = {
+  player_a: PLAYER_A_SELECTED_BORDER,
+  player_b: PLAYER_B_SELECTED_BORDER,
 };
 
 function isTileInHighlights(
@@ -607,12 +624,25 @@ function BoardGridActive({
                 ? highlightPlayerColors[tileKey]
                 : undefined;
               const needsDelay = isScoredHighlight && highlightDelayMs > 0;
+              // Selected-tile colors are scoped to tiles currently in the
+              // selected or swapping state so unrelated tiles don't carry
+              // unused CSS vars (issue #209).
+              const selectedBgColor =
+                playerSlot && (isSelected || isSwapping)
+                  ? SELECTED_BG_COLORS[playerSlot]
+                  : undefined;
+              const selectedBorderColor =
+                playerSlot && (isSelected || isSwapping)
+                  ? SELECTED_BORDER_COLORS[playerSlot]
+                  : undefined;
               const tileStyle: CSSProperties | undefined =
-                frozenStyle || highlightColor || needsDelay
+                frozenStyle || highlightColor || needsDelay || selectedBgColor
                   ? ({
                       ...frozenStyle,
                       ...(highlightColor && { "--highlight-color": highlightColor }),
                       ...(needsDelay && { animationDelay: `${highlightDelayMs}ms` }),
+                      ...(selectedBgColor && { "--selected-bg": selectedBgColor }),
+                      ...(selectedBorderColor && { "--selected-border": selectedBorderColor }),
                     } as CSSProperties)
                   : undefined;
 

--- a/lib/constants/playerColors.ts
+++ b/lib/constants/playerColors.ts
@@ -18,6 +18,17 @@ export const PLAYER_B_OVERLAY = "oklch(0.56 0.08 220 / 0.4)";
 export const PLAYER_A_HIGHLIGHT = "oklch(0.68 0.14 60 / 0.6)";
 export const PLAYER_B_HIGHLIGHT = "oklch(0.56 0.08 220 / 0.6)";
 
+// Selected-tile colors (issue #209): player-identity color in a deep shade so
+// the click-to-pick state stays distinct from the lighter scored highlights
+// (60% alpha) and frozen overlays (40% alpha) that already use the player
+// hue. Background is the deep variant at 55% alpha for a saturated fill that
+// keeps the letter readable; border is the deep variant solid for the dark
+// edge the design calls for.
+export const PLAYER_A_SELECTED_BG = "oklch(0.48 0.14 55 / 0.55)";
+export const PLAYER_A_SELECTED_BORDER = "oklch(0.48 0.14 55)";
+export const PLAYER_B_SELECTED_BG = "oklch(0.38 0.08 220 / 0.55)";
+export const PLAYER_B_SELECTED_BORDER = "oklch(0.38 0.08 220)";
+
 // Both-player gradient (split diagonal) for shared / contested tiles
 export const BOTH_GRADIENT =
   "linear-gradient(135deg, oklch(0.68 0.14 60 / 0.4) 50%, oklch(0.56 0.08 220 / 0.4) 50%)";
@@ -26,18 +37,24 @@ export interface PlayerColorSet {
   hex: string;
   overlay: string;
   highlight: string;
+  selectedBg: string;
+  selectedBorder: string;
 }
 
 const PLAYER_A_COLORS: PlayerColorSet = {
   hex: PLAYER_A_HEX,
   overlay: PLAYER_A_OVERLAY,
   highlight: PLAYER_A_HIGHLIGHT,
+  selectedBg: PLAYER_A_SELECTED_BG,
+  selectedBorder: PLAYER_A_SELECTED_BORDER,
 };
 
 const PLAYER_B_COLORS: PlayerColorSet = {
   hex: PLAYER_B_HEX,
   overlay: PLAYER_B_OVERLAY,
   highlight: PLAYER_B_HIGHLIGHT,
+  selectedBg: PLAYER_B_SELECTED_BG,
+  selectedBorder: PLAYER_B_SELECTED_BORDER,
 };
 
 /** Return the color set for a given player slot. */

--- a/tests/unit/components/game/BoardGrid.test.tsx
+++ b/tests/unit/components/game/BoardGrid.test.tsx
@@ -13,6 +13,10 @@ import {
   PLAYER_B_OVERLAY,
   PLAYER_A_HIGHLIGHT,
   PLAYER_B_HIGHLIGHT,
+  PLAYER_A_SELECTED_BG,
+  PLAYER_A_SELECTED_BORDER,
+  PLAYER_B_SELECTED_BG,
+  PLAYER_B_SELECTED_BORDER,
 } from "@/lib/constants/playerColors";
 
 function createGrid(): BoardGridType {
@@ -666,6 +670,66 @@ describe("BoardGrid scored tile highlights with player colors (US7)", () => {
 
     expect(tile1).not.toHaveClass("board-grid__cell--scored");
     expect(tile2).not.toHaveClass("board-grid__cell--scored");
+  });
+});
+
+describe("BoardGrid selected tile player colors (issue #209)", () => {
+  test("player A: clicking a tile applies player A's deep-ochre selected CSS vars", async () => {
+    const grid = createGrid();
+    render(
+      <BoardGrid grid={grid} matchId="test-match-id" playerSlot="player_a" />,
+    );
+
+    const tile = screen.getAllByTestId("board-tile")[0];
+    fireEvent.click(tile);
+
+    await waitFor(() => {
+      expect(tile).toHaveAttribute("aria-selected", "true");
+    });
+    expect(tile).toHaveClass("board-grid__cell--selected");
+    expect(tile.style.getPropertyValue("--selected-bg")).toBe(
+      PLAYER_A_SELECTED_BG,
+    );
+    expect(tile.style.getPropertyValue("--selected-border")).toBe(
+      PLAYER_A_SELECTED_BORDER,
+    );
+  });
+
+  test("player B: clicking a tile applies player B's deep-blue selected CSS vars", async () => {
+    const grid = createGrid();
+    render(
+      <BoardGrid grid={grid} matchId="test-match-id" playerSlot="player_b" />,
+    );
+
+    const tile = screen.getAllByTestId("board-tile")[0];
+    fireEvent.click(tile);
+
+    await waitFor(() => {
+      expect(tile).toHaveAttribute("aria-selected", "true");
+    });
+    expect(tile).toHaveClass("board-grid__cell--selected");
+    expect(tile.style.getPropertyValue("--selected-bg")).toBe(
+      PLAYER_B_SELECTED_BG,
+    );
+    expect(tile.style.getPropertyValue("--selected-border")).toBe(
+      PLAYER_B_SELECTED_BORDER,
+    );
+  });
+
+  test("unselected tiles do not carry the selected CSS vars", async () => {
+    const grid = createGrid();
+    render(
+      <BoardGrid grid={grid} matchId="test-match-id" playerSlot="player_a" />,
+    );
+
+    const tiles = screen.getAllByTestId("board-tile");
+    fireEvent.click(tiles[0]);
+
+    await waitFor(() => {
+      expect(tiles[0]).toHaveAttribute("aria-selected", "true");
+    });
+    expect(tiles[5].style.getPropertyValue("--selected-bg")).toBe("");
+    expect(tiles[5].style.getPropertyValue("--selected-border")).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #209.

Post-Warm-Editorial, the click-to-select tile highlight used `--ochre`, which is now visually identical to Player A's `--p1`. The selected state was no longer distinct from the player's own scored/frozen tiles.

- Selected tiles now paint in the **active player's identity hue** at a deep, saturated shade with a solid dark border (2px).
- Player A → deep burnt-ochre fill (55% α) + solid deep-ochre border.
- Player B → deep blue fill (55% α) + solid deep-blue border.
- Boards rendered without a `playerSlot` (e.g. read-only previews) fall back to the original ochre treatment, so non-match contexts are unchanged.

The deeper shade keeps the selected state visibly distinct from the **lighter** scored highlights (60% α, same hue) and frozen overlays (40% α, same hue) that already use the player color family — so all four states (idle / selected / scored / frozen) form a clear visual hierarchy in each player's color.

## Approach

- New constants `PLAYER_A_SELECTED_BG/BORDER` + `PLAYER_B_SELECTED_BG/BORDER` in `lib/constants/playerColors.ts`, exposed via `PlayerColorSet`.
- `BoardGrid` sets inline `--selected-bg` / `--selected-border` CSS vars on tiles whose `isSelected || isSwapping` is true, scoped by `playerSlot`.
- `.board-grid__cell--selected` consumes the new vars (`var(--selected-bg, ochre fallback)`) and bumps the border to 2px for the requested dark-edge cue.
- Mirrors the existing `--highlight-color` pattern that scored tiles already use.

## Visual proof

Side-by-side preview rendered against the dev server. Each column shows idle / selected / scored:

- **Player A**: cream → deep burnt-ochre + dark border → lighter ochre tint
- **Player B**: cream → deep blue + dark border → lighter blue tint
- **Fallback** (no slot): original ochre look preserved

## Out of scope (potential follow-up)

`.board-grid__cell--locked` (the post-submission swap highlight) and `.board-grid__cell--opponent-reveal` (currently hardcoded to `--p1`) have the same player-color-clash problem but were out of scope for this issue's "selecting a tile to swap" wording. Worth a separate PR if we want full color symmetry across all post-click tile states.

## Test plan

- [x] 3 new unit tests under "BoardGrid selected tile player colors (issue #209)" covering Player A, Player B, and the unselected case (`tests/unit/components/game/BoardGrid.test.tsx`)
- [x] Full unit suite: 1043 passing, 2 skipped (no regressions)
- [x] `pnpm typecheck` clean
- [x] `pnpm exec eslint` clean on touched files
- [x] Visual verification: confirmed computed styles for both player slots + fallback via the dev server
- [ ] Manual smoke test in a live two-player match (selected tile in your own color, scored highlights still distinct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)