### PR TITLE
fix(match): keep swap highlight until scoring is revealed (O-74)

### DIFF
--- a/components/game/BoardGrid.tsx
+++ b/components/game/BoardGrid.tsx
@@ -65,12 +65,14 @@ interface BoardGridProps {
   /** Coordinates of the two tiles involved in the locked swap — rendered with orange highlight. */
   lockedTiles?: [Coordinate, Coordinate] | null;
   /**
-   * Coordinates of the player's own swapped tiles that are fading out after the
-   * reveal window because they did not score (spec 043, US3). Rendered with the
-   * `board-grid__cell--swap-fade` animation. Tiles also present in
-   * `currentRoundScoredTiles` are promoted to the scored mark and do not fade.
+   * O-74: whether this round's scoring has been revealed. While false, swap
+   * tiles (`lockedTiles` / `opponentLockedTiles`) show the lift continuously.
+   * Once true, swap tiles that scored promote to the current-round mark and the
+   * rest fade out (`board-grid__cell--swap-fade`) — so the highlight never
+   * disappears before the scored words appear, and it does so identically for
+   * both the mover and the opponent.
    */
-  revealFadeTiles?: [Coordinate, Coordinate] | null;
+  swapScoringRevealed?: boolean;
   /** Coordinates of opponent's swapped tiles during reveal phase — rendered with orange fade animation. */
   opponentRevealTiles?: [Coordinate, Coordinate] | null;
   /**
@@ -234,7 +236,7 @@ export function BoardGrid({
   disabled = false,
   showLockBanner = false,
   lockedTiles = null,
-  revealFadeTiles = null,
+  swapScoringRevealed = false,
   opponentRevealTiles = null,
   opponentLockedTiles = null,
   externalSwap = null,
@@ -265,7 +267,7 @@ export function BoardGrid({
       disabled={disabled}
       showLockBanner={showLockBanner}
       lockedTiles={lockedTiles}
-      revealFadeTiles={revealFadeTiles}
+      swapScoringRevealed={swapScoringRevealed}
       opponentRevealTiles={opponentRevealTiles}
       opponentLockedTiles={opponentLockedTiles}
       externalSwap={externalSwap}
@@ -294,7 +296,7 @@ function BoardGridActive({
   disabled = false,
   showLockBanner = false,
   lockedTiles = null,
-  revealFadeTiles = null,
+  swapScoringRevealed = false,
   opponentRevealTiles = null,
   opponentLockedTiles = null,
   externalSwap = null,
@@ -783,26 +785,30 @@ function BoardGridActive({
                 swappingTiles !== null &&
                 ((swappingTiles[0].x === colIndex && swappingTiles[0].y === rowIndex) ||
                   (swappingTiles[1].x === colIndex && swappingTiles[1].y === rowIndex));
-              // Spec 043 (US3): a swapped tile that scored is promoted to the
-              // current-round mark and never shows the transient lift/fade.
-              const isLockedRaw =
+              // O-74: swap-lift lifecycle. A swapped tile (the player's own
+              // `lockedTiles` or the opponent's `opponentLockedTiles`) shows the
+              // lift CONTINUOUSLY until this round's scoring is revealed. Once
+              // revealed (`swapScoringRevealed`), a scored swap tile promotes to
+              // the current-round mark; the rest fade out. Identical for both the
+              // mover and the opponent so neither sees a stale/early-cleared state.
+              const isOwnSwapRaw =
                 lockedTiles !== null &&
                 ((lockedTiles[0].x === colIndex && lockedTiles[0].y === rowIndex) ||
                   (lockedTiles[1].x === colIndex && lockedTiles[1].y === rowIndex));
-              const isLocked = isLockedRaw && !isCurrentRoundScored;
-              const isFading =
-                revealFadeTiles !== null &&
-                !isCurrentRoundScored &&
-                ((revealFadeTiles[0].x === colIndex && revealFadeTiles[0].y === rowIndex) ||
-                  (revealFadeTiles[1].x === colIndex && revealFadeTiles[1].y === rowIndex));
+              const isOpponentSwapRaw =
+                opponentLockedTiles !== null &&
+                ((opponentLockedTiles[0].x === colIndex && opponentLockedTiles[0].y === rowIndex) ||
+                  (opponentLockedTiles[1].x === colIndex && opponentLockedTiles[1].y === rowIndex));
+              // Scored swap tiles promote — they never show the lift/fade.
+              const isOwnSwap = isOwnSwapRaw && !isCurrentRoundScored;
+              const isOpponentSwap = isOpponentSwapRaw && !isCurrentRoundScored;
+              const isFading = (isOwnSwap || isOpponentSwap) && swapScoringRevealed;
+              const isLocked = isOwnSwap && !isFading;
+              const isOpponentLocked = isOpponentSwap && !isFading;
               const isOpponentReveal =
                 opponentRevealTiles !== null &&
                 ((opponentRevealTiles[0].x === colIndex && opponentRevealTiles[0].y === rowIndex) ||
                   (opponentRevealTiles[1].x === colIndex && opponentRevealTiles[1].y === rowIndex));
-              const isOpponentLocked =
-                opponentLockedTiles !== null &&
-                ((opponentLockedTiles[0].x === colIndex && opponentLockedTiles[0].y === rowIndex) ||
-                  (opponentLockedTiles[1].x === colIndex && opponentLockedTiles[1].y === rowIndex));
               const isInvalid =
                 invalidTiles !== null &&
                 ((invalidTiles[0].x === colIndex && invalidTiles[0].y === rowIndex) ||
@@ -830,11 +836,20 @@ function BoardGridActive({
                 playerSlot && (isSelected || isSwapping)
                   ? SELECTED_BORDER_COLORS[playerSlot]
                   : undefined;
-              const lockedBgColor =
-                playerSlot && (isLocked || isFading) ? LOCKED_BG_COLORS[playerSlot] : undefined;
-              const lockedBorderColor =
-                playerSlot && (isLocked || isFading) ? LOCKED_BORDER_COLORS[playerSlot] : undefined;
               const opponentSlot = playerSlot ? oppositeSlot(playerSlot) : undefined;
+              // The fade keyframe reads `--locked-bg` regardless of owner, so a
+              // fading own tile uses the player's color and a fading opponent
+              // tile uses the opponent's color. The own lift also reads it.
+              const fadeSlot = isFading
+                ? (isOwnSwap ? playerSlot : opponentSlot)
+                : undefined;
+              const lockedColorSlot = isLocked ? playerSlot : fadeSlot;
+              const lockedBgColor = lockedColorSlot
+                ? LOCKED_BG_COLORS[lockedColorSlot]
+                : undefined;
+              const lockedBorderColor = lockedColorSlot
+                ? LOCKED_BORDER_COLORS[lockedColorSlot]
+                : undefined;
               const opponentLockedBgColor =
                 opponentSlot && isOpponentLocked
                   ? LOCKED_BG_COLORS[opponentSlot]

--- a/components/match/MatchClient.tsx
+++ b/components/match/MatchClient.tsx
@@ -61,11 +61,6 @@ const POLL_ENDPOINT = (matchId: string) => `/api/match/${matchId}/state`;
 /** Interval for the background safety-net poller (runs alongside Realtime). */
 const SAFETY_POLL_INTERVAL_MS = 2_000;
 
-/** Spec 043 (US3): how long the own-swap lift stays before it fades out. */
-const SWAP_REVEAL_WINDOW_MS = 2_600;
-/** Spec 043 (US3): duration of the own-swap fade-out (matches the CSS keyframe). */
-const SWAP_FADE_MS = 450;
-
 function formatClockMMSS(seconds: number): string {
   const clamped = Math.max(0, Math.floor(seconds));
   const m = Math.floor(clamped / 60);
@@ -155,12 +150,12 @@ export function MatchClient({
   // Move lock state (US1): after swap, board is locked until next round
   const [moveLocked, setMoveLocked] = useState(false);
   const [lockedSwapTiles, setLockedSwapTiles] = useState<[Coordinate, Coordinate] | null>(null);
-  // Spec 043 (US3): the own-swap lift is transient. After the reveal window it
-  // moves to `revealFadeTiles` (fade-out) for tiles that did not score; scored
-  // tiles are promoted to the persistent current-round mark in BoardGrid.
-  const [revealFadeTiles, setRevealFadeTiles] = useState<[Coordinate, Coordinate] | null>(null);
-  const swapRevealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const swapFadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Spec 043 / O-74: the swap lift stays on the swapped tiles until SCORING is
+  // revealed for the round (not a fixed timer). Once revealed, BoardGrid
+  // promotes scored swap tiles to the current-round mark and fades the rest.
+  // Cleared on round advance. This keeps both players' boards consistent: the
+  // swap highlight never disappears before the scored words appear.
+  const [scoringRevealed, setScoringRevealed] = useState(false);
   const [selectedTile, setSelectedTile] = useState<Coordinate | null>(null);
 
   // Sequential reveal state (US1): active player's swap tiles and highlights during reveal phases
@@ -344,6 +339,10 @@ export function MatchClient({
       );
       setCurrentRoundScored((prev) => ({ ...prev, ...scored }));
     }
+    // O-74: scoring is now revealed for the round — swap lifts may transition
+    // (scored tiles promote, unscored fade). Set even for zero-word rounds so
+    // unscored swap tiles still fade on resolution.
+    setScoringRevealed(true);
 
     if (prefersReducedMotionRef.current) {
       // Skip highlight animation entirely
@@ -409,15 +408,6 @@ export function MatchClient({
     vibrateMatchStart();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // Spec 043 (US3) — clear pending reveal-fade timers on unmount.
-  useEffect(
-    () => () => {
-      if (swapRevealTimerRef.current) clearTimeout(swapRevealTimerRef.current);
-      if (swapFadeTimerRef.current) clearTimeout(swapFadeTimerRef.current);
-    },
-    [],
-  );
 
   // Navigate to final summary when match completes — wait for all animations to finish
   const matchEndSoundFiredRef = useRef(false);
@@ -668,11 +658,9 @@ export function MatchClient({
   useEffect(() => {
     setMoveLocked(false);
     setLockedSwapTiles(null);
-    // Spec 043 (US3) — cancel any pending reveal-fade timers and clear the
-    // fading tiles so a stale timer from the prior round can't fire mid-next-round.
-    if (swapRevealTimerRef.current) clearTimeout(swapRevealTimerRef.current);
-    if (swapFadeTimerRef.current) clearTimeout(swapFadeTimerRef.current);
-    setRevealFadeTiles(null);
+    // O-74 — a new round starts with no scoring revealed, so the next swap's
+    // lift shows until that round's scoring lands.
+    setScoringRevealed(false);
     // Issue #210 — drop the externally-driven swap, the persistent opponent-
     // color tiles, and forget which opponent moves were animated; the next
     // round starts with a clean slate.
@@ -734,6 +722,8 @@ export function MatchClient({
       ...prev,
       ...buildCurrentRoundScoredFromPartial(partial, matchState.timers.playerA.playerId),
     }));
+    // O-74: first-mover scoring revealed mid-round — swap lifts transition.
+    setScoringRevealed(true);
     setActiveRevealHighlights(deriveRevealHighlightsFromPartial(partial));
     setAnimationPhase("round-recap");
     playWordDiscovery();
@@ -822,23 +812,8 @@ export function MatchClient({
     ({ move }: { move: { from: Coordinate; to: Coordinate } }) => {
       setSwapError(null);
       setMoveLocked(true);
-      const pair: [Coordinate, Coordinate] = [move.from, move.to];
-      setLockedSwapTiles(pair);
-      setRevealFadeTiles(null);
-      // Spec 043 (US3): keep the waiting state (moveLocked) but make the swap
-      // lift transient — after the reveal window, fade the tiles out. Tiles that
-      // scored are promoted to the current-round mark by BoardGrid and skip the
-      // fade. Reduced motion clears instantly.
-      if (swapRevealTimerRef.current) clearTimeout(swapRevealTimerRef.current);
-      if (swapFadeTimerRef.current) clearTimeout(swapFadeTimerRef.current);
-      swapRevealTimerRef.current = setTimeout(() => {
-        setLockedSwapTiles((prev) => (prev === pair ? null : prev));
-        if (prefersReducedMotionRef.current) return;
-        setRevealFadeTiles(pair);
-        swapFadeTimerRef.current = setTimeout(() => {
-          setRevealFadeTiles((prev) => (prev === pair ? null : prev));
-        }, SWAP_FADE_MS);
-      }, SWAP_REVEAL_WINDOW_MS);
+      setLockedSwapTiles([move.from, move.to]);
+      // O-74: the lift persists until scoring is revealed (see `scoringRevealed`).
     },
     [],
   );
@@ -1194,7 +1169,7 @@ export function MatchClient({
                 disabled={moveLocked}
                 showLockBanner={moveLocked}
                 lockedTiles={lockedSwapTiles}
-                revealFadeTiles={revealFadeTiles}
+                swapScoringRevealed={scoringRevealed}
                 opponentLockedTiles={opponentSwapTiles}
                 opponentRevealTiles={
                   animationPhase === "round-recap" && activeRevealMove

--- a/tests/unit/components/BoardGrid.swapReveal.spec.tsx
+++ b/tests/unit/components/BoardGrid.swapReveal.spec.tsx
@@ -46,25 +46,43 @@ describe("BoardGrid swap reveal-then-fade (US3, FR-004/005/006)", () => {
     expect(tile.className).not.toContain("board-grid__cell--locked");
   });
 
-  it("applies the swap-fade animation to an unscored fading tile", () => {
-    render(
-      <BoardGrid grid={grid} matchId="m-1" playerSlot="player_a" revealFadeTiles={pair} />,
-    );
-    expect(tileAt(0, 0).className).toContain("board-grid__cell--swap-fade");
-  });
-
-  it("does not fade a scored tile — it keeps the current-round mark", () => {
+  it("fades an unscored swap tile once scoring is revealed (O-74)", () => {
     render(
       <BoardGrid
         grid={grid}
         matchId="m-1"
         playerSlot="player_a"
-        revealFadeTiles={pair}
+        lockedTiles={pair}
+        swapScoringRevealed
+      />,
+    );
+    const tile = tileAt(0, 0);
+    expect(tile.className).toContain("board-grid__cell--swap-fade");
+    expect(tile.className).not.toContain("board-grid__cell--locked");
+  });
+
+  it("does not fade a scored tile once scoring is revealed — it promotes to the mark", () => {
+    render(
+      <BoardGrid
+        grid={grid}
+        matchId="m-1"
+        playerSlot="player_a"
+        lockedTiles={pair}
+        swapScoringRevealed
         currentRoundScoredTiles={{ "0,0": PLAYER_A_HIGHLIGHT }}
       />,
     );
     const tile = tileAt(0, 0);
     expect(tile.className).toContain("board-grid__cell--scored-current");
+    expect(tile.className).not.toContain("board-grid__cell--swap-fade");
+  });
+
+  it("keeps the lift (no fade) while scoring is NOT yet revealed (O-74)", () => {
+    render(
+      <BoardGrid grid={grid} matchId="m-1" playerSlot="player_a" lockedTiles={pair} />,
+    );
+    const tile = tileAt(0, 0);
+    expect(tile.className).toContain("board-grid__cell--locked");
     expect(tile.className).not.toContain("board-grid__cell--swap-fade");
   });
 });

--- a/tests/unit/components/MatchClient.test.tsx
+++ b/tests/unit/components/MatchClient.test.tsx
@@ -995,6 +995,100 @@ describe("MatchClient opponent move reveal (issue #210)", () => {
   });
 });
 
+// ─── O-74: swap highlight stays until scoring, then fades/promotes ──────────
+
+describe("MatchClient swap highlight persists until scoring (O-74)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockMatchCallbacks.onSummary = null;
+    mockMatchCallbacks.onState = null;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        const col = Number(this.getAttribute("data-col") ?? 0);
+        const row = Number(this.getAttribute("data-row") ?? 0);
+        const size = 50;
+        return {
+          top: row * size, left: col * size,
+          bottom: row * size + size, right: col * size + size,
+          width: size, height: size, x: col * size, y: row * size,
+          toJSON: () => ({}),
+        };
+      },
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ status: "accepted", grid: null }), {
+        status: 200, headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  async function submitOwnSwap(tiles: HTMLElement[]): Promise<void> {
+    act(() => { fireEvent.click(tiles[0]); }); // (0,0)
+    act(() => { fireEvent.click(tiles[1]); }); // (1,0)
+    await act(async () => {
+      fireEvent.transitionEnd(tiles[0], { propertyName: "transform" });
+      await vi.advanceTimersByTimeAsync(350);
+    });
+  }
+
+  test("own swap stays highlighted (no fixed-timer fade) while waiting for scoring", async () => {
+    const { MatchClient } = await import("@/components/match/MatchClient");
+    await act(async () => {
+      render(
+        <MatchClient
+          initialState={createMatchState()}
+          currentPlayerId="player-1"
+          matchId="match-test-123"
+          playerProfiles={defaultProfiles}
+        />,
+      );
+    });
+
+    const tiles = screen.getAllByTestId("board-tile");
+    await submitOwnSwap(tiles);
+
+    // Locked lift is shown on the swapped tiles.
+    expect(tiles[0]).toHaveClass("board-grid__cell--locked");
+
+    // Advance well past the old fixed reveal window — with no scoring yet, the
+    // highlight MUST persist (it should fade only when scoring is revealed).
+    await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+
+    expect(tiles[0]).toHaveClass("board-grid__cell--locked");
+    expect(tiles[0]).not.toHaveClass("board-grid__cell--swap-fade");
+  });
+
+  test("own unscored swap tiles fade once the round summary (scoring) is revealed", async () => {
+    const { MatchClient } = await import("@/components/match/MatchClient");
+    await act(async () => {
+      render(
+        <MatchClient
+          initialState={createMatchState()}
+          currentPlayerId="player-1"
+          matchId="match-test-123"
+          playerProfiles={defaultProfiles}
+        />,
+      );
+    });
+
+    const tiles = screen.getAllByTestId("board-tile");
+    await submitOwnSwap(tiles);
+    expect(tiles[0]).toHaveClass("board-grid__cell--locked");
+
+    // Scoring is revealed (the swapped tiles (0,0)/(1,0) are NOT among the
+    // scored words in mockRoundSummary) → the lift transitions to a fade.
+    act(() => { mockMatchCallbacks.onSummary!(mockRoundSummary); });
+
+    expect(tiles[0]).not.toHaveClass("board-grid__cell--locked");
+    expect(tiles[0]).toHaveClass("board-grid__cell--swap-fade");
+  });
+});
+
 // ─── DisconnectionModal end-of-match guard (issue #161 follow-up) ──────────
 
 describe("MatchClient disconnection modal guard", () => {


### PR DESCRIPTION
Fixes Linear **O-74** — *Different move letters shown between players*.

## Root cause

The spec-043 swap "reveal-then-fade" cleared the swap-lift highlight on a **fixed 2.6s timer** (`SWAP_REVEAL_WINDOW_MS`), decoupled from when the scored words were actually revealed. With instant scoring, the swap highlight could disappear before — or unrelated to — the scoring reveal, so the mover and the opponent momentarily showed inconsistent board states (the reported "different letters"). Board content is consistent in steady state (both players resolve to the post-swap board); the regression was purely the **highlight timing**.

## Fix

Drive the swap-highlight lifecycle off the **scoring-reveal event**, not a timer:

- New `scoringRevealed` flag — set when the partial (instant) **or** full round summary lands, cleared on round advance. Passed to `BoardGrid` as `swapScoringRevealed`.
- While `false`: swap tiles (own `lockedTiles` **and** opponent `opponentLockedTiles`) show the lift **continuously**.
- Once `true`: scored swap tiles **promote** to the current-round mark; the rest **fade out** — identically for both the mover and the opponent.
- Removes the fixed-timer machinery (`SWAP_REVEAL_WINDOW_MS` / `SWAP_FADE_MS` / `revealFadeTiles` state + timers). The 450ms fade is now purely the CSS keyframe.

This directly implements the issue's prescription: *"the swapped tiles should stay highlighted until the scored words are shown, then fade to the same color as the scored word — for both players."*

## Tests (TDD — failing first, then green)

- `MatchClient.test.tsx`: swap lift **persists** past the old 2.6s window when no scoring has landed; **fades** only once the round summary arrives (unscored tiles).
- `BoardGrid.swapReveal.spec.tsx`: updated to the `swapScoringRevealed` contract (lift while not revealed → promote scored / fade unscored once revealed).
- Full suite: **1198 passing**, 2 skipped, lint + typecheck clean.

## Scope
Presentation only — no server, schema, or scoring-engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)