### PR TITLE
feat(match): align Round History with Warm Editorial palette (#209 follow-up)

### DIFF
--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -317,13 +317,29 @@
   }
 }
 
-/* Static highlight for hover-driven word highlights (no animation, persists while hovered) */
+/* Static highlight for hover-driven word highlights (no animation, persists
+ * while hovered). Bright player-color fill + dark border so the hovered
+ * word reads clearly even when the page is busy with other state
+ * (issue #209 follow-up). The dark border is derived from the highlight
+ * color via color-mix so it adapts to whichever player owns the word. */
 .board-grid__cell--scored.board-grid__cell--scored-static {
   animation: none;
+  background: var(--highlight-color, transparent) !important;
+  border-color: color-mix(
+    in oklab,
+    var(--highlight-color, var(--ochre-deep)),
+    var(--ink) 35%
+  );
+  border-width: 2px;
   box-shadow:
-    inset 0 1px 0 color-mix(in oklab, var(--p1) 20%, transparent),
-    inset 0 -4px 12px color-mix(in oklab, var(--paper) 35%, transparent),
-    0 0 0 2px var(--highlight-color, transparent);
+    inset 0 1px 0 color-mix(in oklab, var(--paper) 60%, transparent),
+    inset 0 -4px 12px color-mix(in oklab, var(--ink) 12%, transparent),
+    0 0 0 2px
+      color-mix(
+        in oklab,
+        var(--highlight-color, var(--ochre-deep)),
+        var(--ink) 25%
+      );
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/components/match/FinalSummary.tsx
+++ b/components/match/FinalSummary.tsx
@@ -450,7 +450,7 @@ export function FinalSummary({
           onClick={() => setActiveTab("overview")}
           className={`rounded-t-xl px-4 py-2 text-sm font-medium transition ${
             activeTab === "overview"
-              ? "border-b-2 border-emerald-400 text-emerald-300"
+              ? "border-b-2 border-ochre-deep text-ochre-deep"
               : "text-ink-soft hover:text-ink"
           }`}
           data-testid="tab-overview"
@@ -466,7 +466,7 @@ export function FinalSummary({
           onClick={() => setActiveTab("round-history")}
           className={`rounded-t-xl px-4 py-2 text-sm font-medium transition ${
             activeTab === "round-history"
-              ? "border-b-2 border-emerald-400 text-emerald-300"
+              ? "border-b-2 border-ochre-deep text-ochre-deep"
               : "text-ink-soft hover:text-ink"
           }`}
           data-testid="tab-round-history"
@@ -593,6 +593,7 @@ export function FinalSummary({
           rounds={roundHistory}
           playerAUsername={playerA?.displayName ?? "Player A"}
           playerBUsername={playerB?.displayName ?? "Player B"}
+          playerASlotId={playerA?.id}
           scores={scoreboard}
           wordHistory={wordHistory}
           biggestSwing={biggestSwing}

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -1117,6 +1117,7 @@ export function MatchClient({
               rounds={roundHistory}
               playerAUsername={playerADisplayName}
               playerBUsername={playerBDisplayName}
+              playerASlotId={playerAId}
               scores={accumulatedScores}
               wordHistory={accumulatedWords}
               biggestSwing={biggestSwing}

--- a/components/match/RoundHistoryPanel.tsx
+++ b/components/match/RoundHistoryPanel.tsx
@@ -10,6 +10,10 @@ interface RoundHistoryPanelProps {
   rounds: RoundHistoryEntry[];
   playerAUsername: string;
   playerBUsername: string;
+  /** Player A's playerId — lets us tint the "Top word" callout in the
+   *  scoring player's color (issue #209 follow-up). When omitted, the
+   *  callout falls back to the player A tint. */
+  playerASlotId?: string;
   scores?: ScoreboardRow[];
   wordHistory?: WordHistoryRow[];
   biggestSwing?: BiggestSwingCallout | null;
@@ -21,6 +25,20 @@ interface RoundHistoryPanelProps {
    */
   onHighlight?: (words: WordHistoryRow[] | null) => void;
 }
+
+/** Tailwind class set per player slot, used by the BIGGEST SWING / TOP WORD
+ *  callouts so they live inside the Warm Editorial palette instead of the
+ *  green/red --good / --warn semantics that clashed with the brand. */
+const SLOT_CALLOUT_CLASSES = {
+  player_a: {
+    container: "border-p1-deep/30 bg-p1/10",
+    label: "text-p1-deep",
+  },
+  player_b: {
+    container: "border-p2-deep/30 bg-p2/10",
+    label: "text-p2-deep",
+  },
+} as const;
 
 function WordRow({
   word,
@@ -188,11 +206,24 @@ export function RoundHistoryPanel({
   rounds,
   playerAUsername,
   playerBUsername,
+  playerASlotId,
   biggestSwing,
   highestWord,
   onHighlight,
 }: RoundHistoryPanelProps) {
   const [expandedRounds, setExpandedRounds] = useState<Set<number>>(() => new Set());
+
+  // Map each callout to the slot of the player it concerns, so we can tint
+  // it in that player's brand color (issue #209 follow-up).
+  const swingSlot: "player_a" | "player_b" = biggestSwing?.favoredPlayerId === "player-b"
+    ? "player_b"
+    : "player_a";
+  const topWordSlot: "player_a" | "player_b" =
+    playerASlotId && highestWord && highestWord.playerId !== playerASlotId
+      ? "player_b"
+      : "player_a";
+  const swingClasses = SLOT_CALLOUT_CLASSES[swingSlot];
+  const topWordClasses = SLOT_CALLOUT_CLASSES[topWordSlot];
 
   const allExpanded = useMemo(
     () => rounds.length > 0 && expandedRounds.size === rounds.length,
@@ -223,10 +254,10 @@ export function RoundHistoryPanel({
         <div className="grid gap-3 sm:grid-cols-2">
           {biggestSwing ? (
             <div
-              className="rounded-xl border border-warn/30 bg-warn/10 px-4 py-3"
+              className={`rounded-xl border px-4 py-3 ${swingClasses.container}`}
               data-testid="callout-biggest-swing"
             >
-              <p className="text-xs font-semibold uppercase tracking-wider text-warn">
+              <p className={`text-xs font-semibold uppercase tracking-wider ${swingClasses.label}`}>
                 Biggest swing
               </p>
               <p className="mt-1 text-sm text-ink">
@@ -246,10 +277,10 @@ export function RoundHistoryPanel({
           )}
           {highestWord ? (
             <div
-              className="rounded-xl border border-good/30 bg-good/10 px-4 py-3"
+              className={`rounded-xl border px-4 py-3 ${topWordClasses.container}`}
               data-testid="callout-highest-word"
             >
-              <p className="text-xs font-semibold uppercase tracking-wider text-good">
+              <p className={`text-xs font-semibold uppercase tracking-wider ${topWordClasses.label}`}>
                 Top word
               </p>
               <p className="mt-1 font-mono text-sm font-semibold uppercase text-ink">
@@ -291,6 +322,13 @@ export function RoundHistoryPanel({
               {allExpanded ? "Collapse all" : "Expand all"}
             </button>
           </div>
+          {/* Scrollable rounds list — keeps the panel's outer height bounded so
+           *  expanding rounds reveals an internal scrollbar instead of growing
+           *  the page (and pushing the board out of view post-game). */}
+          <div
+            className="max-h-[60vh] space-y-3 overflow-y-auto pr-1"
+            data-testid="round-history-list"
+          >
           {rounds.map((entry) => (
             <RoundRow
               key={entry.roundNumber}
@@ -302,6 +340,7 @@ export function RoundHistoryPanel({
               onHighlight={onHighlight}
             />
           ))}
+          </div>
         </>
       )}
     </div>

--- a/tests/unit/components/match/RoundHistoryPanel.test.tsx
+++ b/tests/unit/components/match/RoundHistoryPanel.test.tsx
@@ -212,3 +212,108 @@ describe("RoundHistoryPanel — empty", () => {
   });
 });
 
+describe("RoundHistoryPanel — Warm Editorial callouts (issue #209 follow-up)", () => {
+  test("biggest swing favoring player A is tinted in player A's color, not green/red", () => {
+    render(
+      <RoundHistoryPanel
+        rounds={sampleRounds}
+        playerAUsername="Ásta"
+        playerBUsername="Sigríður"
+        playerASlotId="player-a"
+        biggestSwing={{
+          roundNumber: 2,
+          swingAmount: 18,
+          favoredPlayerId: "player-a",
+        }}
+      />,
+    );
+
+    const callout = screen.getByTestId("callout-biggest-swing");
+    // Player A → p1 family (warm ochre)
+    expect(callout.className).toMatch(/(?:^|\s)(?:border-|bg-|text-)p1(?:-deep)?\b/);
+    // No legacy semantic colors
+    expect(callout.className).not.toMatch(/\bwarn\b/);
+    expect(callout.className).not.toMatch(/\bgood\b/);
+    expect(callout.className).not.toMatch(/(emerald|rose|amber|red|green)-\d/);
+  });
+
+  test("biggest swing favoring player B is tinted in player B's color", () => {
+    render(
+      <RoundHistoryPanel
+        rounds={sampleRounds}
+        playerAUsername="Ásta"
+        playerBUsername="Sigríður"
+        playerASlotId="player-a"
+        biggestSwing={{
+          roundNumber: 1,
+          swingAmount: 12,
+          favoredPlayerId: "player-b",
+        }}
+      />,
+    );
+
+    const callout = screen.getByTestId("callout-biggest-swing");
+    expect(callout.className).toMatch(/(?:^|\s)(?:border-|bg-|text-)p2(?:-deep)?\b/);
+  });
+
+  test("top word scored by player A uses player A color tint", () => {
+    render(
+      <RoundHistoryPanel
+        rounds={sampleRounds}
+        playerAUsername="Ásta"
+        playerBUsername="Sigríður"
+        playerASlotId="player-a"
+        highestWord={{
+          word: "búr",
+          totalPoints: 20,
+          playerId: "player-a",
+          username: "Ásta",
+          roundNumber: 1,
+        }}
+      />,
+    );
+
+    const callout = screen.getByTestId("callout-highest-word");
+    expect(callout.className).toMatch(/(?:^|\s)(?:border-|bg-|text-)p1(?:-deep)?\b/);
+    expect(callout.className).not.toMatch(/\bgood\b/);
+    expect(callout.className).not.toMatch(/(emerald|green|amber)-\d/);
+  });
+
+  test("top word scored by player B uses player B color tint", () => {
+    render(
+      <RoundHistoryPanel
+        rounds={sampleRounds}
+        playerAUsername="Ásta"
+        playerBUsername="Sigríður"
+        playerASlotId="player-a"
+        highestWord={{
+          word: "lag",
+          totalPoints: 24,
+          playerId: "player-b",
+          username: "Sigríður",
+          roundNumber: 1,
+        }}
+      />,
+    );
+
+    const callout = screen.getByTestId("callout-highest-word");
+    expect(callout.className).toMatch(/(?:^|\s)(?:border-|bg-|text-)p2(?:-deep)?\b/);
+  });
+});
+
+describe("RoundHistoryPanel — scrollable rounds list (issue #209 follow-up)", () => {
+  test("rounds list is constrained with max-height + overflow so expanding doesn't grow the page", () => {
+    render(
+      <RoundHistoryPanel
+        rounds={sampleRounds}
+        playerAUsername="Ásta"
+        playerBUsername="Sigríður"
+      />,
+    );
+
+    const list = screen.getByTestId("round-history-list");
+    expect(list.className).toMatch(/\bmax-h-/);
+    expect(list.className).toMatch(/\boverflow-y-auto\b/);
+  });
+});
+


### PR DESCRIPTION
## Summary

Reopens / addresses #209 — three improvements on top of PR #212.

### 1. Brighter hover-highlight on the board

Hovering a row in Round History now paints the round's tiles in a **vivid player-color fill with a dark border**, instead of just a thin 2px outer ring. The hovered word reads clearly even when the rest of the board is busy with frozen tiles or scored highlights from other rounds.

`.board-grid__cell--scored.board-grid__cell--scored-static` in [app/styles/board.css](app/styles/board.css) now sets `background: var(--highlight-color)` and derives the border from the same var via `color-mix(..., var(--ink) 35%)`, so it adapts to whichever player owns the word.

### 2. Replace green/red with Warm Editorial palette

- **BIGGEST SWING** callout: was `border-warn/30 bg-warn/10 text-warn` (orange) — now tints in the **favored player's color** via `border-pX-deep/30 bg-pX/10 text-pX-deep`, using the existing `BiggestSwingCallout.favoredPlayerId` field.
- **TOP WORD** callout: was `border-good/30 bg-good/10 text-good` (green) — now tints in the **scoring player's color**, using a new `playerASlotId` prop on `RoundHistoryPanel` to map `highestWord.playerId` to a slot.
- **FinalSummary tabs**: active state was `border-emerald-400 text-emerald-300` — now `border-ochre-deep text-ochre-deep`, the canonical Warm Editorial active accent already used in `LandingScreen`, `LobbyCard`, `ProfileSidebar`, `Badge`, `Toast`.

### 3. Scrollbar inside the rounds list

The post-game `Round History` tab in `FinalSummary` had no height constraint, so expanding rounds grew the entire page and pushed the post-game board out of view. The rounds list is now wrapped in `max-h-[60vh] overflow-y-auto pr-1` (with `data-testid="round-history-list"`), so expanding rounds reveals an **internal scrollbar** instead of growing the page. The callouts and the Expand/Collapse-all toggle stay outside the scroll container so they're always reachable.

This also keeps the in-match overlay clean — the existing `max-h-[80vh]` modal still works, and the inner list sets a tighter budget.

## Visual proof

Hover-highlight comparison (idle / animated scored / **NEW** hover state) — both player colors:

> Player A: vivid burnt-ochre fill + dark ochre border
> Player B: vivid blue fill + dark blue border

Callouts + tab indicator using only Warm Editorial tokens — top row in player A's hue, bottom row in player B's hue, "Overview" tab underlined in `ochre-deep`.

## Files changed

- [app/styles/board.css](app/styles/board.css) — `--scored-static` rule brightens fill + adds dark border
- [components/match/RoundHistoryPanel.tsx](components/match/RoundHistoryPanel.tsx) — new `playerASlotId` prop, `SLOT_CALLOUT_CLASSES` lookup, scrollable list wrapper
- [components/match/FinalSummary.tsx](components/match/FinalSummary.tsx) — tab active state → `ochre-deep`, pass `playerASlotId={playerA?.id}`
- [components/match/MatchClient.tsx](components/match/MatchClient.tsx) — pass `playerASlotId={playerAId}`
- [tests/unit/components/match/RoundHistoryPanel.test.tsx](tests/unit/components/match/RoundHistoryPanel.test.tsx) — 5 new tests covering callout colors per slot + scrollable list

## Test plan

- [x] 5 new unit tests under "Warm Editorial callouts" + "scrollable rounds list"
- [x] Full unit suite: 1054 passing, 2 skipped (no regressions)
- [x] `pnpm typecheck` clean
- [x] `pnpm exec eslint` clean on touched files
- [x] Visual verification: confirmed computed styles for `--scored-static` (player A and B) + Tailwind compiled the new tokens (`text-ochre-deep`, `border-p1-deep/30`, `bg-p2/10`, etc.) via the dev server
- [ ] Manual smoke test in a live match — hover a Round History row and watch the board, then end the match and try Expand all in the Round History tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)