### PR TITLE
feat(match): persist opponent swap in their color, click-lock until round ends

### DIFF
--- a/app/styles/board.css
+++ b/app/styles/board.css
@@ -207,14 +207,17 @@
 }
 
 /* Move lock: highlight on swapped tiles until next round (US1).
- * Uses the active player's hue via `--locked-bg` (set inline by BoardGrid
- * per `playerSlot`); falls back to the original ochre treatment when no
- * player slot is provided (e.g. read-only previews). */
+ * Uses the active player's hue via `--locked-bg` (light tint) plus
+ * `--locked-border` (deep border), mirroring the selected-state treatment
+ * so the swap reads as a *lift* rather than a darken. Falls back to the
+ * legacy ochre treatment when no player slot is provided. */
 .board-grid__cell--locked {
   background: var(
     --locked-bg,
     color-mix(in oklab, var(--ochre) 70%, transparent)
   ) !important;
+  border-color: var(--locked-border, color-mix(in oklab, var(--ochre) 90%, transparent));
+  border-width: 2px;
   cursor: not-allowed;
   opacity: 1 !important;
   filter: none !important;
@@ -222,6 +225,30 @@
 
 .board-grid__cell--locked:hover,
 .board-grid__cell--locked:focus-within {
+  transform: none;
+}
+
+/* Opponent's revealed swap (issue #210 follow-up): same lift treatment as
+ * own-locked, but reads `--opponent-locked-bg` / `--opponent-locked-border`
+ * so the tiles persist in the opponent's identity color until the round
+ * resolves. Click is blocked at the JS layer (see BoardGrid handleTileClick). */
+.board-grid__cell--opponent-locked {
+  background: var(
+    --opponent-locked-bg,
+    color-mix(in oklab, var(--ochre) 70%, transparent)
+  ) !important;
+  border-color: var(
+    --opponent-locked-border,
+    color-mix(in oklab, var(--ochre) 90%, transparent)
+  );
+  border-width: 2px;
+  cursor: not-allowed;
+  opacity: 1 !important;
+  filter: none !important;
+}
+
+.board-grid__cell--opponent-locked:hover,
+.board-grid__cell--opponent-locked:focus-within {
   transform: none;
 }
 

--- a/components/game/BoardGrid.tsx
+++ b/components/game/BoardGrid.tsx
@@ -25,7 +25,9 @@ import {
   PLAYER_B_SELECTED_BG,
   PLAYER_B_SELECTED_BORDER,
   PLAYER_A_LOCKED_BG,
+  PLAYER_A_LOCKED_BORDER,
   PLAYER_B_LOCKED_BG,
+  PLAYER_B_LOCKED_BORDER,
 } from "@/lib/constants/playerColors";
 import { usePinchZoom } from "@/components/game/usePinchZoom";
 import { LETTER_SCORING_VALUES_IS } from "@/lib/game-engine/letter-values/letter_scoring_values_is";
@@ -57,6 +59,13 @@ interface BoardGridProps {
   lockedTiles?: [Coordinate, Coordinate] | null;
   /** Coordinates of opponent's swapped tiles during reveal phase — rendered with orange fade animation. */
   opponentRevealTiles?: [Coordinate, Coordinate] | null;
+  /**
+   * Coordinates of the opponent's mid-round revealed swap. Rendered in the
+   * opponent's identity color (opposite slot of `playerSlot`) and held until
+   * the round resolves. Clicks on these tiles are blocked — they're locked
+   * for the rest of the round (issue #210 follow-up).
+   */
+  opponentLockedTiles?: [Coordinate, Coordinate] | null;
   /**
    * When set, BoardGrid runs the FLIP swap animation for the given (from, to)
    * exactly once per `key`. Used by MatchClient (issue #210) to animate the
@@ -142,12 +151,22 @@ const SELECTED_BORDER_COLORS = {
 };
 
 /** Per-player locked-tile color (issue #209 follow-up): keeps the
- * post-submission swap highlight in the active player's hue instead of
- * reverting to the legacy ochre fallback. */
+ * post-submission swap highlight in the active player's hue. The deep
+ * border lifts the tile (matches the selected-state treatment) rather
+ * than darkening it. Used both for the local player's own swap and for
+ * the opponent's mid-round revealed swap (with the opposite slot's vars). */
 const LOCKED_BG_COLORS = {
   player_a: PLAYER_A_LOCKED_BG,
   player_b: PLAYER_B_LOCKED_BG,
 };
+const LOCKED_BORDER_COLORS = {
+  player_a: PLAYER_A_LOCKED_BORDER,
+  player_b: PLAYER_B_LOCKED_BORDER,
+};
+
+function oppositeSlot(slot: "player_a" | "player_b"): "player_a" | "player_b" {
+  return slot === "player_a" ? "player_b" : "player_a";
+}
 
 function isTileInHighlights(
   colIndex: number,
@@ -198,6 +217,7 @@ export function BoardGrid({
   showLockBanner = false,
   lockedTiles = null,
   opponentRevealTiles = null,
+  opponentLockedTiles = null,
   externalSwap = null,
   onSwapComplete,
   onSwapError,
@@ -226,6 +246,7 @@ export function BoardGrid({
       showLockBanner={showLockBanner}
       lockedTiles={lockedTiles}
       opponentRevealTiles={opponentRevealTiles}
+      opponentLockedTiles={opponentLockedTiles}
       externalSwap={externalSwap}
       onSwapComplete={onSwapComplete}
       onSwapError={onSwapError}
@@ -252,6 +273,7 @@ function BoardGridActive({
   showLockBanner = false,
   lockedTiles = null,
   opponentRevealTiles = null,
+  opponentLockedTiles = null,
   externalSwap = null,
   onSwapComplete,
   onSwapError,
@@ -542,6 +564,19 @@ function BoardGridActive({
     animateSwap(externalSwap.from, externalSwap.to, () => {});
   }, [externalSwap, animateSwap, grid]);
 
+  // If the opponent's revealed swap covers a tile the user has selected, drop
+  // the selection — that tile is now locked for the rest of the round.
+  useEffect(() => {
+    if (!selected || !opponentLockedTiles) return;
+    const [a, b] = opponentLockedTiles;
+    if (
+      (selected.x === a.x && selected.y === a.y) ||
+      (selected.x === b.x && selected.y === b.y)
+    ) {
+      setSelected(null);
+    }
+  }, [opponentLockedTiles, selected]);
+
   const handleTileClick = useCallback(
     (rowIndex: number, colIndex: number) => {
       if (isSubmitting || isAnimating || disabled) {
@@ -549,6 +584,19 @@ function BoardGridActive({
       }
 
       const coordinate = { x: colIndex, y: rowIndex } as SelectedTile;
+
+      // Opponent's mid-round revealed swap locks those tiles for the rest
+      // of the round (issue #210 follow-up).
+      const isOpponentLockedTarget =
+        opponentLockedTiles !== null &&
+        ((opponentLockedTiles[0].x === coordinate.x &&
+          opponentLockedTiles[0].y === coordinate.y) ||
+          (opponentLockedTiles[1].x === coordinate.x &&
+            opponentLockedTiles[1].y === coordinate.y));
+      if (isOpponentLockedTarget) {
+        onInvalidMove?.();
+        return;
+      }
 
       if (!selected) {
         onTileSelect?.();
@@ -583,7 +631,7 @@ function BoardGridActive({
       setSelected(null);
       animateSwap(selected, coordinate);
     },
-    [animateSwap, isSubmitting, isAnimating, disabled, selected, frozenTiles, onTileSelect, onInvalidMove]
+    [animateSwap, isSubmitting, isAnimating, disabled, selected, frozenTiles, opponentLockedTiles, onTileSelect, onInvalidMove]
   );
 
   // Deselect on Escape key
@@ -682,6 +730,10 @@ function BoardGridActive({
                 opponentRevealTiles !== null &&
                 ((opponentRevealTiles[0].x === colIndex && opponentRevealTiles[0].y === rowIndex) ||
                   (opponentRevealTiles[1].x === colIndex && opponentRevealTiles[1].y === rowIndex));
+              const isOpponentLocked =
+                opponentLockedTiles !== null &&
+                ((opponentLockedTiles[0].x === colIndex && opponentLockedTiles[0].y === rowIndex) ||
+                  (opponentLockedTiles[1].x === colIndex && opponentLockedTiles[1].y === rowIndex));
               const isInvalid =
                 invalidTiles !== null &&
                 ((invalidTiles[0].x === colIndex && invalidTiles[0].y === rowIndex) ||
@@ -708,12 +760,24 @@ function BoardGridActive({
                   : undefined;
               const lockedBgColor =
                 playerSlot && isLocked ? LOCKED_BG_COLORS[playerSlot] : undefined;
+              const lockedBorderColor =
+                playerSlot && isLocked ? LOCKED_BORDER_COLORS[playerSlot] : undefined;
+              const opponentSlot = playerSlot ? oppositeSlot(playerSlot) : undefined;
+              const opponentLockedBgColor =
+                opponentSlot && isOpponentLocked
+                  ? LOCKED_BG_COLORS[opponentSlot]
+                  : undefined;
+              const opponentLockedBorderColor =
+                opponentSlot && isOpponentLocked
+                  ? LOCKED_BORDER_COLORS[opponentSlot]
+                  : undefined;
               const tileStyle: CSSProperties | undefined =
                 frozenStyle ||
                 highlightColor ||
                 needsDelay ||
                 selectedBgColor ||
-                lockedBgColor
+                lockedBgColor ||
+                opponentLockedBgColor
                   ? ({
                       ...frozenStyle,
                       ...(highlightColor && { "--highlight-color": highlightColor }),
@@ -721,6 +785,13 @@ function BoardGridActive({
                       ...(selectedBgColor && { "--selected-bg": selectedBgColor }),
                       ...(selectedBorderColor && { "--selected-border": selectedBorderColor }),
                       ...(lockedBgColor && { "--locked-bg": lockedBgColor }),
+                      ...(lockedBorderColor && { "--locked-border": lockedBorderColor }),
+                      ...(opponentLockedBgColor && {
+                        "--opponent-locked-bg": opponentLockedBgColor,
+                      }),
+                      ...(opponentLockedBorderColor && {
+                        "--opponent-locked-border": opponentLockedBorderColor,
+                      }),
                     } as CSSProperties)
                   : undefined;
 
@@ -740,7 +811,7 @@ function BoardGridActive({
                   aria-colindex={colIndex + 1}
                   aria-selected={isSelected}
                   aria-disabled={isTileFrozen || undefined}
-                  className={`board-grid__cell${isSelected || isSwapping ? " board-grid__cell--selected" : ""}${isLocked ? " board-grid__cell--locked" : ""}${isOpponentReveal ? " board-grid__cell--opponent-reveal" : ""}${isTileFrozen ? " board-grid__cell--frozen" : ""}${isScoredHighlight ? ` board-grid__cell--scored${persistentHighlight ? " board-grid__cell--scored-static" : ""}` : ""}${isInvalid ? " board-grid__cell--invalid" : ""}`}
+                  className={`board-grid__cell${isSelected || isSwapping ? " board-grid__cell--selected" : ""}${isLocked ? " board-grid__cell--locked" : ""}${isOpponentLocked ? " board-grid__cell--opponent-locked" : ""}${isOpponentReveal ? " board-grid__cell--opponent-reveal" : ""}${isTileFrozen ? " board-grid__cell--frozen" : ""}${isScoredHighlight ? ` board-grid__cell--scored${persistentHighlight ? " board-grid__cell--scored-static" : ""}` : ""}${isInvalid ? " board-grid__cell--invalid" : ""}`}
                   data-testid="board-tile"
                   data-tile-index={rowIndex * 10 + colIndex}
                   data-col={colIndex}

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -153,6 +153,11 @@ export function MatchClient({
   const [externalSwap, setExternalSwap] = useState<
     { from: Coordinate; to: Coordinate; key: string } | null
   >(null);
+  // The opponent's revealed swap tiles, held in the opponent's identity color
+  // and click-locked until the round resolves (issue #210 follow-up).
+  const [opponentSwapTiles, setOpponentSwapTiles] = useState<
+    [Coordinate, Coordinate] | null
+  >(null);
   const animatedOpponentMoveKeysRef = useRef<Set<string>>(new Set());
 
   // Resign state
@@ -611,15 +616,18 @@ export function MatchClient({
   useEffect(() => {
     setMoveLocked(false);
     setLockedSwapTiles(null);
-    // Issue #210 — drop the externally-driven swap and forget which opponent
-    // moves were animated; the next round starts with a clean slate.
+    // Issue #210 — drop the externally-driven swap, the persistent opponent-
+    // color tiles, and forget which opponent moves were animated; the next
+    // round starts with a clean slate.
     setExternalSwap(null);
+    setOpponentSwapTiles(null);
     animatedOpponentMoveKeysRef.current = new Set();
   }, [matchState.currentRound]);
 
   // Issue #210 — when a state snapshot carries a new opponent pendingMove,
   // surface it to BoardGrid as an externalSwap so the FLIP animates the
-  // opponent's swap immediately on the current player's board.
+  // opponent's swap immediately on the current player's board, and pin the
+  // tiles in the opponent's identity color until the round resolves.
   useEffect(() => {
     const opponentPlayerId =
       currentPlayerId === matchState.timers.playerA.playerId
@@ -637,6 +645,7 @@ export function MatchClient({
       to: opponentMove.to,
       key,
     });
+    setOpponentSwapTiles([opponentMove.from, opponentMove.to]);
   }, [
     matchState.pendingMoves,
     currentPlayerId,
@@ -1024,6 +1033,7 @@ export function MatchClient({
                 disabled={moveLocked}
                 showLockBanner={false}
                 lockedTiles={lockedSwapTiles}
+                opponentLockedTiles={opponentSwapTiles}
                 opponentRevealTiles={
                   animationPhase === "round-recap" && activeRevealMove
                     ? [activeRevealMove.from, activeRevealMove.to]

--- a/lib/constants/playerColors.ts
+++ b/lib/constants/playerColors.ts
@@ -38,13 +38,15 @@ export const PLAYER_A_SELECTED_BORDER = "oklch(0.48 0.14 55)";
 export const PLAYER_B_SELECTED_BG = "oklch(0.86 0.04 220 / 0.85)";
 export const PLAYER_B_SELECTED_BORDER = "oklch(0.38 0.08 220)";
 
-// Locked-tile colors (post-submission swap highlight): keep the player's
-// identity hue at the same 70% saturation the original ochre used, so the
-// "I just swapped these" cue stays strong but follows the active player's
-// color. Without this, Player B's tiles flipped from blue (selected) back
-// to orange (legacy --ochre fallback) on submit.
-export const PLAYER_A_LOCKED_BG = "oklch(0.68 0.14 60 / 0.7)";
-export const PLAYER_B_LOCKED_BG = "oklch(0.56 0.08 220 / 0.7)";
+// Locked-tile colors (post-submission swap highlight): a *light* tint on the
+// tile body with a *deep* border, mirroring the selected-state treatment so
+// the swap cue lifts the tile rather than darkening it. Used both for the
+// current player's own swap (`lockedTiles`) and for the opponent's revealed
+// swap (`opponentLockedTiles`, where the opposite slot's vars are applied).
+export const PLAYER_A_LOCKED_BG = "oklch(0.92 0.06 70 / 0.85)";
+export const PLAYER_A_LOCKED_BORDER = "oklch(0.48 0.14 55)";
+export const PLAYER_B_LOCKED_BG = "oklch(0.86 0.04 220 / 0.85)";
+export const PLAYER_B_LOCKED_BORDER = "oklch(0.38 0.08 220)";
 
 // Both-player gradient (split diagonal) for shared / contested tiles
 export const BOTH_GRADIENT =

--- a/tests/unit/components/MatchClient.test.tsx
+++ b/tests/unit/components/MatchClient.test.tsx
@@ -922,6 +922,77 @@ describe("MatchClient opponent move reveal (issue #210)", () => {
       "board-grid__cell--opponent-reveal",
     );
   });
+
+  test("opponent's revealed swap tiles stay marked as opponent-locked until the round resolves", async () => {
+    const { MatchClient } = await import("@/components/match/MatchClient");
+
+    await act(async () => {
+      render(
+        <MatchClient
+          initialState={createMatchState({ board: distinctBoard() })}
+          currentPlayerId="player-1"
+          matchId="match-test-123"
+          playerProfiles={defaultProfiles}
+        />,
+      );
+    });
+
+    // Opponent submits mid-round.
+    await act(async () => {
+      mockMatchCallbacks.onState!(
+        createMatchState({
+          board: distinctBoard(),
+          pendingMoves: [
+            {
+              playerId: "player-2",
+              from: { x: 2, y: 3 },
+              to: { x: 4, y: 3 },
+              submittedAt: "2026-01-01T00:00:01.000Z",
+            },
+          ],
+        }),
+      );
+    });
+
+    const tiles = screen.getAllByTestId("board-tile");
+    expect(tiles[3 * 10 + 2]).toHaveClass("board-grid__cell--opponent-locked");
+    expect(tiles[3 * 10 + 4]).toHaveClass("board-grid__cell--opponent-locked");
+
+    // Subsequent broadcasts during the same round must keep the class on.
+    await act(async () => {
+      mockMatchCallbacks.onState!(
+        createMatchState({
+          board: distinctBoard(),
+          pendingMoves: [
+            {
+              playerId: "player-2",
+              from: { x: 2, y: 3 },
+              to: { x: 4, y: 3 },
+              submittedAt: "2026-01-01T00:00:01.000Z",
+            },
+          ],
+        }),
+      );
+    });
+    expect(tiles[3 * 10 + 2]).toHaveClass("board-grid__cell--opponent-locked");
+
+    // Round resolves → currentRound increments → tiles release.
+    await act(async () => {
+      mockMatchCallbacks.onState!(
+        createMatchState({
+          board: distinctBoard(),
+          currentRound: 2,
+          pendingMoves: [],
+        }),
+      );
+    });
+    expect(tiles[3 * 10 + 2]).not.toHaveClass(
+      "board-grid__cell--opponent-locked",
+    );
+    expect(tiles[3 * 10 + 4]).not.toHaveClass(
+      "board-grid__cell--opponent-locked",
+    );
+  });
 });
 
 // ─── DisconnectionModal end-of-match guard (issue #161 follow-up) ──────────

--- a/tests/unit/components/game/BoardGrid.test.tsx
+++ b/tests/unit/components/game/BoardGrid.test.tsx
@@ -18,7 +18,9 @@ import {
   PLAYER_B_SELECTED_BG,
   PLAYER_B_SELECTED_BORDER,
   PLAYER_A_LOCKED_BG,
+  PLAYER_A_LOCKED_BORDER,
   PLAYER_B_LOCKED_BG,
+  PLAYER_B_LOCKED_BORDER,
 } from "@/lib/constants/playerColors";
 
 /**
@@ -826,6 +828,139 @@ describe("BoardGrid locked tile player colors (issue #209 follow-up)", () => {
 
     const tiles = screen.getAllByTestId("board-tile");
     expect(tiles[5].style.getPropertyValue("--locked-bg")).toBe("");
+  });
+
+  test("locked tiles also carry --locked-border so the tile lifts rather than darkens", () => {
+    const grid = createGrid();
+    render(
+      <BoardGrid
+        grid={grid}
+        matchId="test-match-id"
+        playerSlot="player_a"
+        lockedTiles={[{ x: 0, y: 0 }, { x: 1, y: 0 }]}
+      />,
+    );
+
+    const tiles = screen.getAllByTestId("board-tile");
+    expect(tiles[0].style.getPropertyValue("--locked-border")).toBe(
+      PLAYER_A_LOCKED_BORDER,
+    );
+    expect(tiles[1].style.getPropertyValue("--locked-border")).toBe(
+      PLAYER_A_LOCKED_BORDER,
+    );
+  });
+});
+
+describe("BoardGrid opponentLockedTiles (issue #210 follow-up)", () => {
+  function createDistinctGrid(): BoardGridType {
+    return Array.from({ length: BOARD_SIZE }, (_, row) =>
+      Array.from({ length: BOARD_SIZE }, (_, col) =>
+        String.fromCharCode("A".charCodeAt(0) + (row * BOARD_SIZE + col) % 26),
+      ),
+    );
+  }
+
+  test("renders opponent-locked class with the OPPOSITE slot's locked colors", () => {
+    const grid = createDistinctGrid();
+    render(
+      <BoardGrid
+        grid={grid}
+        matchId="test-match-id"
+        playerSlot="player_a"
+        opponentLockedTiles={[{ x: 2, y: 3 }, { x: 4, y: 3 }]}
+      />,
+    );
+
+    const tiles = screen.getAllByTestId("board-tile");
+    const tileA = tiles[3 * BOARD_SIZE + 2];
+    const tileB = tiles[3 * BOARD_SIZE + 4];
+    expect(tileA).toHaveClass("board-grid__cell--opponent-locked");
+    expect(tileB).toHaveClass("board-grid__cell--opponent-locked");
+    expect(tileA.style.getPropertyValue("--opponent-locked-bg")).toBe(
+      PLAYER_B_LOCKED_BG,
+    );
+    expect(tileA.style.getPropertyValue("--opponent-locked-border")).toBe(
+      PLAYER_B_LOCKED_BORDER,
+    );
+    expect(tileB.style.getPropertyValue("--opponent-locked-bg")).toBe(
+      PLAYER_B_LOCKED_BG,
+    );
+  });
+
+  test("from player_b's perspective, opponent-locked uses player_a's colors", () => {
+    const grid = createDistinctGrid();
+    render(
+      <BoardGrid
+        grid={grid}
+        matchId="test-match-id"
+        playerSlot="player_b"
+        opponentLockedTiles={[{ x: 0, y: 0 }, { x: 1, y: 0 }]}
+      />,
+    );
+
+    const tiles = screen.getAllByTestId("board-tile");
+    expect(tiles[0].style.getPropertyValue("--opponent-locked-bg")).toBe(
+      PLAYER_A_LOCKED_BG,
+    );
+    expect(tiles[0].style.getPropertyValue("--opponent-locked-border")).toBe(
+      PLAYER_A_LOCKED_BORDER,
+    );
+  });
+
+  test("clicks on opponent-locked tiles do not start a selection or submit a swap", () => {
+    const grid = createDistinctGrid();
+    const onTileSelect = vi.fn();
+    const onInvalidMove = vi.fn();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+      throw new Error("opponent-locked clicks must not hit the network");
+    });
+
+    render(
+      <BoardGrid
+        grid={grid}
+        matchId="test-match-id"
+        playerSlot="player_a"
+        opponentLockedTiles={[{ x: 2, y: 3 }, { x: 4, y: 3 }]}
+        onTileSelect={onTileSelect}
+        onInvalidMove={onInvalidMove}
+      />,
+    );
+
+    const tiles = screen.getAllByTestId("board-tile");
+    fireEvent.click(tiles[3 * BOARD_SIZE + 2]);
+
+    expect(onTileSelect).not.toHaveBeenCalled();
+    expect(onInvalidMove).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  test("a selected tile is deselected if the opponent's swap covers it", () => {
+    const grid = createDistinctGrid();
+    const { rerender } = render(
+      <BoardGrid
+        grid={grid}
+        matchId="test-match-id"
+        playerSlot="player_a"
+        opponentLockedTiles={null}
+      />,
+    );
+
+    const tiles = screen.getAllByTestId("board-tile");
+    const target = tiles[3 * BOARD_SIZE + 2];
+    fireEvent.click(target);
+    expect(target.getAttribute("aria-selected")).toBe("true");
+
+    rerender(
+      <BoardGrid
+        grid={grid}
+        matchId="test-match-id"
+        playerSlot="player_a"
+        opponentLockedTiles={[{ x: 2, y: 3 }, { x: 4, y: 3 }]}
+      />,
+    );
+
+    expect(tiles[3 * BOARD_SIZE + 2].getAttribute("aria-selected")).toBe("false");
   });
 });
 


### PR DESCRIPTION
Follow-up to #220. Three improvements to the mid-round opponent-swap reveal:

## Summary

- **Persist the opponent's color** — the revealed swap tiles stay in the opponent's identity color from the moment they appear until the round resolves, on both boards. From your POV the opponent's swap is blue (or ochre); from their POV your swap is the opposite. Replaces the prior treatment where the FLIP animated and then the tiles reverted to the paper background.
- **Click-lock the opponent's tiles** — clicks on the opponent's revealed swap tiles are rejected (`onInvalidMove`); if you had one of those tiles selected when the reveal lands, the selection drops automatically.
- **Lift, don't darken** — both `--locked` and the new `--opponent-locked` treatments now use a *light tint* + *deep border*, mirroring the selected-state shape (issue #209). The previous saturated mid-tone read as a darken; the new shape lifts the tile.

## Files changed

| Path | What |
|---|---|
| `lib/constants/playerColors.ts` | Lighten `LOCKED_BG` (was `oklch(0.68 …)`/`oklch(0.56 …)`, now `oklch(0.92 …)`/`oklch(0.86 …)`); add `LOCKED_BORDER` (deep oklch). |
| `app/styles/board.css` | `.board-grid__cell--locked` draws the dark border. New `.board-grid__cell--opponent-locked` with the same shape, reading `--opponent-locked-bg` / `--opponent-locked-border`. Both vars carry an ochre fallback. |
| `components/game/BoardGrid.tsx` | `opponentLockedTiles` prop; `LOCKED_BORDER_COLORS` map + `oppositeSlot` helper; per-tile vars set from the opposite slot; `handleTileClick` rejects opponent-locked targets; new effect deselects on cover. |
| `components/match/MatchClient.tsx` | `opponentSwapTiles` state set in the same `pendingMoves` effect as `externalSwap`, cleared on `currentRound` change, passed as `opponentLockedTiles`. |
| `tests/unit/components/game/BoardGrid.test.tsx` | +5 tests: own-locked carries `--locked-border`; opponent-locked applies opposite slot's colors (both viewer perspectives); clicks blocked; selection deselected. |
| `tests/unit/components/MatchClient.test.tsx` | +1 test: opponent-locked class persists across multiple `state` broadcasts in the same round and releases on `currentRound` increment. |

## Verification

- `pnpm typecheck` — clean on touched files (8 unrelated errors persist in `.next/` types and `lobby-visual.spec.ts` missing `@axe-core/playwright`).
- `pnpm test` — **154 files, 1084 passing, 2 skipped** (was 1078 on `main`; +6 new).
- `pnpm exec eslint` — clean on touched files.

## Test plan

- [ ] Two-player smoke (`pnpm quickstart && pnpm dev`):
  - Player A goes first → on Player B's board the swap tiles light up in **A's color** (warm tint, deep border) and stay that way through Player B's whole move.
  - Player B clicks one of A's revealed tiles → click is ignored (no selection, plays the invalid-move audio cue).
  - Player B selects a non-locked tile, then A submits a swap that covers that tile → B's selection clears automatically.
  - Player B then submits → on A's board, B's tiles briefly show in **B's color** before the round-recap fires; recap does not replay the sky-blue glow on already-revealed tiles.
- [ ] Round transition: when round resolves, both boards release the opponent-locked tiles cleanly (no ghost color into round 2).
- [ ] `prefers-reduced-motion: reduce` — opponent-locked tiles still appear (instant, no FLIP) and still click-lock.

## Out of scope

- No server-side change.
- No new realtime payload (rides on the existing `pendingMoves` field shipped in #220).

🤖 Generated with [Claude Code](https://claude.com/claude-code)