### PR TITLE
fix(board): static highlight no longer shifts the board (#208)

### DIFF
--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -327,7 +327,13 @@
  * while hovered). Bright player-color fill + dark border so the hovered
  * word reads clearly even when the page is busy with other state
  * (issue #209 follow-up). The dark border is derived from the highlight
- * color via color-mix so it adapts to whichever player owns the word. */
+ * color via color-mix so it adapts to whichever player owns the word.
+ *
+ * Important: every shadow layer is `inset` so highlighting cannot grow the
+ * tile beyond its border-box. An outer-spread shadow caused the board to
+ * appear to expand under the cursor, shifting the page below (issue #208
+ * follow-up). The bright fill + 2px dark border carry the visual weight on
+ * their own. */
 .board-grid__cell--scored.board-grid__cell--scored-static {
   animation: none;
   background: var(--highlight-color, transparent) !important;
@@ -339,13 +345,7 @@
   border-width: 2px;
   box-shadow:
     inset 0 1px 0 color-mix(in oklab, var(--paper) 60%, transparent),
-    inset 0 -4px 12px color-mix(in oklab, var(--ink) 12%, transparent),
-    0 0 0 2px
-      color-mix(
-        in oklab,
-        var(--highlight-color, var(--ochre-deep)),
-        var(--ink) 25%
-      );
+    inset 0 -4px 12px color-mix(in oklab, var(--ink) 12%, transparent);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/tests/unit/styles/board-static-highlight.spec.ts
+++ b/tests/unit/styles/board-static-highlight.spec.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression for issue #208 follow-up: hovering a round/word in the post-game
+ * Round History panel must NOT change the board's footprint. Any non-`inset`
+ * box-shadow with a positive spread paints OUTSIDE the tile and made the
+ * board appear to expand under the cursor, shifting the page below it.
+ *
+ * The static-highlight rule is allowed to change `background`, `border-color`,
+ * `border-width` (border-box keeps the outer dimensions stable), and `inset`
+ * box-shadows. Outer-spread shadows are forbidden.
+ */
+function extractStaticHighlightRule(css: string): string {
+  const start = css.indexOf(
+    ".board-grid__cell--scored.board-grid__cell--scored-static",
+  );
+  if (start === -1) {
+    throw new Error("static highlight rule not found in board.css");
+  }
+  const open = css.indexOf("{", start);
+  const close = css.indexOf("}", open);
+  return css.slice(open + 1, close);
+}
+
+function extractBoxShadow(rule: string): string | null {
+  const match = rule.match(/box-shadow\s*:\s*([^;]+);/);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Split a `box-shadow` value on commas that aren't inside parentheses
+ * (color-mix(), oklch(), etc. contain commas).
+ */
+function splitShadowLayers(value: string): string[] {
+  const layers: string[] = [];
+  let depth = 0;
+  let buffer = "";
+  for (const ch of value) {
+    if (ch === "(") depth += 1;
+    else if (ch === ")") depth -= 1;
+    if (ch === "," && depth === 0) {
+      layers.push(buffer.trim());
+      buffer = "";
+    } else {
+      buffer += ch;
+    }
+  }
+  if (buffer.trim()) layers.push(buffer.trim());
+  return layers;
+}
+
+describe("board.css — static highlight rule", () => {
+  const css = readFileSync(
+    resolve(__dirname, "../../../app/styles/board.css"),
+    "utf-8",
+  );
+  const rule = extractStaticHighlightRule(css);
+
+  it("box-shadow does not contain any outer (non-inset) layer", () => {
+    const value = extractBoxShadow(rule);
+    expect(value, "expected the static rule to declare box-shadow").not.toBeNull();
+    const layers = splitShadowLayers(value!);
+    for (const layer of layers) {
+      expect(
+        layer.startsWith("inset"),
+        `outer-spread shadow paints outside the tile and shifts the board: "${layer}"`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the latest #208 follow-up: hovering a round/word in the post-game Round History panel made the board appear to expand and the page below it shift down.

## Root cause

The static-highlight rule on \`.board-grid__cell--scored.board-grid__cell--scored-static\` declared:

\`\`\`css
box-shadow:
  inset 0 1px 0 ...,
  inset 0 -4px 12px ...,
  0 0 0 2px <derived dark color>;  /* ← outer-spread ring */
\`\`\`

That outer-spread layer paints a 2px ring around the OUTSIDE of the tile's border-box. Box-shadow doesn't formally reflow, but stacked with the bright fill + the 2px dark border, the visual halo read as the board "growing." With many tiles highlighted at once on a round-level hover, the page below shifted noticeably.

## Fix

- Drop the outer-spread shadow layer. Every remaining layer is \`inset\`, so highlighting can never paint outside the border-box.
- Keep the bright \`--highlight-color\` fill and the 2px dark border (color-mixed from the highlight color) — together they carry the visual weight on their own.

## Files

- \`app/styles/board.css\` — remove the \`0 0 0 2px ...\` outer ring on the static-highlight rule; document why every layer must be inset.
- \`tests/unit/styles/board-static-highlight.spec.ts\` — new regression test that parses the rule and asserts every box-shadow layer starts with \`inset\` (TDD: failed first, then green).

## Test plan

- [ ] Two-player match → post-game → Round History tab.
- [ ] Hover any round and any individual word.
- [ ] Tiles light up with the bright fill + dark border. **The board's footprint does not change**, and content below the board stays put.
- [ ] In-match round-recap animation (separate \`.board-grid__cell--scored\` rule, no \`-static\`) still flashes scored tiles with the original glow — sanity check this hasn't regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)