### PR TITLE
chore: upgrade to pnpm 11.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   NEXT_TELEMETRY_DISABLED: 1
   HUSKY: 0
   CI: true
-  PNPM_VERSION: 10.28.0
+  PNPM_VERSION: 11.7.0
 
 jobs:
   lint:

--- a/package.json
+++ b/package.json
@@ -2,39 +2,10 @@
   "name": "wottle",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@11.7.0",
   "engines": {
     "node": ">=22.0.0",
-    "pnpm": ">=10.0.0"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "@opentelemetry/api": "*"
-      }
-    },
-    "allowedDeprecatedVersions": {
-      "@opentelemetry/otlp-proto-exporter-base": "0.41.2",
-      "glob": "7.2.3",
-      "inflight": "1.0.6"
-    },
-    "overrides": {
-      "protobufjs@<7.5.5": ">=7.5.5",
-      "lodash@<4.18.0": ">=4.18.0",
-      "fast-xml-parser@<5.5.7": ">=5.5.7",
-      "flatted@<3.4.2": ">=3.4.2",
-      "axios@<1.15.0": ">=1.15.0",
-      "follow-redirects@<1.16.0": ">=1.16.0",
-      "picomatch@<2.3.2": ">=2.3.2",
-      "anymatch>picomatch": "^4.0.4",
-      "readdirp>picomatch": "^4.0.4",
-      "esbuild@<0.25.0": ">=0.25.0",
-      "tmp@<0.2.4": ">=0.2.4",
-      "brace-expansion@<1.1.13": "^1.1.13",
-      "brace-expansion@>=2.0.0 <2.0.3": "^2.0.3",
-      "brace-expansion@>=4.0.0 <5.0.5": "^5.0.5",
-      "brace-expansion@5.0.4": "^5.0.5"
-    }
+    "pnpm": ">=11.0.0"
   },
   "scripts": {
     "dev": "next dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,39 @@
-onlyBuiltDependencies:
-  - '@playwright/browser-chromium'
-  - esbuild
-  - protobufjs
-  - sharp
-  - unix-dgram
-  - unrs-resolver
+# Build-script allowlist for native deps. pnpm 11 replaces the old
+# `onlyBuiltDependencies` array with this map (pkg -> true|false).
+allowBuilds:
+  '@playwright/browser-chromium': true
+  esbuild: true
+  protobufjs: true
+  sharp: true
+  unix-dgram: true
+  unrs-resolver: true
+
+# Migrated from the package.json "pnpm" field, which pnpm 11 no longer reads
+# (settings now live here / in ~/.config/pnpm/config.yaml). See pnpm 11 release notes.
+
+# Security overrides — force CVE-patched versions across the dependency graph.
+overrides:
+  'protobufjs@<7.5.5': '>=7.5.5'
+  'lodash@<4.18.0': '>=4.18.0'
+  'fast-xml-parser@<5.5.7': '>=5.5.7'
+  'flatted@<3.4.2': '>=3.4.2'
+  'axios@<1.15.0': '>=1.15.0'
+  'follow-redirects@<1.16.0': '>=1.16.0'
+  'picomatch@<2.3.2': '>=2.3.2'
+  'anymatch>picomatch': '^4.0.4'
+  'readdirp>picomatch': '^4.0.4'
+  'esbuild@<0.25.0': '>=0.25.0'
+  'tmp@<0.2.4': '>=0.2.4'
+  'brace-expansion@<1.1.13': '^1.1.13'
+  'brace-expansion@>=2.0.0 <2.0.3': '^2.0.3'
+  'brace-expansion@>=4.0.0 <5.0.5': '^5.0.5'
+  'brace-expansion@5.0.4': '^5.0.5'
+
+peerDependencyRules:
+  allowedVersions:
+    '@opentelemetry/api': '*'
+
+allowedDeprecatedVersions:
+  '@opentelemetry/otlp-proto-exporter-base': '0.41.2'
+  glob: '7.2.3'
+  inflight: '1.0.6'


### PR DESCRIPTION
## Summary

Adopt **pnpm 11.7.0** as the project's package manager (was pinned to 10.28.0). pnpm self-manages its version from the `packageManager` field, so bare `pnpm` uses 11.7 locally and `pnpm/action-setup` uses it in CI.

## Changes

- **`package.json`**: `packageManager` `pnpm@10.28.0` → `11.7.0`; `engines.pnpm` `>=10.0.0` → `>=11.0.0`; removed the `pnpm` field (pnpm 11 no longer reads it).
- **`pnpm-workspace.yaml`**: migrated the settings out of the `package.json` `pnpm` field into the location pnpm 11 reads —
  - **`overrides`** — security pins forcing CVE-patched versions (protobufjs, lodash, axios, fast-xml-parser, follow-redirects, picomatch, esbuild, tmp, flatted, brace-expansion, …),
  - **`peerDependencyRules`** and **`allowedDeprecatedVersions`**,
  - converted **`onlyBuiltDependencies` → `allowBuilds`** map (pnpm 11's replacement; the 6 native deps set to `true`).
- **`.github/workflows/ci.yml`**: `PNPM_VERSION` `10.28.0` → `11.7.0`.

## Why the config moves

pnpm 11 (a) ignores the `package.json` `pnpm` field — its `overrides`/`peerDependencyRules`/`allowedDeprecatedVersions` move to `pnpm-workspace.yaml`, and (b) replaces `onlyBuiltDependencies` with the `allowBuilds` map (unlisted native deps fail with `ERR_PNPM_IGNORED_BUILDS` under the default `strictDepBuilds`). Both migrated per the [pnpm 11 release notes](https://pnpm.io/blog/releases/11.0).

## Verification

- `pnpm install --frozen-lockfile` under 11.7: clean, native build scripts run, supply-chain policy passes, **`pnpm-lock.yaml` unchanged** (overrides match — no dependency churn).
- `tsc --noEmit` clean · `eslint --max-warnings=0` clean · unit suite **1146 passing** (2 skipped).

## Notes

- A prior stash reverted an 11.x bump (likely earlier CI friction) — worth watching this PR's CI.
- `deploy-migrations.yml` uses pnpm `version: latest` (already unpinned) — left as-is; can pin to 11.7.0 separately if desired.
- The security `overrides` are preserved verbatim; dropping them would reintroduce the dependabot-flagged CVEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)