### PR TITLE
fix(match): per-tile hover color, brighter highlight, sticky board (#208)

### DIFF
--- a/components/match/FinalSummary.tsx
+++ b/components/match/FinalSummary.tsx
@@ -9,9 +9,8 @@ import { BoardGrid as BoardGridComponent } from "@/components/game/BoardGrid";
 import { RoundHistoryPanel } from "@/components/match/RoundHistoryPanel";
 import { deriveRoundHistory } from "@/components/match/deriveRoundHistory";
 import { deriveBiggestSwing, deriveHighestScoringWord } from "@/components/match/deriveCallouts";
+import { derivePostGameHighlightColors } from "@/components/match/derivePostGameHighlightColors";
 import {
-  PLAYER_A_HIGHLIGHT,
-  PLAYER_B_HIGHLIGHT,
   PLAYER_A_HEX,
   PLAYER_B_HEX,
 } from "@/lib/constants/playerColors";
@@ -310,15 +309,9 @@ export function FinalSummary({
       setHighlightPlayerColors({});
       return;
     }
-    const colors: Record<string, string> = {};
-    for (const word of words) {
-      const color =
-        word.playerId === playerA?.id ? PLAYER_A_HIGHLIGHT : PLAYER_B_HIGHLIGHT;
-      for (const coord of word.coordinates) {
-        colors[`${coord.x},${coord.y}`] = color;
-      }
-    }
-    setHighlightPlayerColors(colors);
+    setHighlightPlayerColors(
+      derivePostGameHighlightColors(words, frozenTiles ?? {}, playerA?.id ?? ""),
+    );
   };
 
   const isRematchDisabled =
@@ -377,7 +370,14 @@ export function FinalSummary({
     >
       {/* Board with player HUD panels, matching in-game 3-column layout */}
       {board && (
-        <div className="summary-board-layout mb-6" data-testid="final-summary-board">
+        <div
+          className={`summary-board-layout mb-6${
+            activeTab === "round-history"
+              ? " sticky top-0 z-10 bg-paper pt-1 pb-3"
+              : ""
+          }`}
+          data-testid="final-summary-board"
+        >
           {/* Left panel: current player (same as in-game) */}
           <div className="summary-board-layout__panel">
             <div className="flex flex-col items-center gap-2 rounded-xl border border-hair bg-paper-2 p-4">

--- a/components/match/derivePostGameHighlightColors.ts
+++ b/components/match/derivePostGameHighlightColors.ts
@@ -1,0 +1,40 @@
+import type { WordHistoryRow } from "@/components/match/FinalSummary";
+import type { FrozenTileMap } from "@/lib/types/match";
+import {
+  PLAYER_A_HOVER_HIGHLIGHT,
+  PLAYER_B_HOVER_HIGHLIGHT,
+} from "@/lib/constants/playerColors";
+
+/**
+ * Derives the per-tile highlight color map for a hover in the post-game
+ * Round History panel.
+ *
+ * For each coord in the hovered words, the colour is chosen from the *frozen
+ * tile owner* — not the word's author — so a word that crosses tiles owned
+ * by both players highlights each tile in its own colour. Falls back to the
+ * word author when the tile is not frozen (rare in post-game state).
+ */
+export function derivePostGameHighlightColors(
+  words: WordHistoryRow[],
+  frozenTiles: FrozenTileMap,
+  playerAId: string,
+): Record<string, string> {
+  const colors: Record<string, string> = {};
+  for (const word of words) {
+    const wordAuthorColor =
+      word.playerId === playerAId
+        ? PLAYER_A_HOVER_HIGHLIGHT
+        : PLAYER_B_HOVER_HIGHLIGHT;
+    for (const coord of word.coordinates) {
+      const key = `${coord.x},${coord.y}`;
+      const frozenOwner = frozenTiles[key]?.owner;
+      const color = frozenOwner
+        ? frozenOwner === "player_a"
+          ? PLAYER_A_HOVER_HIGHLIGHT
+          : PLAYER_B_HOVER_HIGHLIGHT
+        : wordAuthorColor;
+      colors[key] = color;
+    }
+  }
+  return colors;
+}

--- a/lib/constants/playerColors.ts
+++ b/lib/constants/playerColors.ts
@@ -14,9 +14,17 @@ export const PLAYER_B_HEX = "var(--p2)";
 export const PLAYER_A_OVERLAY = "oklch(0.68 0.14 60 / 0.4)";
 export const PLAYER_B_OVERLAY = "oklch(0.56 0.08 220 / 0.4)";
 
-// Scored-tile highlights (60% alpha)
+// Scored-tile highlights (60% alpha) — used by the in-match round-recap
+// animation where tiles flash briefly on a paper-coloured board.
 export const PLAYER_A_HIGHLIGHT = "oklch(0.68 0.14 60 / 0.6)";
 export const PLAYER_B_HIGHLIGHT = "oklch(0.56 0.08 220 / 0.6)";
+
+// Post-game hover highlights (issue #208 follow-up): brighter than the
+// scored/frozen layers so hovering a round/word in history *lifts* the
+// tile rather than darkening it. Higher OKLCH lightness keeps these
+// readable against both the cream paper and the player frozen overlays.
+export const PLAYER_A_HOVER_HIGHLIGHT = "oklch(0.88 0.10 70 / 0.9)";
+export const PLAYER_B_HOVER_HIGHLIGHT = "oklch(0.82 0.07 220 / 0.9)";
 
 // Selected-tile colors (issue #209): player-identity hue rendered as a *light*
 // tint on the tile body with a *deep* solid border, so the click-to-pick

--- a/tests/unit/components/FinalSummary.test.tsx
+++ b/tests/unit/components/FinalSummary.test.tsx
@@ -212,4 +212,25 @@ describe("FinalSummary", () => {
     expect(summary.className).not.toContain("bg-slate-");
     expect(summary.className).toMatch(/bg-paper|bg-surface-0/);
   });
+
+  it("makes the board sticky on the round-history tab so it stays visible while scrolling", async () => {
+    const board = Array.from({ length: 10 }, () => Array.from({ length: 10 }, () => "A"));
+    render(
+      <FinalSummary
+        {...makeProps({
+          board,
+        })}
+      />,
+    );
+
+    const boardWrapper = screen.getByTestId("final-summary-board");
+    // Default tab is "overview" — board does not need to be sticky there.
+    expect(boardWrapper.className).not.toMatch(/sticky/);
+
+    // Switching to round-history should sticky-pin the board so the user can
+    // scroll the round list without losing the board context.
+    const { fireEvent } = await import("@testing-library/react");
+    fireEvent.click(screen.getByTestId("tab-round-history"));
+    expect(boardWrapper.className).toMatch(/sticky/);
+  });
 });

--- a/tests/unit/components/match/derivePostGameHighlightColors.spec.ts
+++ b/tests/unit/components/match/derivePostGameHighlightColors.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import { derivePostGameHighlightColors } from "@/components/match/derivePostGameHighlightColors";
+import {
+  PLAYER_A_HOVER_HIGHLIGHT,
+  PLAYER_B_HOVER_HIGHLIGHT,
+} from "@/lib/constants/playerColors";
+import type { WordHistoryRow } from "@/components/match/FinalSummary";
+import type { FrozenTileMap } from "@/lib/types/match";
+
+function makeWord(overrides: Partial<WordHistoryRow> = {}): WordHistoryRow {
+  return {
+    roundNumber: 1,
+    playerId: "player-a",
+    word: "búr",
+    totalPoints: 20,
+    lettersPoints: 15,
+    bonusPoints: 5,
+    coordinates: [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+    ],
+    ...overrides,
+  };
+}
+
+describe("derivePostGameHighlightColors", () => {
+  it("colors each tile by its frozen owner, not the word author", () => {
+    // Word authored by player A passing through tiles that were last frozen by
+    // player B — every coord should glow blue, not orange.
+    const words: WordHistoryRow[] = [
+      makeWord({
+        playerId: "player-a",
+        coordinates: [
+          { x: 0, y: 0 },
+          { x: 1, y: 0 },
+          { x: 2, y: 0 },
+        ],
+      }),
+    ];
+    const frozenTiles: FrozenTileMap = {
+      "0,0": { owner: "player_b" },
+      "1,0": { owner: "player_b" },
+      "2,0": { owner: "player_b" },
+    };
+
+    const colors = derivePostGameHighlightColors(words, frozenTiles, "player-a");
+
+    expect(colors["0,0"]).toBe(PLAYER_B_HOVER_HIGHLIGHT);
+    expect(colors["1,0"]).toBe(PLAYER_B_HOVER_HIGHLIGHT);
+    expect(colors["2,0"]).toBe(PLAYER_B_HOVER_HIGHLIGHT);
+  });
+
+  it("colors mixed-ownership tiles individually", () => {
+    const words: WordHistoryRow[] = [
+      makeWord({
+        playerId: "player-a",
+        coordinates: [
+          { x: 0, y: 0 },
+          { x: 1, y: 0 },
+          { x: 2, y: 0 },
+        ],
+      }),
+    ];
+    const frozenTiles: FrozenTileMap = {
+      "0,0": { owner: "player_b" },
+      "1,0": { owner: "player_a" },
+      "2,0": { owner: "player_a" },
+    };
+
+    const colors = derivePostGameHighlightColors(words, frozenTiles, "player-a");
+
+    expect(colors["0,0"]).toBe(PLAYER_B_HOVER_HIGHLIGHT);
+    expect(colors["1,0"]).toBe(PLAYER_A_HOVER_HIGHLIGHT);
+    expect(colors["2,0"]).toBe(PLAYER_A_HOVER_HIGHLIGHT);
+  });
+
+  it("falls back to the word author's color for unfrozen tiles", () => {
+    const words: WordHistoryRow[] = [
+      makeWord({
+        playerId: "player-b",
+        coordinates: [{ x: 4, y: 4 }],
+      }),
+    ];
+    const frozenTiles: FrozenTileMap = {};
+
+    const colors = derivePostGameHighlightColors(words, frozenTiles, "player-a");
+
+    expect(colors["4,4"]).toBe(PLAYER_B_HOVER_HIGHLIGHT);
+  });
+
+  it("merges multiple words (round-level hover)", () => {
+    const words: WordHistoryRow[] = [
+      makeWord({
+        playerId: "player-a",
+        coordinates: [
+          { x: 0, y: 0 },
+          { x: 1, y: 0 },
+        ],
+      }),
+      makeWord({
+        playerId: "player-b",
+        coordinates: [
+          { x: 5, y: 5 },
+          { x: 6, y: 5 },
+        ],
+      }),
+    ];
+    const frozenTiles: FrozenTileMap = {
+      "0,0": { owner: "player_a" },
+      "1,0": { owner: "player_a" },
+      "5,5": { owner: "player_b" },
+      "6,5": { owner: "player_b" },
+    };
+
+    const colors = derivePostGameHighlightColors(words, frozenTiles, "player-a");
+
+    expect(colors["0,0"]).toBe(PLAYER_A_HOVER_HIGHLIGHT);
+    expect(colors["1,0"]).toBe(PLAYER_A_HOVER_HIGHLIGHT);
+    expect(colors["5,5"]).toBe(PLAYER_B_HOVER_HIGHLIGHT);
+    expect(colors["6,5"]).toBe(PLAYER_B_HOVER_HIGHLIGHT);
+  });
+
+  it("returns an empty map for an empty word array", () => {
+    expect(derivePostGameHighlightColors([], {}, "player-a")).toEqual({});
+  });
+});
+
+describe("PLAYER_X_HOVER_HIGHLIGHT brightness", () => {
+  it("is brighter than the regular tile colors (OKLCH lightness ≥ 0.8)", () => {
+    const oklchLightness = (value: string): number | null => {
+      const match = value.match(/oklch\(\s*([0-9.]+)/);
+      return match ? Number(match[1]) : null;
+    };
+    expect(oklchLightness(PLAYER_A_HOVER_HIGHLIGHT)!).toBeGreaterThanOrEqual(0.8);
+    expect(oklchLightness(PLAYER_B_HOVER_HIGHLIGHT)!).toBeGreaterThanOrEqual(0.8);
+  });
+});


### PR DESCRIPTION
## Summary

Three follow-ups requested on issue #208:

1. **Hover color matches the underlying tile, not the word author.** Previously a word that crossed frozen tiles owned by both players painted *everything* in the word author's colour. Now each tile glows in its frozen owner's hue.
2. **Highlight is brighter, not darker.** The previous highlight darkened the tile (60% α saturated). New `PLAYER_X_HOVER_HIGHLIGHT` constants are high-lightness (OKLCH ≈ 0.85) so hovering *lifts* the tile.
3. **Board stays visible while scrolling rounds.** When the Round History tab is active, the board section is `position: sticky; top: 0` with a paper backdrop. The Overview tab is unchanged.

## Files

- `lib/constants/playerColors.ts` — new `PLAYER_A_HOVER_HIGHLIGHT` / `PLAYER_B_HOVER_HIGHLIGHT` (kept the existing `PLAYER_X_HIGHLIGHT` so the in-match round-recap animation stays untouched).
- `components/match/derivePostGameHighlightColors.ts` — new pure utility; for each coord, picks the frozen owner's bright color, falling back to the word author when the tile isn't frozen.
- `components/match/FinalSummary.tsx` — `handleHighlight` delegates to the new utility; board container gets `sticky top-0 z-10 bg-paper` only when the Round History tab is active.
- `tests/unit/components/match/derivePostGameHighlightColors.spec.ts` — 6 new tests covering single-owner, mixed-owner, fallback, multi-word merge, empty-input, and brightness assertion.
- `tests/unit/components/FinalSummary.test.tsx` — 1 new test verifying the sticky class only appears on the round-history tab.

## Test plan

- [ ] Two-player match → post-game → Round History tab. Hover any round.
  - Tiles owned by Player A glow bright ochre; tiles owned by Player B glow bright blue, even when within the same word.
  - Highlight is brighter than the surrounding cream + frozen overlays (lifts, doesn't darken).
- [ ] Play a long match, expand a few rounds → scroll the page. Board stays pinned at the top while the round list scrolls beneath.
- [ ] Switch back to Overview tab → board scrolls with the page (no sticky).
- [ ] In-match round-recap animation still flashes scored tiles at the original 60% α (sanity check on `PLAYER_X_HIGHLIGHT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)