### PR TITLE
fix(summary): current player on left + consistent color (O-72)

### DIFF
--- a/components/match/FinalSummary.tsx
+++ b/components/match/FinalSummary.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+
+import { useSelfColorStore } from "@/lib/match/selfColorStore";
 
 import type { FrozenTileMap, MatchEndedReason, SeriesContext, TopWord } from "@/lib/types/match";
 import type { BoardGrid, Coordinate } from "@/lib/types/board";
@@ -209,6 +211,17 @@ export function FinalSummary({
   const currentPlayerColor = currentIsPlayerA ? PLAYER_A_HEX : PLAYER_B_HEX;
   const opponentColor = currentIsPlayerA ? PLAYER_B_HEX : PLAYER_A_HEX;
 
+  // Publish the viewer's slot color so the global TopBar avatar matches how the
+  // current player is colored across the summary (O-72). Spectators have no
+  // "self" color, so they leave the avatar on its identity gradient.
+  const setSelfColor = useSelfColorStore((s) => s.setSelfColor);
+  const clearSelfColor = useSelfColorStore((s) => s.clearSelfColor);
+  useEffect(() => {
+    if (isSpectator) return;
+    setSelfColor(currentPlayerColor);
+    return () => clearSelfColor();
+  }, [isSpectator, currentPlayerColor, setSelfColor, clearSelfColor]);
+
   const {
     phase: rematchPhase,
     requestRematch: handleRematch,
@@ -301,8 +314,13 @@ export function FinalSummary({
       isCurrentPlayer: player.id === currentPlayerId,
       isWinner: player.id === winnerId,
     });
-    return [toEntry(playerA, "player_a"), toEntry(playerB, "player_b")];
-  }, [playerA, playerB, wordCountByPlayer, bestWordByPlayer, currentPlayerId, winnerId]);
+    const entryA = toEntry(playerA, "player_a");
+    const entryB = toEntry(playerB, "player_b");
+    // Current player first so their card sits on the left, matching the board
+    // panels above (O-72). Spectators keep player_a → player_b order; `currentIsPlayerA`
+    // is already true for them.
+    return currentIsPlayerA ? [entryA, entryB] : [entryB, entryA];
+  }, [playerA, playerB, wordCountByPlayer, bestWordByPlayer, currentPlayerId, winnerId, currentIsPlayerA]);
 
   const handleHighlight = (words: WordHistoryRow[] | null) => {
     if (!words || words.length === 0) {
@@ -542,7 +560,7 @@ export function FinalSummary({
               <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.12em] text-ink-soft">
                 Round by round
               </p>
-              <RoundByRoundChart rounds={scoreboard} />
+              <RoundByRoundChart rounds={scoreboard} currentIsPlayerA={currentIsPlayerA} />
             </div>
 
             <div className="flex flex-wrap gap-3">

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -27,6 +27,7 @@ import { deriveBiggestSwing, deriveHighestScoringWord } from "@/components/match
 import type { WordHistoryRow, ScoreboardRow } from "@/components/match/FinalSummary";
 import type { MatchPlayerProfiles, MatchState, TimerState, Coordinate } from "@/lib/types/match";
 import { getPlayerColors } from "@/lib/constants/playerColors";
+import { useSelfColorStore } from "@/lib/match/selfColorStore";
 import { getBrowserSupabaseClient } from "@/lib/supabase/browser";
 import { subscribeToMatchChannel } from "@/lib/realtime/matchChannel";
 import { claimWinAction } from "@/app/actions/match/claimWin";
@@ -731,6 +732,14 @@ export function MatchClient({
 
   const playerSlot: "player_a" | "player_b" =
     matchState.timers.playerA.playerId === currentPlayerId ? "player_a" : "player_b";
+
+  // Keep the global TopBar avatar consistent with the player's slot color during
+  // the match too, not just the summary (O-72).
+  const selfSlotColor = getPlayerColors(playerSlot).hex;
+  useEffect(() => {
+    useSelfColorStore.getState().setSelfColor(selfSlotColor);
+    return () => useSelfColorStore.getState().clearSelfColor();
+  }, [selfSlotColor]);
 
   const handleSwapComplete = useCallback(
     ({ move }: { move: { from: Coordinate; to: Coordinate } }) => {

--- a/components/match/RoundByRoundChart.tsx
+++ b/components/match/RoundByRoundChart.tsx
@@ -5,6 +5,19 @@ import type { ScoreboardRow } from "@/components/match/FinalSummary";
 interface RoundByRoundChartProps {
   rounds: ScoreboardRow[];
   maxHeightPx?: number;
+  /**
+   * When false, the current viewer is player B, so player B's bar is drawn on
+   * top to keep "current player first" consistent with the rest of the summary
+   * (O-72). Each player's bar keeps its own slot color and `data-delta`
+   * regardless of vertical position. Defaults to true (spectator / player A).
+   */
+  currentIsPlayerA?: boolean;
+}
+
+interface BarSpec {
+  testid: "round-chart-bar--a" | "round-chart-bar--b";
+  delta: number;
+  colorClass: string;
 }
 
 const DEFAULT_MAX_HEIGHT = 120;
@@ -22,10 +35,33 @@ function maxAbsDelta(rounds: ScoreboardRow[]): number {
 export function RoundByRoundChart({
   rounds,
   maxHeightPx = DEFAULT_MAX_HEIGHT,
+  currentIsPlayerA = true,
 }: RoundByRoundChartProps) {
   const scale = maxAbsDelta(rounds);
   const toHeight = (delta: number): number =>
     scale === 0 ? 0 : Math.round((Math.abs(delta) / scale) * maxHeightPx);
+
+  const renderBar = (spec: BarSpec, position: "top" | "bottom") => {
+    const height = toHeight(spec.delta);
+    const rounding = position === "top" ? "rounded-t" : "rounded-b";
+    const labelEdge = position === "top" ? "top-0.5" : "bottom-0.5";
+    return (
+      <div
+        data-testid={spec.testid}
+        data-delta={spec.delta}
+        className={`relative w-full ${rounding} ${spec.colorClass}`}
+        style={{ height: `${height}px` }}
+      >
+        {spec.delta > 0 && height >= LABEL_MIN_BAR_PX ? (
+          <span
+            className={`absolute inset-x-0 ${labelEdge} text-center font-mono text-[9px] leading-none text-ink/90`}
+          >
+            {spec.delta}
+          </span>
+        ) : null}
+      </div>
+    );
+  };
 
   return (
     <div
@@ -41,8 +77,19 @@ export function RoundByRoundChart({
           style={{ top: `${maxHeightPx}px` }}
         />
         {rounds.map((row) => {
-          const aH = toHeight(row.playerADelta);
-          const bH = toHeight(row.playerBDelta);
+          const aSpec: BarSpec = {
+            testid: "round-chart-bar--a",
+            delta: row.playerADelta,
+            colorClass: "bg-p1",
+          };
+          const bSpec: BarSpec = {
+            testid: "round-chart-bar--b",
+            delta: row.playerBDelta,
+            colorClass: "bg-p2 opacity-70",
+          };
+          // Current player's bar sits on top so "current player first" holds.
+          const topSpec = currentIsPlayerA ? aSpec : bSpec;
+          const bottomSpec = currentIsPlayerA ? bSpec : aSpec;
           return (
             <div
               key={row.roundNumber}
@@ -53,35 +100,13 @@ export function RoundByRoundChart({
                 className="flex w-full flex-col justify-end"
                 style={{ height: `${maxHeightPx}px` }}
               >
-                <div
-                  data-testid="round-chart-bar--a"
-                  data-delta={row.playerADelta}
-                  className="relative w-full rounded-t bg-p1"
-                  style={{ height: `${aH}px` }}
-                >
-                  {row.playerADelta > 0 && aH >= LABEL_MIN_BAR_PX ? (
-                    <span className="absolute inset-x-0 top-0.5 text-center font-mono text-[9px] leading-none text-ink/90">
-                      {row.playerADelta}
-                    </span>
-                  ) : null}
-                </div>
+                {renderBar(topSpec, "top")}
               </div>
               <div
                 className="flex w-full flex-col"
                 style={{ height: `${maxHeightPx}px` }}
               >
-                <div
-                  data-testid="round-chart-bar--b"
-                  data-delta={row.playerBDelta}
-                  className="relative w-full rounded-b bg-p2 opacity-70"
-                  style={{ height: `${bH}px` }}
-                >
-                  {row.playerBDelta > 0 && bH >= LABEL_MIN_BAR_PX ? (
-                    <span className="absolute inset-x-0 bottom-0.5 text-center font-mono text-[9px] leading-none text-ink/90">
-                      {row.playerBDelta}
-                    </span>
-                  ) : null}
-                </div>
+                {renderBar(bottomSpec, "bottom")}
               </div>
               <span className="mt-1 font-mono text-[10px] text-ink-soft">
                 R{row.roundNumber}

--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -10,6 +10,13 @@ interface AvatarProps {
   avatarUrl?: string | null;
   size?: AvatarSize;
   className?: string;
+  /**
+   * Overrides the hash-based identity gradient with a solid color (a design
+   * token like `var(--p2)`). Used to keep the TopBar avatar consistent with the
+   * player's match/slot color on match pages (O-72). Ignored when `avatarUrl`
+   * is present.
+   */
+  colorOverride?: string;
 }
 
 const SIZE_STYLES: Record<AvatarSize, string> = {
@@ -20,7 +27,7 @@ const SIZE_STYLES: Record<AvatarSize, string> = {
 };
 
 export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
-  { playerId, displayName, avatarUrl, size = "md", className = "" },
+  { playerId, displayName, avatarUrl, size = "md", className = "", colorOverride },
   ref,
 ) {
   const label = `${displayName || "Anonymous player"} avatar`;
@@ -46,13 +53,15 @@ export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(function Avatar(
   }
 
   const generated = generateAvatar(playerId, displayName);
+  const background = colorOverride ?? generated.background;
+  const foreground = colorOverride ? "var(--ink)" : generated.foreground;
   return (
     <span
       ref={ref}
       role="img"
       aria-label={label}
       className={`inline-flex items-center justify-center rounded-full font-semibold ${sizeClasses} ${className}`.trim()}
-      style={{ background: generated.background, color: generated.foreground }}
+      style={{ background, color: foreground }}
     >
       {generated.initials}
     </span>

--- a/components/ui/UserMenu.tsx
+++ b/components/ui/UserMenu.tsx
@@ -8,6 +8,7 @@ import { Avatar } from "@/components/ui/Avatar";
 import { LogoutConfirmDialog } from "@/components/ui/LogoutConfirmDialog";
 import type { LobbySession } from "@/lib/matchmaking/profile";
 import { useLobbyPresenceStore } from "@/lib/matchmaking/presenceStore";
+import { useSelfColorStore } from "@/lib/match/selfColorStore";
 import { useSensoryPreferences } from "@/lib/preferences/useSensoryPreferences";
 
 export interface UserMenuProps {
@@ -23,6 +24,7 @@ export function UserMenu({ session }: UserMenuProps) {
   const chipRef = useRef<HTMLButtonElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const { player } = session;
+  const selfColor = useSelfColorStore((s) => s.selfColor);
   const { preferences, setSoundEnabled, setHapticsEnabled } =
     useSensoryPreferences();
 
@@ -96,6 +98,7 @@ export function UserMenu({ session }: UserMenuProps) {
           playerId={player.id}
           displayName={player.displayName}
           avatarUrl={player.avatarUrl ?? undefined}
+          colorOverride={selfColor ?? undefined}
           size="sm"
         />
         <span className="hidden sm:inline">{player.displayName}</span>

--- a/lib/match/selfColorStore.ts
+++ b/lib/match/selfColorStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+
+/**
+ * Holds the current player's match color (their slot's design token, e.g.
+ * `var(--p2)`) while a match context is active. The global TopBar avatar lives
+ * in the root layout — above any match route — so it can't read match state
+ * directly. Match views (`MatchClient`, `FinalSummary`) publish the viewer's
+ * slot color here on mount and clear it on unmount, letting the TopBar avatar
+ * stay consistent with how the player is colored everywhere else on the page
+ * (O-72). Outside a match this is null and the avatar falls back to its
+ * identity gradient.
+ */
+interface SelfColorState {
+  selfColor: string | null;
+  setSelfColor: (color: string | null) => void;
+  clearSelfColor: () => void;
+}
+
+export const useSelfColorStore = create<SelfColorState>((set) => ({
+  selfColor: null,
+  setSelfColor: (color) => set({ selfColor: color }),
+  clearSelfColor: () => set({ selfColor: null }),
+}));

--- a/tests/unit/components/Avatar.test.tsx
+++ b/tests/unit/components/Avatar.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { Avatar } from "@/components/ui/Avatar";
+
+describe("Avatar", () => {
+  test("uses the hash-based gradient background by default", () => {
+    render(<Avatar playerId="p-1" displayName="Kongó" />);
+    const el = screen.getByRole("img");
+    expect(el.style.background).toContain("linear-gradient");
+  });
+
+  test("colorOverride replaces the background with the given color", () => {
+    render(
+      <Avatar playerId="p-1" displayName="Kongó" colorOverride="var(--p2)" />,
+    );
+    const el = screen.getByRole("img");
+    expect(el.style.background).toContain("var(--p2)");
+    expect(el.style.background).not.toContain("linear-gradient");
+  });
+
+  test("still renders the player's initials when overridden", () => {
+    render(
+      <Avatar playerId="p-1" displayName="Kongó" colorOverride="var(--p2)" />,
+    );
+    expect(screen.getByText("KO")).toBeInTheDocument();
+  });
+
+  test("avatarUrl takes precedence over colorOverride", () => {
+    render(
+      <Avatar
+        playerId="p-1"
+        displayName="Kongó"
+        avatarUrl="http://example.test/a.png"
+        colorOverride="var(--p2)"
+      />,
+    );
+    expect(screen.getByRole("img").querySelector("img")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/FinalSummary.test.tsx
+++ b/tests/unit/components/FinalSummary.test.tsx
@@ -76,6 +76,24 @@ function makeProps(overrides?: Partial<FinalSummaryProps>): FinalSummaryProps {
 }
 
 describe("FinalSummary", () => {
+  it("O-72: places the current player's scoreboard card first (left)", () => {
+    render(
+      <FinalSummary
+        {...makeProps({ currentPlayerId: "player-b", winnerId: "player-b" })}
+      />,
+    );
+    const cards = screen.getAllByTestId("post-game-scoreboard-card");
+    expect(cards[0].textContent).toContain("Player B");
+    expect(cards[1].textContent).toContain("Player A");
+  });
+
+  it("O-72: keeps player_a first for spectators", () => {
+    render(<FinalSummary {...makeProps({ isSpectator: true })} />);
+    const cards = screen.getAllByTestId("post-game-scoreboard-card");
+    expect(cards[0].textContent).toContain("Player A");
+    expect(cards[1].textContent).toContain("Player B");
+  });
+
   it("T032: renders frozen tile count for each player", () => {
     render(<FinalSummary {...makeProps()} />);
     // Player A has 5 frozen tiles — shown as "5 frozen" in PostGameScoreboard

--- a/tests/unit/components/UserMenu.test.tsx
+++ b/tests/unit/components/UserMenu.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/match/m1/summary",
+}));
+
+vi.mock("@/app/actions/auth/logout", () => ({
+  logoutAction: vi.fn(),
+}));
+
+vi.mock("@/lib/preferences/useSensoryPreferences", () => ({
+  useSensoryPreferences: () => ({
+    preferences: { soundEnabled: true, hapticsEnabled: true },
+    setSoundEnabled: vi.fn(),
+    setHapticsEnabled: vi.fn(),
+  }),
+}));
+
+import { UserMenu } from "@/components/ui/UserMenu";
+import type { LobbySession } from "@/lib/matchmaking/profile";
+import { useSelfColorStore } from "@/lib/match/selfColorStore";
+
+const session: LobbySession = {
+  token: "t-1",
+  issuedAt: 0,
+  player: {
+    id: "p-kongo",
+    username: "kongo",
+    displayName: "Kongó",
+    avatarUrl: null,
+    status: "in_match",
+    lastSeenAt: new Date(0).toISOString(),
+  },
+};
+
+afterEach(() => {
+  useSelfColorStore.getState().clearSelfColor();
+});
+
+describe("UserMenu avatar color (O-72)", () => {
+  test("uses the identity gradient when no match self-color is set", () => {
+    render(<UserMenu session={session} />);
+    expect(screen.getByRole("img").style.background).toContain("linear-gradient");
+  });
+
+  test("uses the current player's match slot color when set", () => {
+    useSelfColorStore.getState().setSelfColor("var(--p2)");
+    render(<UserMenu session={session} />);
+    const background = screen.getByRole("img").style.background;
+    expect(background).toContain("var(--p2)");
+    expect(background).not.toContain("linear-gradient");
+  });
+});

--- a/tests/unit/components/match/RoundByRoundChart.currentFirst.test.tsx
+++ b/tests/unit/components/match/RoundByRoundChart.currentFirst.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { RoundByRoundChart } from "@/components/match/RoundByRoundChart";
+import type { ScoreboardRow } from "@/components/match/FinalSummary";
+
+const rounds: ScoreboardRow[] = [
+  { roundNumber: 1, playerAScore: 22, playerBScore: 15, playerADelta: 22, playerBDelta: 15 },
+];
+
+function barsInFirstColumn() {
+  const col = screen.getAllByTestId("round-chart-col")[0];
+  return {
+    a: within(col).getByTestId("round-chart-bar--a"),
+    b: within(col).getByTestId("round-chart-bar--b"),
+  };
+}
+
+describe("RoundByRoundChart current-player ordering", () => {
+  test("keeps player A's bar on top by default (spectator / current is player A)", () => {
+    render(<RoundByRoundChart rounds={rounds} />);
+    const { a, b } = barsInFirstColumn();
+    // a precedes b in document order → a is the top bar
+    expect(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test("puts the current player's bar (player B) on top when currentIsPlayerA is false", () => {
+    render(<RoundByRoundChart rounds={rounds} currentIsPlayerA={false} />);
+    const { a, b } = barsInFirstColumn();
+    // b precedes a in document order → b (current) is the top bar
+    expect(b.compareDocumentPosition(a) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test("keeps each player's delta tied to their own bar regardless of order", () => {
+    render(<RoundByRoundChart rounds={rounds} currentIsPlayerA={false} />);
+    const { a, b } = barsInFirstColumn();
+    expect(a.dataset.delta).toBe("22");
+    expect(b.dataset.delta).toBe("15");
+  });
+});

--- a/tests/unit/lib/match/selfColorStore.test.ts
+++ b/tests/unit/lib/match/selfColorStore.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { useSelfColorStore } from "@/lib/match/selfColorStore";
+
+describe("selfColorStore", () => {
+  beforeEach(() => {
+    useSelfColorStore.getState().clearSelfColor();
+  });
+
+  test("defaults to null", () => {
+    expect(useSelfColorStore.getState().selfColor).toBeNull();
+  });
+
+  test("setSelfColor stores the current player's match color", () => {
+    useSelfColorStore.getState().setSelfColor("var(--p2)");
+    expect(useSelfColorStore.getState().selfColor).toBe("var(--p2)");
+  });
+
+  test("clearSelfColor resets to null", () => {
+    useSelfColorStore.getState().setSelfColor("var(--p1)");
+    useSelfColorStore.getState().clearSelfColor();
+    expect(useSelfColorStore.getState().selfColor).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [O-72](https://linear.app/minni/issue/O-72/visual-inconsistency-in-game-summary-page) — two visual inconsistencies on the game summary page:

1. **The current player should always be on the left.** The board panels at the top already put the current player on the left, but the results scoreboard cards (below the Defeat/Victory verdict) and the round-by-round chart were ordered by **slot** (player_a first), so a current player who is `player_b` landed on the right.
2. **The current player's color was inconsistent** — blue in the match/summary (slot color) but orange in the top-right profile menu (identity-hash color).

## Root cause

- **Ordering:** `FinalSummary`'s `scoreboardEntries` was hardcoded `[player_a, player_b]`, and `RoundByRoundChart` always drew player_a's bar on top. The board panels (correct) use `currentPlayer`/`opponent`.
- **Color:** two color systems. The match/summary colors people by **slot** via `getPlayerColors` (player_b = blue). The global `TopBar` avatar colors by an **identity hash** (`generateAvatar(playerId)` = orange). They only collide on the summary page where both are visible. The `TopBar` lives in the root layout (above match routes) so it can't read match state directly.

## Fix

Per product decision, **slot color wins** (the match's established 2-color board system is the source of truth).

- **`lib/match/selfColorStore.ts`** (new): a tiny Zustand store holding the current viewer's slot color. Match views publish it on mount and clear it on unmount; the global avatar reads it as an override and reverts to the identity gradient outside a match.
- **`Avatar`**: optional `colorOverride` prop (solid design-token background, ink foreground). Ignored when `avatarUrl` is set.
- **`UserMenu`**: reads `selfColor` → passes to `Avatar` as `colorOverride`.
- **`FinalSummary`**: reorders scoreboard entries current-player-first for participants (spectators keep player_a → player_b); passes `currentIsPlayerA` to the chart; publishes the viewer's slot color while mounted.
- **`MatchClient`**: publishes the viewer's slot color during the live match too (same latent inconsistency).
- **`RoundByRoundChart`**: new `currentIsPlayerA` prop draws the current player's bar on top; each bar keeps its own slot color and `data-delta` regardless of vertical position.

## Tests

- New (TDD red→green): `selfColorStore`, `Avatar` color override, `UserMenu` store→avatar wiring, `RoundByRoundChart` current-first ordering, `FinalSummary` scoreboard ordering (participant + spectator).
- Full unit suite **1160 passing** (2 skipped), `tsc` + `eslint` (zero warnings) clean. No regressions in existing FinalSummary / RoundByRoundChart / PostGameScoreboard / MatchClient tests.

## Notes

- The `hud-card--you`/`--opp` class names are slightly misnamed after the reorder, but the left accent bar still renders the correct **slot** color, so it's visually correct. Left as-is to avoid scope creep.
- Visual logic is covered by unit tests; a live-summary screenshot (requires a full 10-round match) was not captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)