### PR TITLE
fix(board): paint static highlight with inset ring, never change border (#208)

### DIFF
--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -324,26 +324,28 @@
 }
 
 /* Static highlight for hover-driven word highlights (no animation, persists
- * while hovered). Bright player-color fill + dark border so the hovered
- * word reads clearly even when the page is busy with other state
- * (issue #209 follow-up). The dark border is derived from the highlight
- * color via color-mix so it adapts to whichever player owns the word.
+ * while hovered). Bright player-color fill + a dark inset ring that reads
+ * as a thicker border without actually changing the cell's border CSS
+ * (issue #208 follow-up).
  *
- * Important: every shadow layer is `inset` so highlighting cannot grow the
- * tile beyond its border-box. An outer-spread shadow caused the board to
- * appear to expand under the cursor, shifting the page below (issue #208
- * follow-up). The bright fill + 2px dark border carry the visual weight on
- * their own. */
+ * Why no border-width / border-color override: changing the rendered border
+ * between states elongated the board under the cursor in the user's
+ * environment, even with `box-sizing: border-box`. We keep the border
+ * property identical to the base cell and paint the dark edge with an
+ * `inset 0 0 0 2px` shadow that sits over the existing 1px border. Result:
+ * no layout property of the tile changes when highlighted, the board's
+ * footprint is locked, and the dark ring is darker (40% ink mix) for
+ * stronger contrast against the bright fill. */
 .board-grid__cell--scored.board-grid__cell--scored-static {
   animation: none;
   background: var(--highlight-color, transparent) !important;
-  border-color: color-mix(
-    in oklab,
-    var(--highlight-color, var(--ochre-deep)),
-    var(--ink) 35%
-  );
-  border-width: 2px;
   box-shadow:
+    inset 0 0 0 2px
+      color-mix(
+        in oklab,
+        var(--highlight-color, var(--ochre-deep)),
+        var(--ink) 40%
+      ),
     inset 0 1px 0 color-mix(in oklab, var(--paper) 60%, transparent),
     inset 0 -4px 12px color-mix(in oklab, var(--ink) 12%, transparent);
 }

--- a/tests/unit/styles/board-static-highlight.spec.ts
+++ b/tests/unit/styles/board-static-highlight.spec.ts
@@ -69,4 +69,34 @@ describe("board.css — static highlight rule", () => {
       ).toBe(true);
     }
   });
+
+  it("does not change border-width or border (the cell's border-box must not grow)", () => {
+    // Even with `box-sizing: border-box`, changing the rendered border between
+    // states made the board visibly elongate in the user's environment. To
+    // guarantee no growth, the static rule must not touch any border property.
+    expect(
+      /border-width\s*:/.test(rule),
+      `static rule changes border-width — board elongates on hover`,
+    ).toBe(false);
+    expect(
+      /(^|[^-])border\s*:/.test(rule),
+      `static rule changes the border shorthand — board elongates on hover`,
+    ).toBe(false);
+    expect(
+      /border-color\s*:/.test(rule),
+      `static rule changes border-color — even color-only changes can trigger sub-pixel reflow in some browsers`,
+    ).toBe(false);
+  });
+
+  it("paints a prominent inset ring so the highlight is visible without an outer shadow", () => {
+    const value = extractBoxShadow(rule);
+    const layers = splitShadowLayers(value!);
+    const innerRing = layers.find((l) =>
+      /^inset\s+0\s+0\s+0\s+2px/.test(l),
+    );
+    expect(
+      innerRing,
+      `expected an inset 2px ring layer for the dark edge`,
+    ).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

PR #218 only removed the outer-spread shadow but kept the \`border-width: 2px\` override on the static-highlight rule. The user confirmed the board still elongated under the cursor — the rendered border change itself was the trigger, even with \`box-sizing: border-box\` on the \`<button>\` cells.

This PR locks the cell's border CSS identical to the idle state and paints the dark edge with an \`inset 0 0 0 2px\` shadow that sits over the existing 1px border. **No layout-affecting property of the tile changes between hover and idle**, so the board's footprint cannot shift.

The inset ring also uses a darker mix (40% ink, up from 35%) so the border reads more prominently against the bright fill — addressing the user's secondary ask for a stronger highlight.

## Files

- \`app/styles/board.css\` — drop \`border-width\` and \`border-color\` overrides on \`.board-grid__cell--scored.board-grid__cell--scored-static\`; replace with an \`inset 0 0 0 2px\` shadow ring at 40% ink mix.
- \`tests/unit/styles/board-static-highlight.spec.ts\` — extended with two regression tests (TDD: failed first, then green):
  - the static rule must not declare \`border\`, \`border-width\`, or \`border-color\`
  - an \`inset 0 0 0 2px\` ring layer must be present

## Test plan

- [ ] Two-player match → post-game → Round History tab.
- [ ] Hover any round and any individual word.
- [ ] **The board's footprint stays exactly the same**; nothing below shifts.
- [ ] Highlighted tiles look distinctly bright with a clearly darker edge — visibility on par with or better than before.
- [ ] In-match round-recap animation still flashes scored tiles correctly (separate \`.board-grid__cell--scored\` rule, no \`-static\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)