### PR TITLE
fix(match): apply first mover's swapped letters in opponent reveal (O-58, O-68)

### DIFF
--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -20,6 +20,7 @@ import { deriveRoundHistory } from "@/components/match/deriveRoundHistory";
 import { deriveRevealSequence } from "@/lib/match/revealSequence";
 import {
   buildPartialRevealKey,
+  deriveFirstMoverReveal,
   deriveRevealHighlightsFromPartial,
 } from "@/lib/match/partialReveal";
 import { shouldApplySafetySnapshot } from "@/lib/match/safetySnapshot";
@@ -653,6 +654,20 @@ export function MatchClient({
     animatedPartialRevealsRef.current.add(key);
     animatedOpponentMoveKeysRef.current.add(key);
 
+    // O-58 / O-68 — the opponent's board is the pre-swap snapshot, so apply the
+    // first mover's swap here (the #210 externalSwap path is suppressed above via
+    // the shared dedupe key) so the revealed scored word shows the post-swap
+    // letters rather than the original ones.
+    const reveal = deriveFirstMoverReveal(
+      partial,
+      matchState.pendingMoves,
+      currentPlayerId,
+    );
+    if (reveal) {
+      setExternalSwap(reveal);
+      setOpponentSwapTiles([reveal.from, reveal.to]);
+    }
+
     const colors = deriveHighlightPlayerColors(
       partial.words,
       matchState.timers.playerA.playerId,
@@ -672,7 +687,9 @@ export function MatchClient({
     }, 1200);
   }, [
     matchState.partialSummary,
+    matchState.pendingMoves,
     matchState.timers.playerA.playerId,
+    currentPlayerId,
     playWordDiscovery,
   ]);
 

--- a/lib/match/partialReveal.ts
+++ b/lib/match/partialReveal.ts
@@ -1,5 +1,5 @@
 import type { Coordinate } from "@/lib/types/board";
-import type { PartialRoundSummary } from "@/lib/types/match";
+import type { PartialRoundSummary, PendingMove } from "@/lib/types/match";
 
 /**
  * Dedupe + projection helpers for the instant-scoring partial reveal
@@ -32,4 +32,31 @@ export function isFirstMoverPlayerA(
   playerAId: string,
 ): boolean {
   return partial.firstMoverId === playerAId;
+}
+
+export interface FirstMoverReveal {
+  from: Coordinate;
+  to: Coordinate;
+  key: string;
+}
+
+/**
+ * The opponent's board is `board_snapshot_before` (pre-swap) mid-round, so when
+ * the instant-scoring partial reveal highlights the first mover's scored word,
+ * the swapped-in letters still show their old values (O-58 / O-68). This returns
+ * the first mover's swap so the caller can apply it (via `externalSwap`) on the
+ * opponent's board — making the revealed letters match the scored word.
+ *
+ * Returns null for the first mover themselves: their board already carries the
+ * optimistic swap from their own submission, so re-applying it would double-swap.
+ */
+export function deriveFirstMoverReveal(
+  partial: PartialRoundSummary,
+  pendingMoves: PendingMove[] | undefined,
+  currentPlayerId: string,
+): FirstMoverReveal | null {
+  if (currentPlayerId === partial.firstMoverId) return null;
+  const move = pendingMoves?.find((m) => m.playerId === partial.firstMoverId);
+  if (!move) return null;
+  return { from: move.from, to: move.to, key: buildPartialRevealKey(partial) };
 }

--- a/tests/unit/components/MatchClient.test.tsx
+++ b/tests/unit/components/MatchClient.test.tsx
@@ -1140,3 +1140,76 @@ describe("MatchClient dual timeout (US4)", () => {
     expect(screen.getByText(/both players timed out/i)).toBeInTheDocument();
   });
 });
+
+// ─── Opponent swap-reveal letters (O-58 / O-68) ─────────────────────────────
+
+describe("MatchClient opponent swap-reveal letters (O-58 / O-68)", () => {
+  beforeEach(() => {
+    mockMatchCallbacks.onSummary = null;
+    mockMatchCallbacks.onState = null;
+  });
+
+  function tileLetterAt(col: number, row: number): string | undefined {
+    const cell = document.querySelector(
+      `[data-testid="board-tile"][data-col="${col}"][data-row="${row}"]`,
+    );
+    return cell?.querySelector(".board-grid__tile")?.textContent ?? undefined;
+  }
+
+  test("applies the first mover's swapped letters on the opponent's board during the instant reveal", async () => {
+    const { MatchClient } = await import("@/components/match/MatchClient");
+
+    // Mirror O-68: first mover (player-1) swaps A1 (0,0) ↔ G3 (6,2).
+    // Pre-swap board has 'A' at (0,0) and 'H' at (6,2); after the swap the
+    // opponent should see 'A' at (6,2), not the pre-swap 'H'.
+    const board = Array.from({ length: 10 }, () => Array(10).fill("A"));
+    board[2][6] = "H";
+
+    const submittedAt = "2026-06-09T12:00:00.000Z";
+    const state = createMatchState({
+      board,
+      pendingMoves: [
+        {
+          playerId: "player-1",
+          from: { x: 0, y: 0 },
+          to: { x: 6, y: 2 },
+          submittedAt,
+        },
+      ],
+      partialSummary: {
+        matchId: "match-test-123",
+        roundNumber: 3,
+        firstMoverId: "player-1",
+        firstSubmissionAt: submittedAt,
+        words: [
+          {
+            playerId: "player-1",
+            word: "aðik",
+            length: 4,
+            lettersPoints: 8,
+            bonusPoints: 0,
+            totalPoints: 8,
+            coordinates: [{ x: 6, y: 2 }],
+          },
+        ],
+        delta: { playerA: 8, playerB: 0 },
+        frozenTiles: {},
+      },
+    });
+
+    // Viewer is the opponent (player-2).
+    await act(async () => {
+      render(
+        <MatchClient
+          initialState={state}
+          currentPlayerId="player-2"
+          matchId="match-test-123"
+          playerProfiles={defaultProfiles}
+        />,
+      );
+    });
+
+    expect(tileLetterAt(6, 2)).toBe("A");
+    expect(tileLetterAt(0, 0)).toBe("H");
+  });
+});

--- a/tests/unit/match/partialReveal.spec.ts
+++ b/tests/unit/match/partialReveal.spec.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildPartialRevealKey,
+  deriveFirstMoverReveal,
   deriveRevealHighlightsFromPartial,
   isFirstMoverPlayerA,
 } from "@/lib/match/partialReveal";
-import type { PartialRoundSummary } from "@/lib/types/match";
+import type { PartialRoundSummary, PendingMove } from "@/lib/types/match";
 
 const PLAYER_A = "33333333-3333-3333-3333-333333333333";
 const PLAYER_B = "44444444-4444-4444-4444-444444444444";
@@ -112,6 +113,41 @@ describe("deriveRevealHighlightsFromPartial (T023 projection)", () => {
 
   it("returns an empty array when the partial summary has zero words (defensive — fast path normally returns 'no-score' instead)", () => {
     expect(deriveRevealHighlightsFromPartial(makePartial({ words: [] }))).toEqual([]);
+  });
+});
+
+describe("deriveFirstMoverReveal (O-58 / O-68 opponent letter swap)", () => {
+  const firstMoverMove: PendingMove = {
+    playerId: PLAYER_A,
+    from: { x: 0, y: 0 },
+    to: { x: 6, y: 2 },
+    submittedAt: "2026-06-09T12:00:00.000Z",
+  };
+
+  it("returns the first mover's swap (with the reveal key) for the opponent", () => {
+    const reveal = deriveFirstMoverReveal(
+      makePartial(),
+      [firstMoverMove],
+      PLAYER_B,
+    );
+    expect(reveal).toEqual({
+      from: { x: 0, y: 0 },
+      to: { x: 6, y: 2 },
+      key: `${PLAYER_A}-2026-06-09T12:00:00.000Z`,
+    });
+  });
+
+  it("returns null for the first mover themselves (their board already swapped)", () => {
+    expect(
+      deriveFirstMoverReveal(makePartial(), [firstMoverMove], PLAYER_A),
+    ).toBeNull();
+  });
+
+  it("returns null when the first mover's pending move is absent", () => {
+    expect(deriveFirstMoverReveal(makePartial(), [], PLAYER_B)).toBeNull();
+    expect(
+      deriveFirstMoverReveal(makePartial(), undefined, PLAYER_B),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes [O-68](https://linear.app/minni/issue/O-68/swap-stafir-eru-ekki-syndir-eins-hja-baðum-keppendum) and its cross-linked twin [O-58](https://linear.app/minni/issue/O-58/in-the-last-round-the-letters-shown-are-wrong-when-the-last). They're the same bug: during the opponent's mid-round reveal, the scored word is drawn on the **pre-swap** letters, so the opponent sees the original tiles instead of the swapped-in ones (e.g. **HÐIK** instead of **AÐIK** / KIÐA), and in the last round briefly sees the board "as if the tiles weren't swapped."

## Root cause

The opponent's board is `board_snapshot_before` (pre-swap) mid-round — `loadMatchState` only returns `board_snapshot_after` once the round is `completed`. The swapped letters are corrected **client-side** by the issue-#210 `externalSwap` path in `BoardGrid`.

But the spec-042 instant-scoring partial reveal (`MatchClient`) seeds the shared `animatedOpponentMoveKeysRef` dedupe key, which makes the `externalSwap` effect early-return — so the letter swap never runs. The opponent gets the scored-word highlight on the pre-swap board.

(This surfaced after PR #234 made the instant-scoring fast path actually fire in prod, routing the opponent reveal through this path.)

## Fix

Apply the first mover's swap explicitly during the partial reveal so the revealed letters are post-swap. The first mover's own board already carries the optimistic swap, so the helper returns `null` for them (no double-swap).

- **`lib/match/partialReveal.ts`** — new pure `deriveFirstMoverReveal(partial, pendingMoves, currentPlayerId)` → the first mover's `{ from, to, key }` for the opponent, `null` otherwise.
- **`components/match/MatchClient.tsx`** — the partial-reveal effect sets `externalSwap` from it. The `lastSummary` recap stays deduped via the existing key, so it won't re-animate the swap.

## Tests

- `deriveFirstMoverReveal` unit cases (opponent gets the swap; first mover gets `null`; absent pending move → `null`) — TDD red→green.
- `MatchClient` regression mirroring the O-68 screenshot (swap A1↔G3): asserts the opponent's G3 cell shows the post-swap **A**. Verified it **fails without the fix** (`expected 'H' to be 'A'`).
- Full unit suite **1150 passing**; `tsc` + `eslint` (zero warnings) clean.

## Scope note

O-68's screenshot is the collecting-phase instant reveal, fixed directly here. O-58 (last-round brief flash) is the same path; the existing round-transition logic clears `externalSwap` and re-syncs to `board_snapshot_after` at resolution. Worth a live two-player last-round confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)