### PR TITLE
fix(match): deliver mid-round freeze updates via safety poller

### DIFF
--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -22,6 +22,7 @@ import {
   buildPartialRevealKey,
   deriveRevealHighlightsFromPartial,
 } from "@/lib/match/partialReveal";
+import { shouldApplySafetySnapshot } from "@/lib/match/safetySnapshot";
 import { deriveBiggestSwing, deriveHighestScoringWord } from "@/components/match/deriveCallouts";
 import type { WordHistoryRow, ScoreboardRow } from "@/components/match/FinalSummary";
 import type { MatchPlayerProfiles, MatchState, TimerState, Coordinate } from "@/lib/types/match";
@@ -565,17 +566,11 @@ export function MatchClient({
       const snapshot = await fetchMatchSnapshot(matchId);
       if (!isMounted || !snapshot) return;
 
-      const current = matchStateRef.current;
-      const roundAdvanced = snapshot.currentRound > current.currentRound;
-      const matchCompleted =
-        snapshot.state === "completed" && current.state !== "completed";
-      // Also apply when disconnect state flips — this is the only signal
-      // when Realtime broadcasts aren't reaching the surviving client.
-      const disconnectChanged =
-        (snapshot.disconnectedPlayerId ?? null) !==
-        (current.disconnectedPlayerId ?? null);
-
-      if (roundAdvanced || matchCompleted || disconnectChanged) {
+      // Applies on round advance, match completion, disconnect flips, and
+      // mid-round instant-scoring changes (frozen tiles / partial summary) —
+      // each is a broadcast-carried signal the client can't recover from
+      // when Realtime delivery fails silently.
+      if (shouldApplySafetySnapshot(matchStateRef.current, snapshot)) {
         applySnapshot(snapshot);
       }
     };

--- a/lib/match/safetySnapshot.ts
+++ b/lib/match/safetySnapshot.ts
@@ -1,0 +1,61 @@
+import { buildPartialRevealKey } from "./partialReveal";
+import type { MatchState } from "@/lib/types/match";
+
+/**
+ * Decides whether the background safety-net poller should apply a freshly
+ * fetched snapshot. The poller runs alongside Realtime and exists for the
+ * case where server-side broadcasts fail silently (e.g. local act/Docker,
+ * CI runners) — so it must catch every signal a broadcast can carry that
+ * the client cannot recover from otherwise:
+ *
+ * - the round advanced or the match completed,
+ * - the disconnect flag flipped,
+ * - the instant-scoring fast path (spec 042) froze tiles or published a
+ *   partial summary mid-`collecting`. Without applying these, the second
+ *   player's board keeps offering tiles the server already froze and their
+ *   swaps are rejected with no visible cause.
+ */
+export function shouldApplySafetySnapshot(
+  current: MatchState,
+  snapshot: MatchState,
+): boolean {
+  const roundAdvanced = snapshot.currentRound > current.currentRound;
+  const matchCompleted =
+    snapshot.state === "completed" && current.state !== "completed";
+  const disconnectChanged =
+    (snapshot.disconnectedPlayerId ?? null) !==
+    (current.disconnectedPlayerId ?? null);
+
+  return (
+    roundAdvanced ||
+    matchCompleted ||
+    disconnectChanged ||
+    frozenTilesChanged(current, snapshot) ||
+    partialSummaryChanged(current, snapshot)
+  );
+}
+
+/**
+ * Freeze entries are append-only within a match, so comparing key sets is
+ * sufficient (values never mutate once written).
+ */
+function frozenTilesChanged(current: MatchState, snapshot: MatchState): boolean {
+  const currentKeys = Object.keys(current.frozenTiles ?? {});
+  const snapshotKeys = Object.keys(snapshot.frozenTiles ?? {});
+  if (currentKeys.length !== snapshotKeys.length) return true;
+  const currentSet = new Set(currentKeys);
+  return snapshotKeys.some((key) => !currentSet.has(key));
+}
+
+function partialSummaryChanged(
+  current: MatchState,
+  snapshot: MatchState,
+): boolean {
+  const currentKey = current.partialSummary
+    ? buildPartialRevealKey(current.partialSummary)
+    : null;
+  const snapshotKey = snapshot.partialSummary
+    ? buildPartialRevealKey(snapshot.partialSummary)
+    : null;
+  return currentKey !== snapshotKey;
+}

--- a/tests/integration/ui/helpers/swaps.ts
+++ b/tests/integration/ui/helpers/swaps.ts
@@ -37,7 +37,11 @@ export async function submitSwap(page: Page): Promise<void> {
     // Clear any stray single-tile selection left by a prior attempt.
     await page.keyboard.press("Escape");
 
-    const pair = await findUnfrozenAdjacentPair(page);
+    // Scan from a different row each attempt: when the freeze broadcast is
+    // delayed (safety poll cadence is 2s), the client's `data-frozen` can be
+    // stale, so re-picking the same pair would repeat the same rejection.
+    const startIndex = ((attempt - 1) * 30) % 100;
+    const pair = await findUnfrozenAdjacentPair(page, startIndex);
     if (!pair) throw new Error("No unfrozen adjacent tile pair found");
 
     await clickPair(pair);
@@ -51,15 +55,17 @@ export async function submitSwap(page: Page): Promise<void> {
 }
 
 /**
- * Finds the first horizontal pair (n, n+1) where neither tile is frozen.
- * Re-reads `data-frozen` on every call — frozen state can change mid-round
- * via the instant-scoring broadcast.
+ * Finds the first horizontal pair (n, n+1) — scanning from `startIndex` with
+ * wraparound — where neither tile is frozen. Re-reads `data-frozen` on every
+ * call: frozen state can change mid-round via the instant-scoring broadcast.
  */
 async function findUnfrozenAdjacentPair(
   page: Page,
+  startIndex = 0,
 ): Promise<[Locator, Locator] | null> {
   const board = page.getByTestId("board-grid");
-  for (let n = 0; n < 99; n += 1) {
+  for (let offset = 0; offset < 100; offset += 1) {
+    const n = (startIndex + offset) % 100;
     if (n % 10 === 9) continue;
     const tileA = board.locator(`[data-tile-index="${n}"]`);
     const tileB = board.locator(`[data-tile-index="${n + 1}"]`);

--- a/tests/unit/match/safetySnapshot.spec.ts
+++ b/tests/unit/match/safetySnapshot.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldApplySafetySnapshot } from "@/lib/match/safetySnapshot";
+import type { MatchState, PartialRoundSummary } from "@/lib/types/match";
+
+function buildState(overrides: Partial<MatchState> = {}): MatchState {
+  return {
+    matchId: "match-1",
+    board: [["a"]],
+    currentRound: 3,
+    state: "collecting",
+    scores: { playerA: 0, playerB: 0 },
+    timers: {
+      playerA: { playerId: "player-a", remainingMs: 60_000, status: "running" },
+      playerB: { playerId: "player-b", remainingMs: 60_000, status: "running" },
+    },
+    disconnectedPlayerId: null,
+    frozenTiles: {},
+    partialSummary: null,
+    ...overrides,
+  } as MatchState;
+}
+
+function buildPartialSummary(): PartialRoundSummary {
+  return {
+    matchId: "match-1",
+    roundNumber: 3,
+    firstMoverId: "player-a",
+    firstSubmissionAt: "2026-06-09T21:00:00.000Z",
+    words: [
+      {
+        playerId: "player-a",
+        word: "orð",
+        totalPoints: 9,
+        lettersPoints: 6,
+        bonusPoints: 3,
+        coordinates: [
+          { x: 0, y: 0 },
+          { x: 1, y: 0 },
+          { x: 2, y: 0 },
+        ],
+      },
+    ],
+    frozenTiles: { "0,0": { owner: "player_a" as const } },
+  } as unknown as PartialRoundSummary;
+}
+
+describe("shouldApplySafetySnapshot", () => {
+  it("ignores identical snapshots", () => {
+    expect(shouldApplySafetySnapshot(buildState(), buildState())).toBe(false);
+  });
+
+  it("applies when the round advanced", () => {
+    const snapshot = buildState({ currentRound: 4 });
+    expect(shouldApplySafetySnapshot(buildState(), snapshot)).toBe(true);
+  });
+
+  it("applies when the match completed", () => {
+    const snapshot = buildState({ state: "completed" });
+    expect(shouldApplySafetySnapshot(buildState(), snapshot)).toBe(true);
+  });
+
+  it("applies when disconnect state flips", () => {
+    const snapshot = buildState({ disconnectedPlayerId: "player-b" });
+    expect(shouldApplySafetySnapshot(buildState(), snapshot)).toBe(true);
+  });
+
+  // Spec 042 regression: the instant-scoring fast path freezes tiles while
+  // the round is still `collecting`. When the Realtime broadcast is lost,
+  // the safety poller is the only delivery path — skipping the snapshot
+  // leaves the second player clicking tiles the server already froze.
+  it("applies when tiles froze mid-round", () => {
+    const snapshot = buildState({
+      frozenTiles: { "0,0": { owner: "player_a" as const } },
+    });
+    expect(shouldApplySafetySnapshot(buildState(), snapshot)).toBe(true);
+  });
+
+  it("applies when a partial summary appeared mid-round", () => {
+    const snapshot = buildState({ partialSummary: buildPartialSummary() });
+    expect(shouldApplySafetySnapshot(buildState(), snapshot)).toBe(true);
+  });
+
+  it("ignores a partial summary the client already has", () => {
+    const partial = buildPartialSummary();
+    const current = buildState({
+      partialSummary: partial,
+      frozenTiles: { "0,0": { owner: "player_a" as const } },
+    });
+    const snapshot = buildState({
+      partialSummary: partial,
+      frozenTiles: { "0,0": { owner: "player_a" as const } },
+    });
+    expect(shouldApplySafetySnapshot(current, snapshot)).toBe(false);
+  });
+
+  it("treats missing frozenTiles maps as empty", () => {
+    const current = buildState({ frozenTiles: undefined });
+    const snapshot = buildState({ frozenTiles: {} });
+    expect(shouldApplySafetySnapshot(current, snapshot)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Root-causes the remaining Playwright playtest failures on #229 (`Swap submission not confirmed after 5 attempts`): since spec 042 the instant-scoring fast path freezes tiles mid-`collecting`, but the background safety poller only applied snapshots on round advance / completion / disconnect. When the Realtime broadcast is lost (CI runners, local Docker), the second player's client never learns about the freeze, keeps offering frozen tiles, and every swap is rejected — stalling the round.
- Extracts the apply decision into `shouldApplySafetySnapshot` (`lib/match/safetySnapshot.ts`, unit-tested) and adds two mid-round signals: frozen-tile key-set changes and a new `partialSummary` reveal key. This also makes the first-mover word reveal reach the opponent under broadcast loss.
- Hardens the e2e `submitSwap` helper: each retry scans for an unfrozen pair from a different board row, so a stale `data-frozen` read can't repeat the same server-side rejection.

## Test plan
- [x] `pnpm test:unit` — 169 files / 1143 tests pass (incl. new `safetySnapshot.spec.ts`)
- [x] `pnpm typecheck`, `pnpm lint`
- [ ] CI Playwright playtest suite green (the 4 ten-round specs that failed on #229)

Made with [Cursor](https://cursor.com)