### PR TITLE
chore(cursor): enable Vercel plugin in workspace settings

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -2,6 +2,9 @@
   "plugins": {
     "context7-plugin": {
       "enabled": true
+    },
+    "vercel": {
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- Enables the Vercel plugin in `.cursor/settings.json` so the workspace surfaces Vercel skills + commands during local development.

## Test plan

- [x] No code paths touched — IDE config only.

Made with [Cursor](https://cursor.com)