### PR TITLE
fix(match): move mergeNewFreezesOntoFresh out of "use server" module (build hotfix)

### DIFF
--- a/app/actions/match/publishRoundSummary.ts
+++ b/app/actions/match/publishRoundSummary.ts
@@ -5,6 +5,7 @@ import { aggregateRoundSummary, calculateWordScore } from "@/lib/scoring/roundSu
 import { recordScoreSnapshot } from "@/lib/matchmaking/service";
 import { withRetry } from "@/lib/game-engine/retry";
 import { logPlaytestError, logPlaytestInfo } from "@/lib/observability/log";
+import { mergeNewFreezesOntoFresh } from "@/lib/match/frozenTileMerge";
 import { completeMatchInternal } from "./completeMatch";
 import type { RoundSummary, RoundMove, WordScore, ScoreTotals, FrozenTileMap } from "@/lib/types/match";
 import type { Coordinate } from "@/lib/types/board";
@@ -174,30 +175,6 @@ export async function publishRoundSummary(
     });
 
     return summary;
-}
-
-/**
- * Re-apply only THIS round's new freezes on top of freshly-loaded state.
- *
- * `computed` is `fresh-at-compute-time ∪ this-round`. The keys this round added
- * are those in `computed` but not in `baseline` (freezes are monotonic — a tile
- * never un-freezes mid-match). Layering just that delta onto the freshly-loaded
- * `fresh` map preserves a concurrent round's freezes instead of clobbering them.
- *
- * Exported for unit testing.
- */
-export function mergeNewFreezesOntoFresh(
-    fresh: FrozenTileMap,
-    baseline: FrozenTileMap,
-    computed: FrozenTileMap,
-): FrozenTileMap {
-    const merged: FrozenTileMap = { ...fresh };
-    for (const [key, tile] of Object.entries(computed)) {
-        if (!(key in baseline)) {
-            merged[key] = tile;
-        }
-    }
-    return merged;
 }
 
 /**

--- a/lib/match/frozenTileMerge.ts
+++ b/lib/match/frozenTileMerge.ts
@@ -1,0 +1,27 @@
+import type { FrozenTileMap } from "@/lib/types/match";
+
+/**
+ * Re-apply only THIS round's new freezes on top of freshly-loaded state.
+ *
+ * `computed` is `fresh-at-compute-time ∪ this-round`. The keys this round added
+ * are those in `computed` but not in `baseline` (freezes are monotonic — a tile
+ * never un-freezes mid-match). Layering just that delta onto the freshly-loaded
+ * `fresh` map preserves a concurrent round's freezes instead of clobbering them.
+ *
+ * Used by `persistFrozenTilesAtomically`'s stale-retry path. Lives in `lib`
+ * (not the `"use server"` action module) because it is a pure synchronous
+ * helper — `"use server"` files may only export async Server Actions.
+ */
+export function mergeNewFreezesOntoFresh(
+  fresh: FrozenTileMap,
+  baseline: FrozenTileMap,
+  computed: FrozenTileMap,
+): FrozenTileMap {
+  const merged: FrozenTileMap = { ...fresh };
+  for (const [key, tile] of Object.entries(computed)) {
+    if (!(key in baseline)) {
+      merged[key] = tile;
+    }
+  }
+  return merged;
+}

--- a/tests/unit/match/mergeNewFreezesOntoFresh.spec.ts
+++ b/tests/unit/match/mergeNewFreezesOntoFresh.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { mergeNewFreezesOntoFresh } from "@/app/actions/match/publishRoundSummary";
+import { mergeNewFreezesOntoFresh } from "@/lib/match/frozenTileMerge";
 import type { FrozenTile, FrozenTileMap } from "@/lib/types/match";
 
 /**


### PR DESCRIPTION
## Hotfix — `main` build is currently broken

PR #244 merged before its CI build finished. The merged code added a **synchronous** `export function mergeNewFreezesOntoFresh(...)` to `app/actions/match/publishRoundSummary.ts`, which begins with `"use server"`. Next.js/Turbopack requires every export from a `"use server"` module to be an async Server Action, so the production build fails:

```
./app/actions/match/publishRoundSummary.ts:189
Server Actions must be async functions.
> export function mergeNewFreezesOntoFresh(
```

## Fix
Move the pure helper to `lib/match/frozenTileMerge.ts` (pure logic belongs in `lib`, not an action module) and import it into the action + the unit test. **No behaviour change.**

## Verification
- `pnpm build` succeeds locally (full Turbopack production build).
- `pnpm typecheck` + the `mergeNewFreezesOntoFresh` unit tests (4) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
