### PR TITLE
fix(match): prevent prod schema drift hang (O-62)

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -1,0 +1,48 @@
+name: Deploy Migrations
+
+# Keeps the production Supabase schema in lockstep with merged code.
+# Linear O-62 post-mortem: code querying rounds.frozen_tiles_before reached
+# Vercel while the migration adding the column never reached production,
+# hanging every match at round 1 resolution. This workflow applies pending
+# migrations to the production project on every merge to main that touches
+# supabase/migrations/.
+#
+# Required repository secrets:
+#   SUPABASE_ACCESS_TOKEN  — personal access token (Supabase dashboard → Account → Access Tokens)
+#   SUPABASE_DB_PASSWORD   — production database password
+#   SUPABASE_PROJECT_ID    — production project ref (e.g. vcjmanighljftajzizat)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "supabase/migrations/**"
+  workflow_dispatch:
+
+jobs:
+  deploy-migrations:
+    name: Apply migrations to production
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link production project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Apply pending migrations
+        run: supabase db push
+
+      - name: List applied migrations
+        run: supabase migration list --linked

--- a/lib/match/instantScoring.ts
+++ b/lib/match/instantScoring.ts
@@ -224,13 +224,16 @@ async function loadMatch(
   supabase: ReturnType<typeof getServiceRoleClient>,
   matchId: string,
 ): Promise<MatchRow | null> {
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("matches")
     .select(
       "id, current_round, player_a_id, player_b_id, board_seed, frozen_tiles",
     )
     .eq("id", matchId)
     .maybeSingle();
+  if (error) {
+    throw new Error(`Failed to load match ${matchId}: ${error.message}`);
+  }
   return (data as MatchRow | null) ?? null;
 }
 
@@ -239,12 +242,20 @@ async function loadCurrentRound(
   matchId: string,
   currentRound: number,
 ): Promise<RoundRow | null> {
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("rounds")
     .select("id, state, board_snapshot_before, started_at, frozen_tiles_before")
     .eq("match_id", matchId)
     .eq("round_number", currentRound)
     .maybeSingle();
+  if (error) {
+    // Throwing (instead of returning null → "round-not-found") routes the
+    // real Postgres error into trackInstantScoringFailed's reason. A missing
+    // column in production previously hid behind the generic reason (O-62).
+    throw new Error(
+      `Failed to load round ${currentRound} of match ${matchId}: ${error.message}`,
+    );
+  }
   return (data as RoundRow | null) ?? null;
 }
 

--- a/lib/match/roundEngine.ts
+++ b/lib/match/roundEngine.ts
@@ -135,7 +135,11 @@ export async function advanceRound(matchId: string) {
         .eq("id", matchId)
         .single();
 
-    if (matchError || !match) throw new Error("Match not found");
+    if (matchError || !match) {
+        throw new Error(
+            `Failed to load match ${matchId}: ${matchError?.message ?? "no row returned"}`,
+        );
+    }
 
     if (match.state !== "in_progress") {
         return { status: "not_advancing", reason: "Match is not in progress" };
@@ -151,7 +155,14 @@ export async function advanceRound(matchId: string) {
         .eq("round_number", currentRound)
         .single();
 
-    if (roundError || !round) throw new Error("Round not found");
+    if (roundError || !round) {
+        // Keep the underlying Postgres error in the message — a generic
+        // "Round not found" hid a missing-column schema drift in production
+        // for hours (Linear O-62).
+        throw new Error(
+            `Failed to load round ${currentRound} of match ${matchId}: ${roundError?.message ?? "no row returned"}`,
+        );
+    }
 
     // 3. Check round state - only process if still collecting
     if (round.state !== "collecting") {

--- a/tests/unit/lib/match/roundEngine.test.ts
+++ b/tests/unit/lib/match/roundEngine.test.ts
@@ -1053,3 +1053,66 @@ describe("roundEngine.advanceRound", () => {
         expect(computeSpy).not.toHaveBeenCalled();
     });
 });
+
+describe("roundEngine.advanceRound — DB error surfacing (O-62)", () => {
+    // Regression: a schema mismatch in production (missing
+    // rounds.frozen_tiles_before column) made the round query fail, but the
+    // generic "Round not found" message hid the real Postgres error in the
+    // Vercel logs. The underlying error message must survive into the throw.
+    const matchData = {
+        id: "match-1",
+        current_round: 1,
+        state: "in_progress",
+        player_a_id: "player-a",
+        player_b_id: "player-b",
+        board_seed: "seed-1",
+        player_a_timer_ms: 300_000,
+        player_b_timer_ms: 300_000,
+        frozen_tiles: {},
+    };
+
+    function createErrorChain(message: string) {
+        return {
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: null, error: { message } }),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message } }),
+        };
+    }
+
+    function mockClient(tables: Record<string, unknown>) {
+        vi.mocked(getServiceRoleClient).mockReturnValue({
+            from: vi.fn((table: string) => tables[table] ?? {}),
+        } as never);
+    }
+
+    beforeEach(() => {
+        vi.mocked(getServiceRoleClient).mockReset();
+    });
+
+    it("includes the underlying error when the match query fails", async () => {
+        mockClient({
+            matches: { select: vi.fn(() => createErrorChain("connection refused")) },
+        });
+
+        await expect(advanceRound("match-1")).rejects.toThrow(
+            /match-1.*connection refused/,
+        );
+    });
+
+    it("includes the underlying error when the round query fails", async () => {
+        mockClient({
+            matches: { select: vi.fn(() => createSelectChain(matchData)) },
+            rounds: {
+                select: vi.fn(() =>
+                    createErrorChain(
+                        "column rounds.frozen_tiles_before does not exist",
+                    ),
+                ),
+            },
+        });
+
+        await expect(advanceRound("match-1")).rejects.toThrow(
+            /frozen_tiles_before does not exist/,
+        );
+    });
+});

--- a/tests/unit/match/instantScoring.failure.spec.ts
+++ b/tests/unit/match/instantScoring.failure.spec.ts
@@ -169,4 +169,35 @@ describe("instantScoreFirstSubmission — failure modes (T019a, FR-011)", () => 
       instantScoreFirstSubmission(MATCH_ID),
     ).resolves.toBeDefined();
   });
+
+  it("surfaces the underlying DB error when the round query fails (O-62)", async () => {
+    // Regression: a missing rounds.frozen_tiles_before column in production
+    // made the round query error, which was swallowed into a generic
+    // "round-not-found" reason. The real Postgres message must reach the
+    // failure reason so schema drift is diagnosable from logs.
+    const client = makeOneSubmissionClient();
+    vi.mocked(client.from).mockImplementation((table: string) => {
+      if (table === "rounds") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "column rounds.frozen_tiles_before does not exist" },
+            }),
+          })),
+        } as never;
+      }
+      return makeOneSubmissionClient().from(table) as never;
+    });
+    vi.mocked(getServiceRoleClient).mockReturnValue(client as never);
+
+    const result = await instantScoreFirstSubmission(MATCH_ID);
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.reason).toMatch(/frozen_tiles_before does not exist/);
+    }
+    expect(trackInstantScoringFailed).toHaveBeenCalledOnce();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-migrations.yml` to run `supabase db push` against production on every merge to `main` touching `supabase/migrations/**`, preventing the schema drift that caused round 1 to hang on wottle.vercel.app.
- Surfaces underlying Postgres errors in `advanceRound` and `instantScoreFirstSubmission` instead of generic "Round not found" / `round-not-found`, with regression tests pinning the behavior.

**Production fix already applied:** the three missing migrations (`20260423001`, `20260424001`, `20260609001`) were applied directly to prod Supabase on 2026-06-10 — gameplay should work now without waiting for this PR.

## Test plan

- [x] `pnpm vitest run tests/unit/lib/match/ tests/unit/match/` — 199 tests passing
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [ ] After merge: add GitHub secrets per [O-63](https://linear.app/minni/issue/O-63/add-github-secrets-for-deploy-migrations-workflow) and verify `workflow_dispatch` on Deploy Migrations succeeds
- [ ] Playtest on wottle.vercel.app: both players submit round 1 → round advances to round 2


Made with [Cursor](https://cursor.com)